### PR TITLE
feat(ontology): implement LLM-powered ontology extraction workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
 
 # Cloud Run optimizations via environment variables
 ENV PORT=3443 \
+    BIND_ADDR=0.0.0.0 \
     GOMAXPROCS=2
 
 # Run the binary

--- a/migrations/007_ontology.down.sql
+++ b/migrations/007_ontology.down.sql
@@ -1,0 +1,11 @@
+-- Migration 007 DOWN: Remove ontology extraction system
+-- Drops all tables in reverse dependency order
+
+-- Drop tables with foreign key dependencies first
+DROP TABLE IF EXISTS engine_ontology_questions CASCADE;
+DROP TABLE IF EXISTS engine_workflow_state CASCADE;
+DROP TABLE IF EXISTS engine_llm_conversations CASCADE;
+DROP TABLE IF EXISTS engine_project_knowledge CASCADE;
+DROP TABLE IF EXISTS engine_ontology_chat_messages CASCADE;
+DROP TABLE IF EXISTS engine_ontologies CASCADE;
+DROP TABLE IF EXISTS engine_ontology_workflows CASCADE;

--- a/migrations/007_ontology.up.sql
+++ b/migrations/007_ontology.up.sql
@@ -1,0 +1,403 @@
+-- Migration 007: Ontology extraction system
+-- Creates all tables needed for LLM-powered ontology extraction workflow:
+--   - engine_ontology_workflows: Workflow lifecycle and progress tracking
+--   - engine_ontologies: Tiered ontology storage (domain/entity/column)
+--   - engine_ontology_chat_messages: Chat refinement history
+--   - engine_project_knowledge: Project-level facts
+--   - engine_llm_conversations: LLM request/response debugging
+--   - engine_workflow_state: Per-entity extraction state (ephemeral)
+--   - engine_ontology_questions: Questions for user clarification
+
+-- ============================================================================
+-- Table: engine_ontology_workflows
+-- Manages the lifecycle of ontology extraction workflows
+-- ============================================================================
+
+CREATE TABLE engine_ontology_workflows (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES engine_projects(id) ON DELETE CASCADE,
+    state VARCHAR(50) NOT NULL DEFAULT 'pending',
+    progress JSONB NOT NULL DEFAULT '{}',
+    task_queue JSONB NOT NULL DEFAULT '[]',
+    config JSONB NOT NULL DEFAULT '{}',
+    error_message TEXT,
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    -- Ownership for multi-server robustness
+    owner_id UUID,
+    last_heartbeat TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Check constraint for valid workflow states
+ALTER TABLE engine_ontology_workflows
+    ADD CONSTRAINT engine_ontology_workflows_state_check
+    CHECK (state IN ('pending', 'running', 'paused', 'awaiting_input', 'completed', 'failed'));
+
+-- Query indexes
+CREATE INDEX idx_engine_ontology_workflows_project ON engine_ontology_workflows(project_id);
+CREATE INDEX idx_engine_ontology_workflows_state ON engine_ontology_workflows(project_id, state);
+CREATE INDEX idx_workflow_heartbeat ON engine_ontology_workflows (last_heartbeat)
+    WHERE state = 'running';
+
+-- RLS
+ALTER TABLE engine_ontology_workflows ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ontology_workflows_access ON engine_ontology_workflows
+    FOR ALL
+    USING (
+        current_setting('app.current_project_id', true) IS NULL
+        OR project_id = current_setting('app.current_project_id', true)::uuid
+    );
+
+-- Trigger
+CREATE TRIGGER update_engine_ontology_workflows_updated_at
+    BEFORE UPDATE ON engine_ontology_workflows
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- ============================================================================
+-- Table: engine_ontologies
+-- Stores the tiered ontology (domain summary, entity summaries, column details)
+-- ============================================================================
+
+CREATE TABLE engine_ontologies (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES engine_projects(id) ON DELETE CASCADE,
+    version INTEGER NOT NULL DEFAULT 1,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    domain_summary JSONB,
+    entity_summaries JSONB,
+    column_details JSONB,
+    metadata JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Unique constraint: one version per project
+CREATE UNIQUE INDEX idx_engine_ontologies_unique
+    ON engine_ontologies(project_id, version);
+
+-- Query indexes
+CREATE INDEX idx_engine_ontologies_project ON engine_ontologies(project_id);
+
+-- Unique constraint: only one active ontology per project
+CREATE UNIQUE INDEX idx_engine_ontologies_single_active
+    ON engine_ontologies(project_id)
+    WHERE is_active = true;
+
+-- RLS
+ALTER TABLE engine_ontologies ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ontologies_access ON engine_ontologies
+    FOR ALL
+    USING (
+        current_setting('app.current_project_id', true) IS NULL
+        OR project_id = current_setting('app.current_project_id', true)::uuid
+    );
+
+-- Trigger
+CREATE TRIGGER update_engine_ontologies_updated_at
+    BEFORE UPDATE ON engine_ontologies
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- ============================================================================
+-- Add ontology_id FK to workflows (now that ontologies table exists)
+-- ============================================================================
+
+ALTER TABLE engine_ontology_workflows
+    ADD COLUMN ontology_id UUID REFERENCES engine_ontologies(id) ON DELETE CASCADE;
+
+CREATE INDEX idx_engine_ontology_workflows_ontology ON engine_ontology_workflows(ontology_id);
+
+-- ============================================================================
+-- Table: engine_ontology_chat_messages
+-- Stores chat history for the ontology refinement chat interface
+-- ============================================================================
+
+CREATE TABLE engine_ontology_chat_messages (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES engine_projects(id) ON DELETE CASCADE,
+    ontology_id UUID NOT NULL REFERENCES engine_ontologies(id) ON DELETE CASCADE,
+    role VARCHAR(50) NOT NULL,
+    content TEXT NOT NULL,
+    tool_calls JSONB,
+    tool_call_id VARCHAR(255),
+    metadata JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Check constraint for valid chat roles
+ALTER TABLE engine_ontology_chat_messages
+    ADD CONSTRAINT engine_ontology_chat_messages_role_check
+    CHECK (role IN ('user', 'assistant', 'system', 'tool'));
+
+-- Query indexes
+CREATE INDEX idx_engine_ontology_chat_messages_project ON engine_ontology_chat_messages(project_id);
+CREATE INDEX idx_engine_ontology_chat_messages_ontology ON engine_ontology_chat_messages(ontology_id);
+CREATE INDEX idx_engine_ontology_chat_messages_created ON engine_ontology_chat_messages(project_id, created_at DESC);
+
+-- RLS
+ALTER TABLE engine_ontology_chat_messages ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ontology_chat_messages_access ON engine_ontology_chat_messages
+    FOR ALL
+    USING (
+        current_setting('app.current_project_id', true) IS NULL
+        OR project_id = current_setting('app.current_project_id', true)::uuid
+    );
+
+-- ============================================================================
+-- Table: engine_project_knowledge
+-- Stores project-level facts learned during ontology refinement
+-- ============================================================================
+
+CREATE TABLE engine_project_knowledge (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES engine_projects(id) ON DELETE CASCADE,
+    fact_type VARCHAR(100) NOT NULL,
+    key VARCHAR(255) NOT NULL,
+    value TEXT NOT NULL,
+    context TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Unique constraint: one fact per project/type/key combination
+CREATE UNIQUE INDEX idx_engine_project_knowledge_unique
+    ON engine_project_knowledge(project_id, fact_type, key);
+
+-- Query indexes
+CREATE INDEX idx_engine_project_knowledge_project ON engine_project_knowledge(project_id);
+CREATE INDEX idx_engine_project_knowledge_type ON engine_project_knowledge(project_id, fact_type);
+
+-- RLS
+ALTER TABLE engine_project_knowledge ENABLE ROW LEVEL SECURITY;
+CREATE POLICY project_knowledge_access ON engine_project_knowledge
+    FOR ALL
+    USING (
+        current_setting('app.current_project_id', true) IS NULL
+        OR project_id = current_setting('app.current_project_id', true)::uuid
+    );
+
+-- Trigger
+CREATE TRIGGER update_engine_project_knowledge_updated_at
+    BEFORE UPDATE ON engine_project_knowledge
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- ============================================================================
+-- Table: engine_llm_conversations
+-- Captures verbatim LLM requests and responses for debugging and analytics
+-- ============================================================================
+
+CREATE TABLE engine_llm_conversations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES engine_projects(id) ON DELETE CASCADE,
+
+    -- For streaming: groups iterations within a single user request
+    conversation_id UUID,
+    iteration INT NOT NULL DEFAULT 1,
+
+    -- Model info
+    endpoint TEXT NOT NULL,
+    model TEXT NOT NULL,
+
+    -- Request (VERBATIM)
+    request_messages JSONB NOT NULL,
+    request_tools JSONB,
+    temperature DECIMAL(3,2),
+
+    -- Response (VERBATIM)
+    response_content TEXT,
+    response_tool_calls JSONB,
+
+    -- Metrics
+    prompt_tokens INT,
+    completion_tokens INT,
+    total_tokens INT,
+    duration_ms INT NOT NULL,
+
+    -- Status
+    status VARCHAR(20) NOT NULL DEFAULT 'success',
+    error_message TEXT,
+
+    -- Flexible context for caller-specific metadata
+    context JSONB,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_llm_conversations_project ON engine_llm_conversations(project_id, created_at DESC);
+CREATE INDEX idx_llm_conversations_conversation ON engine_llm_conversations(conversation_id) WHERE conversation_id IS NOT NULL;
+CREATE INDEX idx_llm_conversations_context ON engine_llm_conversations USING GIN (context);
+
+-- RLS policy
+ALTER TABLE engine_llm_conversations ENABLE ROW LEVEL SECURITY;
+CREATE POLICY llm_conversations_access ON engine_llm_conversations
+    FOR ALL
+    USING (
+        current_setting('app.current_project_id', true) IS NULL
+        OR project_id = current_setting('app.current_project_id', true)::uuid
+    );
+
+COMMENT ON TABLE engine_llm_conversations IS 'Verbatim log of all LLM API calls for debugging and analytics';
+COMMENT ON COLUMN engine_llm_conversations.conversation_id IS 'Groups related calls in multi-turn streaming conversations';
+COMMENT ON COLUMN engine_llm_conversations.iteration IS 'Tool-calling iteration number within a single user request';
+COMMENT ON COLUMN engine_llm_conversations.request_messages IS 'Full OpenAI-format message array sent to LLM';
+COMMENT ON COLUMN engine_llm_conversations.context IS 'Caller-specific context (workflow_id, task_name, session_id, etc.)';
+
+-- ============================================================================
+-- Table: engine_workflow_state
+-- Tracks the state of each entity during ontology extraction
+-- This is ephemeral data - deleted when workflow completes successfully.
+-- ============================================================================
+
+CREATE TABLE engine_workflow_state (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES engine_projects(id) ON DELETE CASCADE,
+    ontology_id UUID NOT NULL REFERENCES engine_ontologies(id) ON DELETE CASCADE,
+    workflow_id UUID NOT NULL REFERENCES engine_ontology_workflows(id) ON DELETE CASCADE,
+
+    -- Entity identification
+    -- entity_type: 'global' | 'table' | 'column'
+    -- entity_key: '' (global) | 'orders' (table) | 'orders.status' (column)
+    entity_type VARCHAR(20) NOT NULL,
+    entity_key TEXT NOT NULL,
+
+    -- Extraction state
+    status VARCHAR(30) NOT NULL DEFAULT 'pending',
+
+    -- All extraction state: gathered data, LLM analysis, questions, answers
+    state_data JSONB NOT NULL DEFAULT '{}',
+
+    -- Change detection (for future incremental refresh)
+    data_fingerprint TEXT,
+
+    -- Error tracking
+    last_error TEXT,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Check constraint for valid entity types
+ALTER TABLE engine_workflow_state
+    ADD CONSTRAINT engine_workflow_state_entity_type_check
+    CHECK (entity_type IN ('global', 'table', 'column'));
+
+-- Check constraint for valid status values (state machine)
+-- pending → scanning → scanned → analyzing → complete
+--                                    ↓
+--                              needs_input → (answer) → analyzing
+-- Any state can transition to: failed
+ALTER TABLE engine_workflow_state
+    ADD CONSTRAINT engine_workflow_state_status_check
+    CHECK (status IN ('pending', 'scanning', 'scanned', 'analyzing',
+                      'complete', 'needs_input', 'failed'));
+
+-- Unique constraint: one state per entity per workflow
+CREATE UNIQUE INDEX idx_workflow_state_entity
+    ON engine_workflow_state(workflow_id, entity_type, entity_key);
+
+-- Query indexes
+CREATE INDEX idx_workflow_state_by_status
+    ON engine_workflow_state(workflow_id, status);
+CREATE INDEX idx_workflow_state_project
+    ON engine_workflow_state(project_id);
+
+-- RLS
+ALTER TABLE engine_workflow_state ENABLE ROW LEVEL SECURITY;
+CREATE POLICY workflow_state_access ON engine_workflow_state
+    FOR ALL
+    USING (
+        current_setting('app.current_project_id', true) IS NULL
+        OR project_id = current_setting('app.current_project_id', true)::uuid
+    );
+
+-- Trigger for updated_at
+CREATE TRIGGER update_engine_workflow_state_updated_at
+    BEFORE UPDATE ON engine_workflow_state
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- ============================================================================
+-- Table: engine_ontology_questions
+-- Questions generated during ontology extraction for user clarification
+-- Questions are decoupled from workflow lifecycle for flexibility
+-- ============================================================================
+
+CREATE TABLE engine_ontology_questions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES engine_projects(id) ON DELETE CASCADE,
+    ontology_id UUID NOT NULL REFERENCES engine_ontologies(id) ON DELETE CASCADE,
+
+    -- Question content
+    text TEXT NOT NULL,
+    reasoning TEXT,                          -- Why the LLM generated this question
+    category VARCHAR(100),                   -- e.g., 'relationship', 'terminology', 'business_rules'
+
+    -- Priority and requirements
+    priority INTEGER NOT NULL DEFAULT 3,     -- 1=critical, 2=high, 3=medium, 4=low, 5=optional
+    is_required BOOLEAN NOT NULL DEFAULT false,
+
+    -- What this question affects (for deterministic entity updates)
+    -- Structure: {"tables": ["table1"], "columns": ["col1", "col2"], "entity_type": "table|column"}
+    affects JSONB NOT NULL DEFAULT '{}',
+
+    -- Source entity information (which entity generated this question)
+    source_entity_type VARCHAR(20),          -- 'table', 'column', 'global'
+    source_entity_key TEXT,                  -- e.g., 'users' or 'users.email'
+
+    -- Status tracking
+    status VARCHAR(50) NOT NULL DEFAULT 'pending',
+
+    -- Answer information
+    answer TEXT,
+    answered_by UUID,
+    answered_at TIMESTAMPTZ,
+
+    -- Timestamps
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Check constraint for valid question statuses
+ALTER TABLE engine_ontology_questions
+    ADD CONSTRAINT engine_ontology_questions_status_check
+    CHECK (status IN ('pending', 'answered', 'skipped', 'deleted'));
+
+-- Check constraint for valid priority values (1=highest, 5=lowest)
+ALTER TABLE engine_ontology_questions
+    ADD CONSTRAINT engine_ontology_questions_priority_check
+    CHECK (priority >= 1 AND priority <= 5);
+
+-- Query by project
+CREATE INDEX idx_engine_ontology_questions_project ON engine_ontology_questions(project_id);
+
+-- Query by ontology
+CREATE INDEX idx_engine_ontology_questions_ontology ON engine_ontology_questions(ontology_id);
+
+-- Efficient query for pending questions by priority
+CREATE INDEX idx_engine_ontology_questions_pending ON engine_ontology_questions(project_id, status, priority)
+    WHERE status = 'pending';
+
+-- Query for required pending questions
+CREATE INDEX idx_engine_ontology_questions_required ON engine_ontology_questions(project_id, is_required)
+    WHERE status = 'pending' AND is_required = true;
+
+-- RLS
+ALTER TABLE engine_ontology_questions ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ontology_questions_access ON engine_ontology_questions
+    FOR ALL
+    USING (
+        current_setting('app.current_project_id', true) IS NULL
+        OR project_id = current_setting('app.current_project_id', true)::uuid
+    );
+
+-- Trigger
+CREATE TRIGGER update_engine_ontology_questions_updated_at
+    BEFORE UPDATE ON engine_ontology_questions
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();

--- a/pkg/adapters/datasource/interfaces.go
+++ b/pkg/adapters/datasource/interfaces.go
@@ -88,6 +88,11 @@ type SchemaDiscoverer interface {
 	AnalyzeJoin(ctx context.Context, sourceSchema, sourceTable, sourceColumn,
 		targetSchema, targetTable, targetColumn string) (*JoinAnalysis, error)
 
+	// GetDistinctValues returns up to limit distinct non-null values from a column.
+	// Values are returned as strings, sorted alphabetically.
+	// Used during the scanning phase to collect sample values for enum detection.
+	GetDistinctValues(ctx context.Context, schemaName, tableName, columnName string, limit int) ([]string, error)
+
 	// Close releases the database connection.
 	Close() error
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ import (
 // Secrets (passwords, keys) must only come from environment variables.
 type Config struct {
 	// Server configuration
+	BindAddr     string `yaml:"bind_addr" env:"BIND_ADDR" env-default:"127.0.0.1"`
 	Port         string `yaml:"port" env:"PORT" env-default:"3443"`
 	Env          string `yaml:"env" env:"ENVIRONMENT" env-default:"local"`
 	BaseURL      string `yaml:"base_url" env:"BASE_URL" env-default:"http://localhost:3443"`

--- a/pkg/handlers/config.go
+++ b/pkg/handlers/config.go
@@ -53,10 +53,7 @@ func (h *ConfigHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 	if err := WriteJSON(w, http.StatusOK, response); err != nil {
 		h.logger.Error("Failed to encode config response", zap.Error(err))
-		return
 	}
-
-	h.logger.Debug("Config request served", zap.String("remote_addr", r.RemoteAddr))
 }
 
 // GetDatasourceTypes returns available datasource adapter types.
@@ -70,10 +67,5 @@ func (h *ConfigHandler) GetDatasourceTypes(w http.ResponseWriter, r *http.Reques
 
 	if err := WriteJSON(w, http.StatusOK, types); err != nil {
 		h.logger.Error("Failed to encode datasource types response", zap.Error(err))
-		return
 	}
-
-	h.logger.Debug("Datasource types request served",
-		zap.String("remote_addr", r.RemoteAddr),
-		zap.Int("types_count", len(types)))
 }

--- a/pkg/handlers/config_project.go
+++ b/pkg/handlers/config_project.go
@@ -62,10 +62,7 @@ func (h *ProjectConfigHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 	if err := WriteJSON(w, http.StatusOK, response); err != nil {
 		h.logger.Error("Failed to encode project config response", zap.Error(err))
-		return
 	}
-
-	h.logger.Debug("Project config request served", zap.String("remote_addr", r.RemoteAddr))
 }
 
 // buildAIOption converts server config to API response format.

--- a/pkg/handlers/datasources.go
+++ b/pkg/handlers/datasources.go
@@ -422,9 +422,6 @@ func (h *DatasourcesHandler) Delete(w http.ResponseWriter, r *http.Request) {
 func (h *DatasourcesHandler) TestConnection(w http.ResponseWriter, r *http.Request) {
 	pidStr := r.PathValue("pid")
 
-	h.logger.Debug("TestConnection request received",
-		zap.String("project_id", pidStr))
-
 	_, err := uuid.Parse(pidStr)
 	if err != nil {
 		h.logger.Debug("Invalid project ID", zap.String("pid", pidStr), zap.Error(err))
@@ -442,14 +439,6 @@ func (h *DatasourcesHandler) TestConnection(w http.ResponseWriter, r *http.Reque
 		}
 		return
 	}
-
-	h.logger.Debug("TestConnection parsed request",
-		zap.String("type", req.Type),
-		zap.String("host", req.Host),
-		zap.Int("port", req.Port),
-		zap.String("user", req.User),
-		zap.String("name", req.Name),
-		zap.String("ssl_mode", req.SSLMode))
 
 	if req.Type == "" {
 		h.logger.Debug("Missing datasource type in request")
@@ -474,10 +463,6 @@ func (h *DatasourcesHandler) TestConnection(w http.ResponseWriter, r *http.Reque
 		}
 		return
 	}
-
-	h.logger.Debug("Connection test successful",
-		zap.String("type", req.Type),
-		zap.String("host", req.Host))
 
 	response := TestConnectionResponse{
 		Success: true,

--- a/pkg/handlers/datasources_integration_test.go
+++ b/pkg/handlers/datasources_integration_test.go
@@ -85,6 +85,7 @@ func setupIntegrationTest(t *testing.T) *integrationTestContext {
 		repo,
 		encryptor,
 		&integrationMockAdapterFactory{},
+		nil, // No project service for tests
 		zap.NewNop(),
 	)
 

--- a/pkg/handlers/mocks_test.go
+++ b/pkg/handlers/mocks_test.go
@@ -13,9 +13,10 @@ import (
 
 // mockProjectService is a configurable mock for all handler tests.
 type mockProjectService struct {
-	project         *models.Project
-	provisionResult *services.ProvisionResult
-	err             error
+	project             *models.Project
+	provisionResult     *services.ProvisionResult
+	defaultDatasourceID uuid.UUID
+	err                 error
 }
 
 func (m *mockProjectService) GetByID(ctx context.Context, id uuid.UUID) (*models.Project, error) {
@@ -66,6 +67,21 @@ func (m *mockProjectService) ProvisionFromClaims(ctx context.Context, claims *au
 		Name:      claims.Email,
 		Created:   false,
 	}, nil
+}
+
+func (m *mockProjectService) GetDefaultDatasourceID(ctx context.Context, projectID uuid.UUID) (uuid.UUID, error) {
+	if m.err != nil {
+		return uuid.Nil, m.err
+	}
+	return m.defaultDatasourceID, nil
+}
+
+func (m *mockProjectService) SetDefaultDatasourceID(ctx context.Context, projectID uuid.UUID, datasourceID uuid.UUID) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.defaultDatasourceID = datasourceID
+	return nil
 }
 
 // mockAuthService is a mock AuthService for integration testing.
@@ -266,7 +282,7 @@ func (m *mockSchemaService) UpdateColumnMetadata(ctx context.Context, projectID,
 	return m.err
 }
 
-func (m *mockSchemaService) SaveSelections(ctx context.Context, projectID, datasourceID uuid.UUID, tableSelections map[string]bool, columnSelections map[string][]string) error {
+func (m *mockSchemaService) SaveSelections(ctx context.Context, projectID, datasourceID uuid.UUID, tableSelections map[uuid.UUID]bool, columnSelections map[uuid.UUID][]uuid.UUID) error {
 	return m.err
 }
 

--- a/pkg/handlers/ontology.go
+++ b/pkg/handlers/ontology.go
@@ -1,0 +1,512 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/auth"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/services"
+)
+
+// ============================================================================
+// Request/Response Types
+// ============================================================================
+
+// StartExtractionRequest for POST /ontology/extract
+// Note: datasource_id is no longer required - fetched from project configuration
+type StartExtractionRequest struct {
+	IncludeAllTables   bool     `json:"include_all_tables,omitempty"`
+	SelectedTableIDs   []string `json:"selected_table_ids,omitempty"`
+	SkipDataProfiling  bool     `json:"skip_data_profiling,omitempty"`
+	ProjectDescription string   `json:"project_description,omitempty"`
+}
+
+// WorkflowStatusResponse for GET /ontology/status
+// Field names match frontend WorkflowStatusResponse type in ui/src/types/ontology.ts
+type WorkflowStatusResponse struct {
+	WorkflowID      string                `json:"workflow_id"`
+	ProjectID       string                `json:"project_id,omitempty"`
+	CurrentPhase    string                `json:"current_phase"`
+	CompletedPhases []string              `json:"completed_phases"`
+	ConfidenceScore float64               `json:"confidence_score"`
+	IterationCount  int                   `json:"iteration_count"`
+	IsComplete      bool                  `json:"is_complete"`
+	StatusLabel     string                `json:"status_label"`
+	StatusType      string                `json:"status_type"`
+	CanStartNew     bool                  `json:"can_start_new"`
+	HasResult       bool                  `json:"has_result"`
+	TaskQueue       []models.WorkflowTask `json:"task_queue,omitempty"`
+	TotalTasks      int                   `json:"total_tasks,omitempty"`
+	CompletedTasks  int                   `json:"completed_tasks,omitempty"`
+	LastError       string                `json:"last_error,omitempty"`
+	CreatedAt       *string               `json:"created_at,omitempty"`
+	UpdatedAt       *string               `json:"updated_at,omitempty"`
+	CompletedAt     *string               `json:"completed_at,omitempty"`
+	// New fields for UX improvements
+	OntologyReady   bool   `json:"ontology_ready,omitempty"`
+	TotalEntities   int    `json:"total_entities,omitempty"`
+	CurrentEntity   int    `json:"current_entity,omitempty"`
+	ProgressMessage string `json:"progress_message,omitempty"`
+}
+
+// OntologyResponse for GET /ontology/result
+type OntologyResponse struct {
+	ID              string                           `json:"id"`
+	ProjectID       string                           `json:"project_id"`
+	Version         int                              `json:"version"`
+	IsActive        bool                             `json:"is_active"`
+	DomainSummary   *models.DomainSummary            `json:"domain_summary,omitempty"`
+	EntitySummaries map[string]*models.EntitySummary `json:"entity_summaries,omitempty"`
+	ColumnDetails   map[string][]models.ColumnDetail `json:"column_details,omitempty"`
+	CreatedAt       string                           `json:"created_at"`
+}
+
+// ============================================================================
+// Handler
+// ============================================================================
+
+// OntologyHandler handles ontology workflow HTTP requests.
+type OntologyHandler struct {
+	workflowService services.OntologyWorkflowService
+	projectService  services.ProjectService
+	logger          *zap.Logger
+}
+
+// NewOntologyHandler creates a new ontology handler.
+func NewOntologyHandler(
+	workflowService services.OntologyWorkflowService,
+	projectService services.ProjectService,
+	logger *zap.Logger,
+) *OntologyHandler {
+	return &OntologyHandler{
+		workflowService: workflowService,
+		projectService:  projectService,
+		logger:          logger,
+	}
+}
+
+// RegisterRoutes registers the ontology handler's routes on the given mux.
+func (h *OntologyHandler) RegisterRoutes(mux *http.ServeMux, authMiddleware *auth.Middleware, tenantMiddleware TenantMiddleware) {
+	base := "/api/projects/{pid}/ontology"
+
+	// Workflow management
+	mux.HandleFunc("POST "+base+"/extract",
+		authMiddleware.RequireAuthWithPathValidation("pid")(tenantMiddleware(h.StartExtraction)))
+	mux.HandleFunc("GET "+base+"/workflow",
+		authMiddleware.RequireAuthWithPathValidation("pid")(tenantMiddleware(h.GetWorkflowStatus)))
+	mux.HandleFunc("GET "+base+"/workflow/{wfid}",
+		authMiddleware.RequireAuthWithPathValidation("pid")(tenantMiddleware(h.GetWorkflowByID)))
+	mux.HandleFunc("POST "+base+"/cancel",
+		authMiddleware.RequireAuthWithPathValidation("pid")(tenantMiddleware(h.Cancel)))
+	mux.HandleFunc("DELETE "+base,
+		authMiddleware.RequireAuthWithPathValidation("pid")(tenantMiddleware(h.DeleteOntology)))
+
+	// Ontology results
+	mux.HandleFunc("GET "+base+"/result",
+		authMiddleware.RequireAuthWithPathValidation("pid")(tenantMiddleware(h.GetResult)))
+}
+
+// StartExtraction handles POST /api/projects/{pid}/ontology/extract
+func (h *OntologyHandler) StartExtraction(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := h.parseProjectID(w, r)
+	if !ok {
+		return
+	}
+
+	var req StartExtractionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		if err := ErrorResponse(w, http.StatusBadRequest, "invalid_request", "Invalid request body"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	// Fetch datasource ID from project configuration
+	dsID, err := h.projectService.GetDefaultDatasourceID(r.Context(), projectID)
+	if err != nil {
+		h.logger.Error("Failed to get project datasource",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "internal_error", "Failed to get project configuration"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	if dsID == uuid.Nil {
+		if err := ErrorResponse(w, http.StatusBadRequest, "no_datasource_configured",
+			"No datasource configured for this project. Please configure a datasource in project settings first."); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	// Build workflow config
+	config := &models.WorkflowConfig{
+		DatasourceID:       dsID,
+		IncludeAllTables:   req.IncludeAllTables,
+		SkipDataProfiling:  req.SkipDataProfiling,
+		ProjectDescription: req.ProjectDescription,
+	}
+
+	// Parse selected table IDs
+	if len(req.SelectedTableIDs) > 0 {
+		config.SelectedTableIDs = make([]uuid.UUID, 0, len(req.SelectedTableIDs))
+		for _, idStr := range req.SelectedTableIDs {
+			tableID, err := uuid.Parse(idStr)
+			if err != nil {
+				if err := ErrorResponse(w, http.StatusBadRequest, "invalid_table_id", "Invalid table ID format: "+idStr); err != nil {
+					h.logger.Error("Failed to write error response", zap.Error(err))
+				}
+				return
+			}
+			config.SelectedTableIDs = append(config.SelectedTableIDs, tableID)
+		}
+	}
+
+	workflow, err := h.workflowService.StartExtraction(r.Context(), projectID, config)
+	if err != nil {
+		h.logger.Error("Failed to start extraction",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "extraction_failed", err.Error()); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	response := ApiResponse{Success: true, Data: h.toWorkflowResponse(workflow)}
+	if err := WriteJSON(w, http.StatusOK, response); err != nil {
+		h.logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
+// GetWorkflowStatus handles GET /api/projects/{pid}/ontology/workflow
+func (h *OntologyHandler) GetWorkflowStatus(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := h.parseProjectID(w, r)
+	if !ok {
+		return
+	}
+
+	workflow, err := h.workflowService.GetStatus(r.Context(), projectID)
+	if err != nil {
+		h.logger.Error("Failed to get workflow status",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "internal_error", "Failed to get workflow status"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	if workflow == nil {
+		// No workflow - check if ontology data exists
+		ontology, _ := h.workflowService.GetOntology(r.Context(), projectID)
+		hasOntologyData := ontology != nil && len(ontology.EntitySummaries) > 0
+
+		currentEntity := 0
+		if ontology != nil {
+			currentEntity = len(ontology.EntitySummaries)
+		}
+
+		// Get total entity count from schema (1 global + tables + columns)
+		totalEntities, err := h.workflowService.GetSchemaEntityCount(r.Context(), projectID)
+		if err != nil {
+			h.logger.Warn("Failed to get schema entity count", zap.Error(err))
+			totalEntities = currentEntity // Fallback to current count
+		}
+
+		response := ApiResponse{Success: true, Data: WorkflowStatusResponse{
+			WorkflowID:      "",
+			CurrentPhase:    "",
+			CompletedPhases: []string{},
+			StatusType:      "info",
+			StatusLabel:     "Ready",
+			CanStartNew:     true,
+			HasResult:       hasOntologyData,
+			OntologyReady:   hasOntologyData,
+			TotalEntities:   totalEntities,
+			CurrentEntity:   currentEntity,
+		}}
+		if err := WriteJSON(w, http.StatusOK, response); err != nil {
+			h.logger.Error("Failed to write response", zap.Error(err))
+		}
+		return
+	}
+
+	// Get ontology to calculate entity progress from entity states
+	ontology, _ := h.workflowService.GetOntology(r.Context(), projectID)
+
+	response := ApiResponse{Success: true, Data: h.toWorkflowResponseWithOntology(workflow, ontology)}
+	if err := WriteJSON(w, http.StatusOK, response); err != nil {
+		h.logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
+// GetWorkflowByID handles GET /api/projects/{pid}/ontology/workflow/{wfid}
+func (h *OntologyHandler) GetWorkflowByID(w http.ResponseWriter, r *http.Request) {
+	_, ok := h.parseProjectID(w, r)
+	if !ok {
+		return
+	}
+
+	wfidStr := r.PathValue("wfid")
+	workflowID, err := uuid.Parse(wfidStr)
+	if err != nil {
+		if err := ErrorResponse(w, http.StatusBadRequest, "invalid_workflow_id", "Invalid workflow ID format"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	workflow, err := h.workflowService.GetByID(r.Context(), workflowID)
+	if err != nil {
+		h.logger.Error("Failed to get workflow",
+			zap.String("workflow_id", workflowID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "internal_error", "Failed to get workflow"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	if workflow == nil {
+		if err := ErrorResponse(w, http.StatusNotFound, "not_found", "Workflow not found"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	response := ApiResponse{Success: true, Data: h.toWorkflowResponse(workflow)}
+	if err := WriteJSON(w, http.StatusOK, response); err != nil {
+		h.logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
+// Cancel handles POST /api/projects/{pid}/ontology/cancel
+func (h *OntologyHandler) Cancel(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := h.parseProjectID(w, r)
+	if !ok {
+		return
+	}
+
+	workflow, err := h.workflowService.GetStatus(r.Context(), projectID)
+	if err != nil {
+		h.logger.Error("Failed to get workflow",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "internal_error", "Failed to get workflow"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	if workflow == nil {
+		if err := ErrorResponse(w, http.StatusNotFound, "not_found", "No active workflow"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	if err := h.workflowService.Cancel(r.Context(), workflow.ID); err != nil {
+		h.logger.Error("Failed to cancel workflow",
+			zap.String("workflow_id", workflow.ID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusBadRequest, "cancel_failed", err.Error()); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	response := ApiResponse{Success: true, Data: map[string]string{"message": "Workflow cancelled"}}
+	if err := WriteJSON(w, http.StatusOK, response); err != nil {
+		h.logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
+// DeleteOntology handles DELETE /api/projects/{pid}/ontology
+func (h *OntologyHandler) DeleteOntology(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := h.parseProjectID(w, r)
+	if !ok {
+		return
+	}
+
+	if err := h.workflowService.DeleteOntology(r.Context(), projectID); err != nil {
+		h.logger.Error("Failed to delete ontology",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "delete_failed", err.Error()); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	response := ApiResponse{Success: true, Data: map[string]string{"message": "Ontology deleted"}}
+	if err := WriteJSON(w, http.StatusOK, response); err != nil {
+		h.logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
+// GetResult handles GET /api/projects/{pid}/ontology/result
+func (h *OntologyHandler) GetResult(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := h.parseProjectID(w, r)
+	if !ok {
+		return
+	}
+
+	ontology, err := h.workflowService.GetOntology(r.Context(), projectID)
+	if err != nil {
+		h.logger.Error("Failed to get ontology",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "internal_error", "Failed to get ontology"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	if ontology == nil {
+		response := ApiResponse{Success: true, Data: nil}
+		if err := WriteJSON(w, http.StatusOK, response); err != nil {
+			h.logger.Error("Failed to write response", zap.Error(err))
+		}
+		return
+	}
+
+	response := ApiResponse{Success: true, Data: h.toOntologyResponse(ontology)}
+	if err := WriteJSON(w, http.StatusOK, response); err != nil {
+		h.logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
+// ============================================================================
+// Helper Methods
+// ============================================================================
+
+func (h *OntologyHandler) parseProjectID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
+	pidStr := r.PathValue("pid")
+	projectID, err := uuid.Parse(pidStr)
+	if err != nil {
+		if err := ErrorResponse(w, http.StatusBadRequest, "invalid_project_id", "Invalid project ID format"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return uuid.Nil, false
+	}
+	return projectID, true
+}
+
+func (h *OntologyHandler) toWorkflowResponse(w *models.OntologyWorkflow) WorkflowStatusResponse {
+	// Derive current phase and progress fields with nil check
+	currentPhase := ""
+	progressMessage := ""
+	totalEntities := 0
+	currentEntity := 0
+	ontologyReady := false
+	if w.Progress != nil {
+		currentPhase = w.Progress.CurrentPhase
+		progressMessage = w.Progress.Message
+		totalEntities = w.Progress.Total
+		currentEntity = w.Progress.Current
+		ontologyReady = w.Progress.OntologyReady
+	}
+
+	// Count tasks
+	totalTasks := len(w.TaskQueue)
+	completedTasks := 0
+	for _, t := range w.TaskQueue {
+		if t.Status == models.TaskStatusComplete {
+			completedTasks++
+		}
+	}
+
+	// Derive status fields from state
+	isComplete := w.State == models.WorkflowStateCompleted || w.State == models.WorkflowStateFailed
+	statusType, statusLabel := deriveStatusFromState(w.State)
+	canStartNew := w.State.IsTerminal()
+	hasResult := w.State == models.WorkflowStateCompleted
+
+	resp := WorkflowStatusResponse{
+		WorkflowID:      w.ID.String(),
+		ProjectID:       w.ProjectID.String(),
+		CurrentPhase:    currentPhase,
+		CompletedPhases: []string{},
+		ConfidenceScore: 0,
+		IterationCount:  0,
+		IsComplete:      isComplete,
+		StatusLabel:     statusLabel,
+		StatusType:      statusType,
+		CanStartNew:     canStartNew,
+		HasResult:       hasResult,
+		TaskQueue:       w.TaskQueue,
+		TotalTasks:      totalTasks,
+		CompletedTasks:  completedTasks,
+		LastError:       w.ErrorMessage,
+		// New fields for UX improvements
+		OntologyReady:   ontologyReady,
+		TotalEntities:   totalEntities,
+		CurrentEntity:   currentEntity,
+		ProgressMessage: progressMessage,
+	}
+
+	// Format timestamps
+	if !w.CreatedAt.IsZero() {
+		created := w.CreatedAt.Format(time.RFC3339)
+		resp.CreatedAt = &created
+	}
+	if !w.UpdatedAt.IsZero() {
+		updated := w.UpdatedAt.Format(time.RFC3339)
+		resp.UpdatedAt = &updated
+	}
+	if w.CompletedAt != nil {
+		completed := w.CompletedAt.Format(time.RFC3339)
+		resp.CompletedAt = &completed
+	}
+
+	return resp
+}
+
+// toWorkflowResponseWithOntology is like toWorkflowResponse but uses workflow progress directly.
+// Entity counts (global + tables + columns) are now tracked by the orchestrator, not derived from ontology.
+func (h *OntologyHandler) toWorkflowResponseWithOntology(w *models.OntologyWorkflow, ontology *models.TieredOntology) WorkflowStatusResponse {
+	return h.toWorkflowResponse(w)
+}
+
+// deriveStatusFromState converts workflow state to UI-friendly status type and label.
+func deriveStatusFromState(state models.WorkflowState) (statusType, statusLabel string) {
+	switch state {
+	case models.WorkflowStatePending:
+		return "processing", "Initializing"
+	case models.WorkflowStateRunning:
+		return "processing", "Building Ontology"
+	case models.WorkflowStatePaused:
+		return "warning", "Paused"
+	case models.WorkflowStateAwaitingInput:
+		return "info", "Awaiting Input"
+	case models.WorkflowStateCompleted:
+		return "success", "Completed"
+	case models.WorkflowStateFailed:
+		return "error", "Failed"
+	default:
+		return "info", "Unknown"
+	}
+}
+
+func (h *OntologyHandler) toOntologyResponse(o *models.TieredOntology) OntologyResponse {
+	return OntologyResponse{
+		ID:              o.ID.String(),
+		ProjectID:       o.ProjectID.String(),
+		Version:         o.Version,
+		IsActive:        o.IsActive,
+		DomainSummary:   o.DomainSummary,
+		EntitySummaries: o.EntitySummaries,
+		ColumnDetails:   o.ColumnDetails,
+		CreatedAt:       o.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+}

--- a/pkg/handlers/ontology_chat.go
+++ b/pkg/handlers/ontology_chat.go
@@ -1,0 +1,352 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/auth"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/services"
+)
+
+// ============================================================================
+// Request/Response Types
+// ============================================================================
+
+// ChatInitResponse for GET /chat/initialize
+type ChatInitResponse struct {
+	OpeningMessage       string `json:"opening_message"`
+	PendingQuestionCount int    `json:"pending_question_count"`
+	HasExistingHistory   bool   `json:"has_existing_history"`
+}
+
+// SendMessageRequest for POST /chat/message
+type SendMessageRequest struct {
+	Message string `json:"message"`
+}
+
+// ChatMessageResponse for chat history endpoint.
+type ChatMessageResponse struct {
+	ID         string            `json:"id"`
+	ProjectID  string            `json:"project_id"`
+	Role       string            `json:"role"`
+	Content    string            `json:"content"`
+	ToolCalls  []models.ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string            `json:"tool_call_id,omitempty"`
+	CreatedAt  string            `json:"created_at"`
+}
+
+// ChatHistoryResponse for GET /chat/history
+type ChatHistoryResponse struct {
+	Messages []ChatMessageResponse `json:"messages"`
+	Total    int                   `json:"total"`
+}
+
+// KnowledgeFactResponse for knowledge endpoints.
+type KnowledgeFactResponse struct {
+	ID        string `json:"id"`
+	FactType  string `json:"fact_type"`
+	Key       string `json:"key"`
+	Value     string `json:"value"`
+	Context   string `json:"context,omitempty"`
+	CreatedAt string `json:"created_at"`
+}
+
+// KnowledgeListResponse for GET /knowledge
+type KnowledgeListResponse struct {
+	Facts []KnowledgeFactResponse `json:"facts"`
+	Total int                     `json:"total"`
+}
+
+// ============================================================================
+// Handler
+// ============================================================================
+
+// OntologyChatHandler handles ontology chat HTTP requests with SSE support.
+type OntologyChatHandler struct {
+	chatService      services.OntologyChatService
+	knowledgeService services.KnowledgeService
+	logger           *zap.Logger
+}
+
+// NewOntologyChatHandler creates a new ontology chat handler.
+func NewOntologyChatHandler(
+	chatService services.OntologyChatService,
+	knowledgeService services.KnowledgeService,
+	logger *zap.Logger,
+) *OntologyChatHandler {
+	return &OntologyChatHandler{
+		chatService:      chatService,
+		knowledgeService: knowledgeService,
+		logger:           logger,
+	}
+}
+
+// RegisterRoutes registers the chat handler's routes on the given mux.
+func (h *OntologyChatHandler) RegisterRoutes(mux *http.ServeMux, authMiddleware *auth.Middleware, tenantMiddleware TenantMiddleware) {
+	chatBase := "/api/projects/{pid}/ontology/chat"
+
+	mux.HandleFunc("POST "+chatBase+"/initialize",
+		authMiddleware.RequireAuthWithPathValidation("pid")(tenantMiddleware(h.Initialize)))
+	mux.HandleFunc("POST "+chatBase+"/message",
+		authMiddleware.RequireAuthWithPathValidation("pid")(tenantMiddleware(h.SendMessage)))
+	mux.HandleFunc("GET "+chatBase+"/history",
+		authMiddleware.RequireAuthWithPathValidation("pid")(tenantMiddleware(h.GetHistory)))
+	mux.HandleFunc("DELETE "+chatBase+"/history",
+		authMiddleware.RequireAuthWithPathValidation("pid")(tenantMiddleware(h.ClearHistory)))
+
+	// Knowledge endpoints
+	knowledgeBase := "/api/projects/{pid}/ontology/knowledge"
+	mux.HandleFunc("GET "+knowledgeBase,
+		authMiddleware.RequireAuthWithPathValidation("pid")(tenantMiddleware(h.GetKnowledge)))
+}
+
+// Initialize handles POST /api/projects/{pid}/ontology/chat/initialize
+func (h *OntologyChatHandler) Initialize(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := h.parseProjectID(w, r)
+	if !ok {
+		return
+	}
+
+	result, err := h.chatService.Initialize(r.Context(), projectID)
+	if err != nil {
+		h.logger.Error("Failed to initialize chat",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "init_failed", "Failed to initialize chat"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	data := ChatInitResponse{
+		OpeningMessage:       result.OpeningMessage,
+		PendingQuestionCount: result.PendingQuestionCount,
+		HasExistingHistory:   result.HasExistingHistory,
+	}
+
+	response := ApiResponse{Success: true, Data: data}
+	if err := WriteJSON(w, http.StatusOK, response); err != nil {
+		h.logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
+// SendMessage handles POST /api/projects/{pid}/ontology/chat/message
+// This endpoint uses Server-Sent Events (SSE) to stream the response.
+func (h *OntologyChatHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := h.parseProjectID(w, r)
+	if !ok {
+		return
+	}
+
+	var req SendMessageRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if err := ErrorResponse(w, http.StatusBadRequest, "invalid_request", "Invalid request body"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	if req.Message == "" {
+		if err := ErrorResponse(w, http.StatusBadRequest, "missing_message", "Message is required"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	// Set SSE headers
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		h.logger.Error("SSE not supported")
+		if err := ErrorResponse(w, http.StatusInternalServerError, "sse_unsupported", "SSE not supported"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	eventChan := make(chan models.ChatEvent, 100)
+
+	// Start streaming in background
+	go func() {
+		defer close(eventChan)
+		if err := h.chatService.SendMessage(r.Context(), projectID, req.Message, eventChan); err != nil {
+			h.logger.Error("Chat send message error",
+				zap.String("project_id", projectID.String()),
+				zap.Error(err))
+			eventChan <- models.NewErrorEvent(err.Error())
+		}
+	}()
+
+	// Stream events to client
+	for event := range eventChan {
+		data, err := json.Marshal(event)
+		if err != nil {
+			h.logger.Error("Failed to marshal event", zap.Error(err))
+			continue
+		}
+
+		// Write SSE formatted data
+		fmt.Fprintf(w, "data: %s\n\n", data)
+		flusher.Flush()
+
+		// Stop on done or error
+		if event.Type == models.ChatEventDone || event.Type == models.ChatEventError {
+			break
+		}
+	}
+}
+
+// GetHistory handles GET /api/projects/{pid}/ontology/chat/history
+func (h *OntologyChatHandler) GetHistory(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := h.parseProjectID(w, r)
+	if !ok {
+		return
+	}
+
+	// Parse limit from query params
+	limit := 50 // Default
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
+			limit = l
+		}
+	}
+
+	messages, err := h.chatService.GetHistory(r.Context(), projectID, limit)
+	if err != nil {
+		h.logger.Error("Failed to get chat history",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "internal_error", "Failed to get chat history"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	data := ChatHistoryResponse{
+		Messages: make([]ChatMessageResponse, len(messages)),
+		Total:    len(messages),
+	}
+	for i, m := range messages {
+		data.Messages[i] = h.toChatMessageResponse(m)
+	}
+
+	response := ApiResponse{Success: true, Data: data}
+	if err := WriteJSON(w, http.StatusOK, response); err != nil {
+		h.logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
+// ClearHistory handles DELETE /api/projects/{pid}/ontology/chat/history
+func (h *OntologyChatHandler) ClearHistory(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := h.parseProjectID(w, r)
+	if !ok {
+		return
+	}
+
+	if err := h.chatService.ClearHistory(r.Context(), projectID); err != nil {
+		h.logger.Error("Failed to clear chat history",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "internal_error", "Failed to clear chat history"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	response := ApiResponse{Success: true, Data: map[string]string{"message": "Chat history cleared"}}
+	if err := WriteJSON(w, http.StatusOK, response); err != nil {
+		h.logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
+// GetKnowledge handles GET /api/projects/{pid}/ontology/knowledge
+func (h *OntologyChatHandler) GetKnowledge(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := h.parseProjectID(w, r)
+	if !ok {
+		return
+	}
+
+	// Optional filter by type
+	factType := r.URL.Query().Get("type")
+
+	var facts []*models.KnowledgeFact
+	var err error
+
+	if factType != "" {
+		facts, err = h.knowledgeService.GetByType(r.Context(), projectID, factType)
+	} else {
+		facts, err = h.knowledgeService.GetAll(r.Context(), projectID)
+	}
+
+	if err != nil {
+		h.logger.Error("Failed to get knowledge facts",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "internal_error", "Failed to get knowledge facts"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	data := KnowledgeListResponse{
+		Facts: make([]KnowledgeFactResponse, len(facts)),
+		Total: len(facts),
+	}
+	for i, f := range facts {
+		data.Facts[i] = h.toKnowledgeFactResponse(f)
+	}
+
+	response := ApiResponse{Success: true, Data: data}
+	if err := WriteJSON(w, http.StatusOK, response); err != nil {
+		h.logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
+// ============================================================================
+// Helper Methods
+// ============================================================================
+
+func (h *OntologyChatHandler) parseProjectID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
+	pidStr := r.PathValue("pid")
+	projectID, err := uuid.Parse(pidStr)
+	if err != nil {
+		if err := ErrorResponse(w, http.StatusBadRequest, "invalid_project_id", "Invalid project ID format"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return uuid.Nil, false
+	}
+	return projectID, true
+}
+
+func (h *OntologyChatHandler) toChatMessageResponse(m *models.ChatMessage) ChatMessageResponse {
+	return ChatMessageResponse{
+		ID:         m.ID.String(),
+		ProjectID:  m.ProjectID.String(),
+		Role:       string(m.Role),
+		Content:    m.Content,
+		ToolCalls:  m.ToolCalls,
+		ToolCallID: m.ToolCallID,
+		CreatedAt:  m.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+}
+
+func (h *OntologyChatHandler) toKnowledgeFactResponse(f *models.KnowledgeFact) KnowledgeFactResponse {
+	return KnowledgeFactResponse{
+		ID:        f.ID.String(),
+		FactType:  f.FactType,
+		Key:       f.Key,
+		Value:     f.Value,
+		Context:   f.Context,
+		CreatedAt: f.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+}

--- a/pkg/handlers/ontology_chat_integration_test.go
+++ b/pkg/handlers/ontology_chat_integration_test.go
@@ -1,0 +1,857 @@
+//go:build integration
+
+package handlers
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/auth"
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
+	"github.com/ekaya-inc/ekaya-engine/pkg/services"
+	"github.com/ekaya-inc/ekaya-engine/pkg/testhelpers"
+)
+
+// chatIntegrationTestContext holds all dependencies for chat integration tests.
+type chatIntegrationTestContext struct {
+	t                *testing.T
+	engineDB         *testhelpers.EngineDB
+	handler          *OntologyChatHandler
+	chatRepo         repositories.OntologyChatRepository
+	ontologyRepo     repositories.OntologyRepository
+	knowledgeRepo    repositories.KnowledgeRepository
+	projectID        uuid.UUID
+	mockChatService  *mockChatService
+	mockKnowledgeSvc *mockKnowledgeService
+}
+
+// mockChatService is a mock implementation of OntologyChatService for testing.
+type mockChatService struct {
+	initializeFunc   func(ctx context.Context, projectID uuid.UUID) (*models.ChatInitResponse, error)
+	sendMessageFunc  func(ctx context.Context, projectID uuid.UUID, message string, eventChan chan<- models.ChatEvent) error
+	getHistoryFunc   func(ctx context.Context, projectID uuid.UUID, limit int) ([]*models.ChatMessage, error)
+	clearHistoryFunc func(ctx context.Context, projectID uuid.UUID) error
+	saveMessageFunc  func(ctx context.Context, message *models.ChatMessage) error
+}
+
+func (m *mockChatService) Initialize(ctx context.Context, projectID uuid.UUID) (*models.ChatInitResponse, error) {
+	if m.initializeFunc != nil {
+		return m.initializeFunc(ctx, projectID)
+	}
+	return &models.ChatInitResponse{
+		OpeningMessage:       "Hello! How can I help you with your ontology?",
+		PendingQuestionCount: 0,
+		HasExistingHistory:   false,
+	}, nil
+}
+
+func (m *mockChatService) SendMessage(ctx context.Context, projectID uuid.UUID, message string, eventChan chan<- models.ChatEvent) error {
+	if m.sendMessageFunc != nil {
+		return m.sendMessageFunc(ctx, projectID, message, eventChan)
+	}
+	// Default behavior: send a simple response
+	eventChan <- models.NewTextEvent("This is a mock response to: ")
+	eventChan <- models.NewTextEvent(message)
+	eventChan <- models.NewDoneEvent()
+	return nil
+}
+
+func (m *mockChatService) GetHistory(ctx context.Context, projectID uuid.UUID, limit int) ([]*models.ChatMessage, error) {
+	if m.getHistoryFunc != nil {
+		return m.getHistoryFunc(ctx, projectID, limit)
+	}
+	return []*models.ChatMessage{}, nil
+}
+
+func (m *mockChatService) ClearHistory(ctx context.Context, projectID uuid.UUID) error {
+	if m.clearHistoryFunc != nil {
+		return m.clearHistoryFunc(ctx, projectID)
+	}
+	return nil
+}
+
+func (m *mockChatService) SaveMessage(ctx context.Context, message *models.ChatMessage) error {
+	if m.saveMessageFunc != nil {
+		return m.saveMessageFunc(ctx, message)
+	}
+	return nil
+}
+
+// mockKnowledgeService is a mock implementation of KnowledgeService for testing.
+type mockKnowledgeService struct {
+	storeFunc     func(ctx context.Context, projectID uuid.UUID, factType, key, value, contextInfo string) (*models.KnowledgeFact, error)
+	getAllFunc    func(ctx context.Context, projectID uuid.UUID) ([]*models.KnowledgeFact, error)
+	getByTypeFunc func(ctx context.Context, projectID uuid.UUID, factType string) ([]*models.KnowledgeFact, error)
+	deleteFunc    func(ctx context.Context, id uuid.UUID) error
+}
+
+func (m *mockKnowledgeService) Store(ctx context.Context, projectID uuid.UUID, factType, key, value, contextInfo string) (*models.KnowledgeFact, error) {
+	if m.storeFunc != nil {
+		return m.storeFunc(ctx, projectID, factType, key, value, contextInfo)
+	}
+	return &models.KnowledgeFact{
+		ID:        uuid.New(),
+		ProjectID: projectID,
+		FactType:  factType,
+		Key:       key,
+		Value:     value,
+		Context:   contextInfo,
+	}, nil
+}
+
+func (m *mockKnowledgeService) GetAll(ctx context.Context, projectID uuid.UUID) ([]*models.KnowledgeFact, error) {
+	if m.getAllFunc != nil {
+		return m.getAllFunc(ctx, projectID)
+	}
+	return []*models.KnowledgeFact{}, nil
+}
+
+func (m *mockKnowledgeService) GetByType(ctx context.Context, projectID uuid.UUID, factType string) ([]*models.KnowledgeFact, error) {
+	if m.getByTypeFunc != nil {
+		return m.getByTypeFunc(ctx, projectID, factType)
+	}
+	return []*models.KnowledgeFact{}, nil
+}
+
+func (m *mockKnowledgeService) Delete(ctx context.Context, id uuid.UUID) error {
+	if m.deleteFunc != nil {
+		return m.deleteFunc(ctx, id)
+	}
+	return nil
+}
+
+// setupChatIntegrationTest creates a test context with mock services.
+func setupChatIntegrationTest(t *testing.T) *chatIntegrationTestContext {
+	t.Helper()
+
+	engineDB := testhelpers.GetEngineDB(t)
+
+	mockChatSvc := &mockChatService{}
+	mockKnowledgeSvc := &mockKnowledgeService{}
+
+	handler := NewOntologyChatHandler(mockChatSvc, mockKnowledgeSvc, zap.NewNop())
+
+	// Use a unique project ID for chat tests
+	projectID := uuid.MustParse("00000000-0000-0000-0000-000000000044")
+
+	tc := &chatIntegrationTestContext{
+		t:                t,
+		engineDB:         engineDB,
+		handler:          handler,
+		chatRepo:         repositories.NewOntologyChatRepository(),
+		ontologyRepo:     repositories.NewOntologyRepository(),
+		knowledgeRepo:    repositories.NewKnowledgeRepository(),
+		projectID:        projectID,
+		mockChatService:  mockChatSvc,
+		mockKnowledgeSvc: mockKnowledgeSvc,
+	}
+
+	tc.ensureTestProject()
+	return tc
+}
+
+// setupChatIntegrationTestWithRealServices creates test context with real services (for end-to-end).
+func setupChatIntegrationTestWithRealServices(t *testing.T) *chatIntegrationTestContext {
+	t.Helper()
+
+	engineDB := testhelpers.GetEngineDB(t)
+
+	// Create real repositories
+	chatRepo := repositories.NewOntologyChatRepository()
+	ontologyRepo := repositories.NewOntologyRepository()
+	knowledgeRepo := repositories.NewKnowledgeRepository()
+
+	// Create real services
+	knowledgeSvc := services.NewKnowledgeService(knowledgeRepo, zap.NewNop())
+
+	// Use a unique project ID for chat tests
+	projectID := uuid.MustParse("00000000-0000-0000-0000-000000000045")
+
+	tc := &chatIntegrationTestContext{
+		t:             t,
+		engineDB:      engineDB,
+		chatRepo:      chatRepo,
+		ontologyRepo:  ontologyRepo,
+		knowledgeRepo: knowledgeRepo,
+		projectID:     projectID,
+	}
+
+	tc.ensureTestProject()
+
+	// Create mock chat service that writes to real repositories
+	mockChatSvc := &mockChatService{
+		getHistoryFunc: func(ctx context.Context, pid uuid.UUID, limit int) ([]*models.ChatMessage, error) {
+			return chatRepo.GetHistory(ctx, pid, limit)
+		},
+		clearHistoryFunc: func(ctx context.Context, pid uuid.UUID) error {
+			return chatRepo.ClearHistory(ctx, pid)
+		},
+	}
+
+	tc.mockChatService = mockChatSvc
+	tc.mockKnowledgeSvc = &mockKnowledgeService{
+		getAllFunc: func(ctx context.Context, pid uuid.UUID) ([]*models.KnowledgeFact, error) {
+			return knowledgeRepo.GetByProject(ctx, pid)
+		},
+		getByTypeFunc: func(ctx context.Context, pid uuid.UUID, factType string) ([]*models.KnowledgeFact, error) {
+			return knowledgeRepo.GetByType(ctx, pid, factType)
+		},
+	}
+
+	tc.handler = NewOntologyChatHandler(mockChatSvc, knowledgeSvc, zap.NewNop())
+
+	return tc
+}
+
+// ensureTestProject creates the test project if it doesn't exist.
+func (tc *chatIntegrationTestContext) ensureTestProject() {
+	tc.t.Helper()
+
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("Failed to create scope for project setup: %v", err)
+	}
+	defer scope.Close()
+
+	_, err = scope.Conn.Exec(ctx, `
+		INSERT INTO engine_projects (id, name, status)
+		VALUES ($1, $2, 'active')
+		ON CONFLICT (id) DO NOTHING
+	`, tc.projectID, "Chat Integration Test Project")
+	if err != nil {
+		tc.t.Fatalf("Failed to ensure test project: %v", err)
+	}
+}
+
+// cleanup removes test data.
+func (tc *chatIntegrationTestContext) cleanup() {
+	tc.t.Helper()
+
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("Failed to create scope for cleanup: %v", err)
+	}
+	defer scope.Close()
+
+	_, _ = scope.Conn.Exec(ctx, "DELETE FROM engine_ontology_chat_messages WHERE project_id = $1", tc.projectID)
+	_, _ = scope.Conn.Exec(ctx, "DELETE FROM engine_project_knowledge WHERE project_id = $1", tc.projectID)
+	_, _ = scope.Conn.Exec(ctx, "DELETE FROM engine_ontology_questions WHERE project_id = $1", tc.projectID)
+	_, _ = scope.Conn.Exec(ctx, "DELETE FROM engine_ontologies WHERE project_id = $1", tc.projectID)
+}
+
+// makeRequest creates an HTTP request with proper context (tenant scope + auth claims).
+func (tc *chatIntegrationTestContext) makeRequest(method, path string, body any) *http.Request {
+	tc.t.Helper()
+
+	var reqBody *bytes.Reader
+	if body != nil {
+		bodyBytes, err := json.Marshal(body)
+		if err != nil {
+			tc.t.Fatalf("Failed to marshal request body: %v", err)
+		}
+		reqBody = bytes.NewReader(bodyBytes)
+	} else {
+		reqBody = bytes.NewReader(nil)
+	}
+
+	req := httptest.NewRequest(method, path, reqBody)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Set up tenant scope
+	ctx := req.Context()
+	scope, err := tc.engineDB.DB.WithTenant(ctx, tc.projectID)
+	if err != nil {
+		tc.t.Fatalf("Failed to create tenant scope: %v", err)
+	}
+	ctx = database.SetTenantScope(ctx, scope)
+
+	// Set up auth claims
+	claims := &auth.Claims{ProjectID: tc.projectID.String()}
+	ctx = context.WithValue(ctx, auth.ClaimsKey, claims)
+
+	req = req.WithContext(ctx)
+
+	// Clean up tenant scope after test
+	tc.t.Cleanup(func() {
+		scope.Close()
+	})
+
+	return req
+}
+
+// parseSSEEvents parses SSE data from response body.
+func parseSSEEvents(body string) []models.ChatEvent {
+	events := []models.ChatEvent{}
+	scanner := bufio.NewScanner(strings.NewReader(body))
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "data: ") {
+			var event models.ChatEvent
+			jsonData := line[6:] // Remove "data: " prefix
+			if err := json.Unmarshal([]byte(jsonData), &event); err == nil {
+				events = append(events, event)
+			}
+		}
+	}
+
+	return events
+}
+
+// ============================================================================
+// Initialize Tests
+// ============================================================================
+
+func TestChatHandlerIntegration_Initialize_Success(t *testing.T) {
+	tc := setupChatIntegrationTest(t)
+	tc.cleanup()
+
+	tc.mockChatService.initializeFunc = func(ctx context.Context, projectID uuid.UUID) (*models.ChatInitResponse, error) {
+		return &models.ChatInitResponse{
+			OpeningMessage:       "Welcome! Ready to help with your ontology.",
+			PendingQuestionCount: 5,
+			HasExistingHistory:   true,
+		}, nil
+	}
+
+	req := tc.makeRequest(http.MethodPost, "/api/projects/"+tc.projectID.String()+"/ontology/chat/initialize", nil)
+	req.SetPathValue("pid", tc.projectID.String())
+
+	rec := httptest.NewRecorder()
+	tc.handler.Initialize(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp ApiResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if !resp.Success {
+		t.Errorf("expected success to be true")
+	}
+
+	data, ok := resp.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("expected data to be a map, got %T", resp.Data)
+	}
+
+	if data["opening_message"] != "Welcome! Ready to help with your ontology." {
+		t.Errorf("expected opening message, got %v", data["opening_message"])
+	}
+	if data["pending_question_count"] != float64(5) {
+		t.Errorf("expected 5 pending questions, got %v", data["pending_question_count"])
+	}
+	if data["has_existing_history"] != true {
+		t.Errorf("expected has_existing_history true, got %v", data["has_existing_history"])
+	}
+}
+
+// ============================================================================
+// SendMessage SSE Tests
+// ============================================================================
+
+func TestChatHandlerIntegration_SendMessage_SSE_Headers(t *testing.T) {
+	tc := setupChatIntegrationTest(t)
+	tc.cleanup()
+
+	req := tc.makeRequest(http.MethodPost, "/api/projects/"+tc.projectID.String()+"/ontology/chat/message",
+		SendMessageRequest{Message: "Hello"})
+	req.SetPathValue("pid", tc.projectID.String())
+
+	rec := httptest.NewRecorder()
+	tc.handler.SendMessage(rec, req)
+
+	// Verify SSE headers
+	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("expected Content-Type 'text/event-stream', got %q", ct)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-cache" {
+		t.Errorf("expected Cache-Control 'no-cache', got %q", cc)
+	}
+	if conn := rec.Header().Get("Connection"); conn != "keep-alive" {
+		t.Errorf("expected Connection 'keep-alive', got %q", conn)
+	}
+	if xab := rec.Header().Get("X-Accel-Buffering"); xab != "no" {
+		t.Errorf("expected X-Accel-Buffering 'no', got %q", xab)
+	}
+}
+
+func TestChatHandlerIntegration_SendMessage_SSE_Events(t *testing.T) {
+	tc := setupChatIntegrationTest(t)
+	tc.cleanup()
+
+	tc.mockChatService.sendMessageFunc = func(ctx context.Context, projectID uuid.UUID, message string, eventChan chan<- models.ChatEvent) error {
+		eventChan <- models.NewTextEvent("Hello, ")
+		eventChan <- models.NewTextEvent("how can I help?")
+		eventChan <- models.NewDoneEvent()
+		return nil
+	}
+
+	req := tc.makeRequest(http.MethodPost, "/api/projects/"+tc.projectID.String()+"/ontology/chat/message",
+		SendMessageRequest{Message: "Hi"})
+	req.SetPathValue("pid", tc.projectID.String())
+
+	rec := httptest.NewRecorder()
+	tc.handler.SendMessage(rec, req)
+
+	events := parseSSEEvents(rec.Body.String())
+
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+
+	// First text event
+	if events[0].Type != models.ChatEventText {
+		t.Errorf("expected first event type 'text', got %q", events[0].Type)
+	}
+	if events[0].Content != "Hello, " {
+		t.Errorf("expected first event content 'Hello, ', got %q", events[0].Content)
+	}
+
+	// Second text event
+	if events[1].Type != models.ChatEventText {
+		t.Errorf("expected second event type 'text', got %q", events[1].Type)
+	}
+
+	// Done event
+	if events[2].Type != models.ChatEventDone {
+		t.Errorf("expected last event type 'done', got %q", events[2].Type)
+	}
+}
+
+func TestChatHandlerIntegration_SendMessage_WithToolCalls(t *testing.T) {
+	tc := setupChatIntegrationTest(t)
+	tc.cleanup()
+
+	tc.mockChatService.sendMessageFunc = func(ctx context.Context, projectID uuid.UUID, message string, eventChan chan<- models.ChatEvent) error {
+		// Simulate tool call flow
+		toolCall := models.ToolCall{
+			ID:   "call_123",
+			Type: "function",
+			Function: models.ToolCallFunction{
+				Name:      "query_column_values",
+				Arguments: `{"table_name": "accounts", "column_name": "status"}`,
+			},
+		}
+		eventChan <- models.NewToolCallEvent(toolCall)
+		eventChan <- models.NewToolResultEvent("call_123", []string{"active", "inactive", "pending"})
+		eventChan <- models.NewTextEvent("The status column has 3 values.")
+		eventChan <- models.NewDoneEvent()
+		return nil
+	}
+
+	req := tc.makeRequest(http.MethodPost, "/api/projects/"+tc.projectID.String()+"/ontology/chat/message",
+		SendMessageRequest{Message: "What are the status values?"})
+	req.SetPathValue("pid", tc.projectID.String())
+
+	rec := httptest.NewRecorder()
+	tc.handler.SendMessage(rec, req)
+
+	events := parseSSEEvents(rec.Body.String())
+
+	if len(events) != 4 {
+		t.Fatalf("expected 4 events, got %d", len(events))
+	}
+
+	// Tool call event
+	if events[0].Type != models.ChatEventToolCall {
+		t.Errorf("expected tool_call event, got %q", events[0].Type)
+	}
+
+	// Tool result event
+	if events[1].Type != models.ChatEventToolResult {
+		t.Errorf("expected tool_result event, got %q", events[1].Type)
+	}
+	if events[1].Content != "call_123" {
+		t.Errorf("expected tool result content 'call_123', got %q", events[1].Content)
+	}
+
+	// Text event
+	if events[2].Type != models.ChatEventText {
+		t.Errorf("expected text event, got %q", events[2].Type)
+	}
+
+	// Done event
+	if events[3].Type != models.ChatEventDone {
+		t.Errorf("expected done event, got %q", events[3].Type)
+	}
+}
+
+func TestChatHandlerIntegration_SendMessage_OntologyUpdate(t *testing.T) {
+	tc := setupChatIntegrationTest(t)
+	tc.cleanup()
+
+	tc.mockChatService.sendMessageFunc = func(ctx context.Context, projectID uuid.UUID, message string, eventChan chan<- models.ChatEvent) error {
+		eventChan <- models.NewTextEvent("I'll update the accounts table.")
+		eventChan <- models.NewOntologyUpdateEvent("accounts", map[string]any{
+			"business_name": "Customer Accounts",
+			"description":   "Contains all customer account information",
+		})
+		eventChan <- models.NewDoneEvent()
+		return nil
+	}
+
+	req := tc.makeRequest(http.MethodPost, "/api/projects/"+tc.projectID.String()+"/ontology/chat/message",
+		SendMessageRequest{Message: "Update accounts description"})
+	req.SetPathValue("pid", tc.projectID.String())
+
+	rec := httptest.NewRecorder()
+	tc.handler.SendMessage(rec, req)
+
+	events := parseSSEEvents(rec.Body.String())
+
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+
+	// Ontology update event
+	if events[1].Type != models.ChatEventOntologyUpdate {
+		t.Errorf("expected ontology_update event, got %q", events[1].Type)
+	}
+	if events[1].Content != "accounts" {
+		t.Errorf("expected table name 'accounts', got %q", events[1].Content)
+	}
+}
+
+func TestChatHandlerIntegration_SendMessage_KnowledgeStored(t *testing.T) {
+	tc := setupChatIntegrationTest(t)
+	tc.cleanup()
+
+	tc.mockChatService.sendMessageFunc = func(ctx context.Context, projectID uuid.UUID, message string, eventChan chan<- models.ChatEvent) error {
+		fact := &models.KnowledgeFact{
+			ID:       uuid.New(),
+			FactType: models.FactTypeFiscalYear,
+			Key:      "start_month",
+			Value:    "July",
+		}
+		eventChan <- models.NewTextEvent("I've stored that information.")
+		eventChan <- models.NewKnowledgeStoredEvent(fact)
+		eventChan <- models.NewDoneEvent()
+		return nil
+	}
+
+	req := tc.makeRequest(http.MethodPost, "/api/projects/"+tc.projectID.String()+"/ontology/chat/message",
+		SendMessageRequest{Message: "Our fiscal year starts in July"})
+	req.SetPathValue("pid", tc.projectID.String())
+
+	rec := httptest.NewRecorder()
+	tc.handler.SendMessage(rec, req)
+
+	events := parseSSEEvents(rec.Body.String())
+
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+
+	if events[1].Type != models.ChatEventKnowledgeStored {
+		t.Errorf("expected knowledge_stored event, got %q", events[1].Type)
+	}
+}
+
+func TestChatHandlerIntegration_SendMessage_Error(t *testing.T) {
+	tc := setupChatIntegrationTest(t)
+	tc.cleanup()
+
+	tc.mockChatService.sendMessageFunc = func(ctx context.Context, projectID uuid.UUID, message string, eventChan chan<- models.ChatEvent) error {
+		eventChan <- models.NewErrorEvent("Something went wrong")
+		return nil
+	}
+
+	req := tc.makeRequest(http.MethodPost, "/api/projects/"+tc.projectID.String()+"/ontology/chat/message",
+		SendMessageRequest{Message: "test"})
+	req.SetPathValue("pid", tc.projectID.String())
+
+	rec := httptest.NewRecorder()
+	tc.handler.SendMessage(rec, req)
+
+	events := parseSSEEvents(rec.Body.String())
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	if events[0].Type != models.ChatEventError {
+		t.Errorf("expected error event, got %q", events[0].Type)
+	}
+	if events[0].Content != "Something went wrong" {
+		t.Errorf("expected error message, got %q", events[0].Content)
+	}
+}
+
+func TestChatHandlerIntegration_SendMessage_MissingMessage(t *testing.T) {
+	tc := setupChatIntegrationTest(t)
+	tc.cleanup()
+
+	req := tc.makeRequest(http.MethodPost, "/api/projects/"+tc.projectID.String()+"/ontology/chat/message",
+		SendMessageRequest{Message: ""})
+	req.SetPathValue("pid", tc.projectID.String())
+
+	rec := httptest.NewRecorder()
+	tc.handler.SendMessage(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if resp["error"] != "missing_message" {
+		t.Errorf("expected error 'missing_message', got %v", resp["error"])
+	}
+}
+
+// ============================================================================
+// GetHistory Tests
+// ============================================================================
+
+func TestChatHandlerIntegration_GetHistory_Success(t *testing.T) {
+	tc := setupChatIntegrationTest(t)
+	tc.cleanup()
+
+	tc.mockChatService.getHistoryFunc = func(ctx context.Context, projectID uuid.UUID, limit int) ([]*models.ChatMessage, error) {
+		return []*models.ChatMessage{
+			{
+				ID:        uuid.New(),
+				ProjectID: projectID,
+				Role:      models.ChatRoleUser,
+				Content:   "Hello",
+			},
+			{
+				ID:        uuid.New(),
+				ProjectID: projectID,
+				Role:      models.ChatRoleAssistant,
+				Content:   "Hi there!",
+			},
+		}, nil
+	}
+
+	req := tc.makeRequest(http.MethodGet, "/api/projects/"+tc.projectID.String()+"/ontology/chat/history", nil)
+	req.SetPathValue("pid", tc.projectID.String())
+
+	rec := httptest.NewRecorder()
+	tc.handler.GetHistory(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp ApiResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	data, ok := resp.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("expected data to be a map")
+	}
+
+	messages, ok := data["messages"].([]any)
+	if !ok {
+		t.Fatalf("expected messages to be an array")
+	}
+
+	if len(messages) != 2 {
+		t.Errorf("expected 2 messages, got %d", len(messages))
+	}
+
+	if data["total"] != float64(2) {
+		t.Errorf("expected total 2, got %v", data["total"])
+	}
+}
+
+func TestChatHandlerIntegration_GetHistory_WithLimit(t *testing.T) {
+	tc := setupChatIntegrationTest(t)
+	tc.cleanup()
+
+	receivedLimit := 0
+	tc.mockChatService.getHistoryFunc = func(ctx context.Context, projectID uuid.UUID, limit int) ([]*models.ChatMessage, error) {
+		receivedLimit = limit
+		return []*models.ChatMessage{}, nil
+	}
+
+	req := tc.makeRequest(http.MethodGet, "/api/projects/"+tc.projectID.String()+"/ontology/chat/history?limit=25", nil)
+	req.SetPathValue("pid", tc.projectID.String())
+
+	rec := httptest.NewRecorder()
+	tc.handler.GetHistory(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	if receivedLimit != 25 {
+		t.Errorf("expected limit 25, got %d", receivedLimit)
+	}
+}
+
+// ============================================================================
+// ClearHistory Tests
+// ============================================================================
+
+func TestChatHandlerIntegration_ClearHistory_Success(t *testing.T) {
+	tc := setupChatIntegrationTest(t)
+	tc.cleanup()
+
+	cleared := false
+	tc.mockChatService.clearHistoryFunc = func(ctx context.Context, projectID uuid.UUID) error {
+		cleared = true
+		return nil
+	}
+
+	req := tc.makeRequest(http.MethodDelete, "/api/projects/"+tc.projectID.String()+"/ontology/chat/history", nil)
+	req.SetPathValue("pid", tc.projectID.String())
+
+	rec := httptest.NewRecorder()
+	tc.handler.ClearHistory(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if !cleared {
+		t.Error("expected clear history to be called")
+	}
+
+	var resp ApiResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if !resp.Success {
+		t.Error("expected success to be true")
+	}
+}
+
+// ============================================================================
+// GetKnowledge Tests
+// ============================================================================
+
+func TestChatHandlerIntegration_GetKnowledge_Success(t *testing.T) {
+	tc := setupChatIntegrationTest(t)
+	tc.cleanup()
+
+	tc.mockKnowledgeSvc.getAllFunc = func(ctx context.Context, projectID uuid.UUID) ([]*models.KnowledgeFact, error) {
+		return []*models.KnowledgeFact{
+			{
+				ID:       uuid.New(),
+				FactType: models.FactTypeFiscalYear,
+				Key:      "start_month",
+				Value:    "July",
+			},
+			{
+				ID:       uuid.New(),
+				FactType: models.FactTypeTerminology,
+				Key:      "MRR",
+				Value:    "Monthly Recurring Revenue",
+			},
+		}, nil
+	}
+
+	req := tc.makeRequest(http.MethodGet, "/api/projects/"+tc.projectID.String()+"/ontology/knowledge", nil)
+	req.SetPathValue("pid", tc.projectID.String())
+
+	rec := httptest.NewRecorder()
+	tc.handler.GetKnowledge(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp ApiResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	data, ok := resp.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("expected data to be a map")
+	}
+
+	facts, ok := data["facts"].([]any)
+	if !ok {
+		t.Fatalf("expected facts to be an array")
+	}
+
+	if len(facts) != 2 {
+		t.Errorf("expected 2 facts, got %d", len(facts))
+	}
+}
+
+func TestChatHandlerIntegration_GetKnowledge_FilterByType(t *testing.T) {
+	tc := setupChatIntegrationTest(t)
+	tc.cleanup()
+
+	receivedType := ""
+	tc.mockKnowledgeSvc.getByTypeFunc = func(ctx context.Context, projectID uuid.UUID, factType string) ([]*models.KnowledgeFact, error) {
+		receivedType = factType
+		return []*models.KnowledgeFact{
+			{
+				ID:       uuid.New(),
+				FactType: factType,
+				Key:      "test",
+				Value:    "value",
+			},
+		}, nil
+	}
+
+	req := tc.makeRequest(http.MethodGet, "/api/projects/"+tc.projectID.String()+"/ontology/knowledge?type=fiscal_year", nil)
+	req.SetPathValue("pid", tc.projectID.String())
+
+	rec := httptest.NewRecorder()
+	tc.handler.GetKnowledge(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	if receivedType != "fiscal_year" {
+		t.Errorf("expected type filter 'fiscal_year', got %q", receivedType)
+	}
+}
+
+// ============================================================================
+// Invalid Project ID Tests
+// ============================================================================
+
+func TestChatHandlerIntegration_InvalidProjectID(t *testing.T) {
+	tc := setupChatIntegrationTest(t)
+
+	// Create request with invalid project ID
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/invalid-uuid/ontology/chat/initialize", nil)
+	req.SetPathValue("pid", "invalid-uuid")
+
+	rec := httptest.NewRecorder()
+	tc.handler.Initialize(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if resp["error"] != "invalid_project_id" {
+		t.Errorf("expected error 'invalid_project_id', got %v", resp["error"])
+	}
+}

--- a/pkg/handlers/ontology_questions.go
+++ b/pkg/handlers/ontology_questions.go
@@ -1,0 +1,381 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/auth"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/services"
+)
+
+// ============================================================================
+// Request/Response Types
+// ============================================================================
+
+// QuestionResponse for question endpoints.
+type QuestionResponse struct {
+	ID              string   `json:"id"`
+	ProjectID       string   `json:"project_id"`
+	WorkflowID      *string  `json:"workflow_id,omitempty"`
+	Text            string   `json:"text"`
+	Priority        int      `json:"priority"`
+	IsRequired      bool     `json:"is_required"`
+	Category        string   `json:"category,omitempty"`
+	Reasoning       string   `json:"reasoning,omitempty"`
+	AffectedTables  []string `json:"affected_tables,omitempty"`
+	AffectedColumns []string `json:"affected_columns,omitempty"`
+	DetectedPattern string   `json:"detected_pattern,omitempty"`
+	Status          string   `json:"status"`
+	Answer          string   `json:"answer,omitempty"`
+	AnsweredAt      *string  `json:"answered_at,omitempty"`
+	CreatedAt       string   `json:"created_at"`
+}
+
+// QuestionCountsResponse for question counts.
+type QuestionCountsResponse struct {
+	Required int `json:"required"`
+	Optional int `json:"optional"`
+}
+
+// ListQuestionsResponse for GET /questions endpoint.
+type ListQuestionsResponse struct {
+	Questions []QuestionResponse `json:"questions"`
+	Total     int                `json:"total"`
+}
+
+// AnswerQuestionRequest for POST /questions/{id}/answer
+type AnswerQuestionRequest struct {
+	Answer string `json:"answer"`
+}
+
+// AnswerQuestionResponse for answer endpoint.
+type AnswerQuestionResponse struct {
+	QuestionID     string                  `json:"question_id"`
+	NextQuestion   *QuestionResponse       `json:"next_question,omitempty"`
+	AllComplete    bool                    `json:"all_complete"`
+	ActionsSummary string                  `json:"actions_summary,omitempty"`
+	Counts         *QuestionCountsResponse `json:"counts,omitempty"`
+}
+
+// ============================================================================
+// Handler
+// ============================================================================
+
+// OntologyQuestionsHandler handles ontology question HTTP requests.
+type OntologyQuestionsHandler struct {
+	questionService services.OntologyQuestionService
+	logger          *zap.Logger
+}
+
+// NewOntologyQuestionsHandler creates a new ontology questions handler.
+func NewOntologyQuestionsHandler(questionService services.OntologyQuestionService, logger *zap.Logger) *OntologyQuestionsHandler {
+	return &OntologyQuestionsHandler{
+		questionService: questionService,
+		logger:          logger,
+	}
+}
+
+// RegisterRoutes registers the questions handler's routes on the given mux.
+func (h *OntologyQuestionsHandler) RegisterRoutes(mux *http.ServeMux, authMiddleware *auth.Middleware, tenantMiddleware TenantMiddleware) {
+	base := "/api/projects/{pid}/ontology/questions"
+
+	mux.HandleFunc("GET "+base,
+		authMiddleware.RequireAuthWithPathValidation("pid")(tenantMiddleware(h.List)))
+	mux.HandleFunc("GET "+base+"/next",
+		authMiddleware.RequireAuthWithPathValidation("pid")(tenantMiddleware(h.GetNext)))
+	mux.HandleFunc("POST "+base+"/{qid}/answer",
+		authMiddleware.RequireAuthWithPathValidation("pid")(tenantMiddleware(h.Answer)))
+	mux.HandleFunc("POST "+base+"/{qid}/skip",
+		authMiddleware.RequireAuthWithPathValidation("pid")(tenantMiddleware(h.Skip)))
+	mux.HandleFunc("DELETE "+base+"/{qid}",
+		authMiddleware.RequireAuthWithPathValidation("pid")(tenantMiddleware(h.Delete)))
+}
+
+// List handles GET /api/projects/{pid}/ontology/questions
+func (h *OntologyQuestionsHandler) List(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := h.parseProjectID(w, r)
+	if !ok {
+		return
+	}
+
+	questions, err := h.questionService.GetPendingQuestions(r.Context(), projectID)
+	if err != nil {
+		h.logger.Error("Failed to list questions",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "internal_error", "Failed to list questions"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	data := ListQuestionsResponse{
+		Questions: make([]QuestionResponse, len(questions)),
+		Total:     len(questions),
+	}
+	for i, q := range questions {
+		data.Questions[i] = h.toQuestionResponse(q)
+	}
+
+	response := ApiResponse{Success: true, Data: data}
+	if err := WriteJSON(w, http.StatusOK, response); err != nil {
+		h.logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
+// GetNext handles GET /api/projects/{pid}/ontology/questions/next
+func (h *OntologyQuestionsHandler) GetNext(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := h.parseProjectID(w, r)
+	if !ok {
+		return
+	}
+
+	// Check query param for including skipped questions
+	includeSkipped := r.URL.Query().Get("include_skipped") == "true"
+
+	question, err := h.questionService.GetNextQuestion(r.Context(), projectID, includeSkipped)
+	if err != nil {
+		h.logger.Error("Failed to get next question",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "internal_error", "Failed to get next question"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	// Get question counts for UI display
+	counts, err := h.questionService.GetPendingCounts(r.Context(), projectID)
+	if err != nil {
+		h.logger.Error("Failed to get question counts",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		// Non-fatal - continue without counts
+		counts = nil
+	}
+
+	if question == nil {
+		// No more questions
+		data := map[string]any{
+			"question":     nil,
+			"all_complete": true,
+			"counts":       QuestionCountsResponse{Required: 0, Optional: 0},
+		}
+		response := ApiResponse{Success: true, Data: data}
+		if err := WriteJSON(w, http.StatusOK, response); err != nil {
+			h.logger.Error("Failed to write response", zap.Error(err))
+		}
+		return
+	}
+
+	data := map[string]any{
+		"question":     h.toQuestionResponse(question),
+		"all_complete": false,
+	}
+	if counts != nil {
+		data["counts"] = QuestionCountsResponse{Required: counts.Required, Optional: counts.Optional}
+	}
+	response := ApiResponse{Success: true, Data: data}
+	if err := WriteJSON(w, http.StatusOK, response); err != nil {
+		h.logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
+// Answer handles POST /api/projects/{pid}/ontology/questions/{qid}/answer
+func (h *OntologyQuestionsHandler) Answer(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := h.parseProjectID(w, r)
+	if !ok {
+		return
+	}
+
+	questionID, ok := h.parseQuestionID(w, r)
+	if !ok {
+		return
+	}
+
+	var req AnswerQuestionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if err := ErrorResponse(w, http.StatusBadRequest, "invalid_request", "Invalid request body"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	if req.Answer == "" {
+		if err := ErrorResponse(w, http.StatusBadRequest, "missing_answer", "Answer is required"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	// Get user ID from auth context
+	claims, ok := auth.GetClaims(r.Context())
+	if !ok {
+		if err := ErrorResponse(w, http.StatusUnauthorized, "unauthorized", "Authentication required"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	result, err := h.questionService.AnswerQuestion(r.Context(), questionID, req.Answer, claims.Subject)
+	if err != nil {
+		h.logger.Error("Failed to answer question",
+			zap.String("question_id", questionID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "answer_failed", err.Error()); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	// Get updated question counts
+	counts, err := h.questionService.GetPendingCounts(r.Context(), projectID)
+	if err != nil {
+		h.logger.Error("Failed to get question counts after answer",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		// Non-fatal - continue without counts
+		counts = nil
+	}
+
+	data := AnswerQuestionResponse{
+		QuestionID:     result.QuestionID.String(),
+		AllComplete:    result.AllComplete,
+		ActionsSummary: result.ActionsSummary,
+	}
+
+	if counts != nil {
+		data.Counts = &QuestionCountsResponse{Required: counts.Required, Optional: counts.Optional}
+	}
+
+	if result.NextQuestion != nil {
+		next := h.toQuestionResponse(result.NextQuestion)
+		data.NextQuestion = &next
+	}
+
+	response := ApiResponse{Success: true, Data: data}
+	if err := WriteJSON(w, http.StatusOK, response); err != nil {
+		h.logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
+// Skip handles POST /api/projects/{pid}/ontology/questions/{qid}/skip
+func (h *OntologyQuestionsHandler) Skip(w http.ResponseWriter, r *http.Request) {
+	_, ok := h.parseProjectID(w, r)
+	if !ok {
+		return
+	}
+
+	questionID, ok := h.parseQuestionID(w, r)
+	if !ok {
+		return
+	}
+
+	if err := h.questionService.SkipQuestion(r.Context(), questionID); err != nil {
+		h.logger.Error("Failed to skip question",
+			zap.String("question_id", questionID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "skip_failed", err.Error()); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	response := ApiResponse{Success: true, Data: map[string]string{"message": "Question skipped"}}
+	if err := WriteJSON(w, http.StatusOK, response); err != nil {
+		h.logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
+// Delete handles DELETE /api/projects/{pid}/ontology/questions/{qid}
+func (h *OntologyQuestionsHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	_, ok := h.parseProjectID(w, r)
+	if !ok {
+		return
+	}
+
+	questionID, ok := h.parseQuestionID(w, r)
+	if !ok {
+		return
+	}
+
+	if err := h.questionService.DeleteQuestion(r.Context(), questionID); err != nil {
+		h.logger.Error("Failed to delete question",
+			zap.String("question_id", questionID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "delete_failed", err.Error()); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	response := ApiResponse{Success: true, Data: map[string]string{"message": "Question deleted"}}
+	if err := WriteJSON(w, http.StatusOK, response); err != nil {
+		h.logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
+// ============================================================================
+// Helper Methods
+// ============================================================================
+
+func (h *OntologyQuestionsHandler) parseProjectID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
+	pidStr := r.PathValue("pid")
+	projectID, err := uuid.Parse(pidStr)
+	if err != nil {
+		if err := ErrorResponse(w, http.StatusBadRequest, "invalid_project_id", "Invalid project ID format"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return uuid.Nil, false
+	}
+	return projectID, true
+}
+
+func (h *OntologyQuestionsHandler) parseQuestionID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
+	qidStr := r.PathValue("qid")
+	questionID, err := uuid.Parse(qidStr)
+	if err != nil {
+		if err := ErrorResponse(w, http.StatusBadRequest, "invalid_question_id", "Invalid question ID format"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return uuid.Nil, false
+	}
+	return questionID, true
+}
+
+func (h *OntologyQuestionsHandler) toQuestionResponse(q *models.OntologyQuestion) QuestionResponse {
+	resp := QuestionResponse{
+		ID:              q.ID.String(),
+		ProjectID:       q.ProjectID.String(),
+		Text:            q.Text,
+		Priority:        q.Priority,
+		IsRequired:      q.IsRequired,
+		Category:        q.Category,
+		Reasoning:       q.Reasoning,
+		DetectedPattern: q.DetectedPattern,
+		Status:          string(q.Status),
+		Answer:          q.Answer,
+		CreatedAt:       q.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+
+	if q.WorkflowID != nil {
+		wid := q.WorkflowID.String()
+		resp.WorkflowID = &wid
+	}
+
+	if q.Affects != nil {
+		resp.AffectedTables = q.Affects.Tables
+		resp.AffectedColumns = q.Affects.Columns
+	}
+
+	if q.AnsweredAt != nil {
+		answered := q.AnsweredAt.Format("2006-01-02T15:04:05Z07:00")
+		resp.AnsweredAt = &answered
+	}
+
+	return resp
+}

--- a/pkg/handlers/ontology_test.go
+++ b/pkg/handlers/ontology_test.go
@@ -1,0 +1,364 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+)
+
+// ============================================================================
+// Mock Workflow Service for Handler Tests
+// ============================================================================
+
+type mockOntologyWorkflowService struct {
+	startExtractionFunc  func(ctx context.Context, projectID uuid.UUID, config *models.WorkflowConfig) (*models.OntologyWorkflow, error)
+	lastConfig           *models.WorkflowConfig // Captures the config passed to StartExtraction
+	schemaEntityCount    int                    // Return value for GetSchemaEntityCount
+	schemaEntityCountErr error                  // Error return for GetSchemaEntityCount
+	workflow             *models.OntologyWorkflow
+	ontology             *models.TieredOntology
+}
+
+func (m *mockOntologyWorkflowService) StartExtraction(ctx context.Context, projectID uuid.UUID, config *models.WorkflowConfig) (*models.OntologyWorkflow, error) {
+	m.lastConfig = config // Capture for verification
+	if m.startExtractionFunc != nil {
+		return m.startExtractionFunc(ctx, projectID, config)
+	}
+	return &models.OntologyWorkflow{
+		ID:        uuid.New(),
+		ProjectID: projectID,
+		State:     models.WorkflowStatePending,
+		Config:    config,
+	}, nil
+}
+
+func (m *mockOntologyWorkflowService) GetStatus(ctx context.Context, projectID uuid.UUID) (*models.OntologyWorkflow, error) {
+	return m.workflow, nil
+}
+
+func (m *mockOntologyWorkflowService) GetOntology(ctx context.Context, projectID uuid.UUID) (*models.TieredOntology, error) {
+	return m.ontology, nil
+}
+
+func (m *mockOntologyWorkflowService) Cancel(ctx context.Context, workflowID uuid.UUID) error {
+	return nil
+}
+
+func (m *mockOntologyWorkflowService) UpdateProgress(ctx context.Context, workflowID uuid.UUID, progress *models.WorkflowProgress) error {
+	return nil
+}
+
+func (m *mockOntologyWorkflowService) MarkComplete(ctx context.Context, workflowID uuid.UUID) error {
+	return nil
+}
+
+func (m *mockOntologyWorkflowService) MarkFailed(ctx context.Context, workflowID uuid.UUID, errMsg string) error {
+	return nil
+}
+
+func (m *mockOntologyWorkflowService) GetByID(ctx context.Context, workflowID uuid.UUID) (*models.OntologyWorkflow, error) {
+	return nil, nil
+}
+
+func (m *mockOntologyWorkflowService) DeleteOntology(ctx context.Context, projectID uuid.UUID) error {
+	return nil
+}
+
+func (m *mockOntologyWorkflowService) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockOntologyWorkflowService) GetSchemaEntityCount(ctx context.Context, projectID uuid.UUID) (int, error) {
+	return m.schemaEntityCount, m.schemaEntityCountErr
+}
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+func newTestOntologyHandler() (*OntologyHandler, *mockOntologyWorkflowService, *mockProjectService) {
+	logger := zap.NewNop()
+	mockWorkflowService := &mockOntologyWorkflowService{}
+	mockProjService := &mockProjectService{defaultDatasourceID: uuid.New()}
+	handler := NewOntologyHandler(mockWorkflowService, mockProjService, logger)
+	return handler, mockWorkflowService, mockProjService
+}
+
+// createRequestWithProjectID creates an HTTP request with project ID in the path.
+// Uses Go 1.22+ path patterns: /api/projects/{pid}/ontology/extract
+func createRequestWithProjectID(method, path string, body []byte, projectID uuid.UUID) *http.Request {
+	req := httptest.NewRequest(method, path, bytes.NewReader(body))
+	// Set the path value as if parsed by Go 1.22+ ServeMux
+	req.SetPathValue("pid", projectID.String())
+	return req
+}
+
+// ============================================================================
+// StartExtraction Tests - Datasource from Project Configuration
+// ============================================================================
+
+// TestStartExtraction_WithProjectDatasource verifies that extraction uses
+// the datasource configured at the project level.
+func TestStartExtraction_WithProjectDatasource(t *testing.T) {
+	handler, mockWorkflowService, mockProjService := newTestOntologyHandler()
+	projectID := uuid.New()
+	datasourceID := uuid.New()
+	mockProjService.defaultDatasourceID = datasourceID
+	description := "E-commerce platform for selling widgets and gadgets"
+
+	reqBody := StartExtractionRequest{
+		ProjectDescription: description,
+	}
+	body, _ := json.Marshal(reqBody)
+
+	req := createRequestWithProjectID("POST", "/api/projects/"+projectID.String()+"/ontology/extract", body, projectID)
+	rr := httptest.NewRecorder()
+
+	handler.StartExtraction(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Verify project_description was passed to the service
+	if mockWorkflowService.lastConfig == nil {
+		t.Fatal("expected config to be passed to service, got nil")
+	}
+
+	if mockWorkflowService.lastConfig.ProjectDescription != description {
+		t.Errorf("expected project_description %q, got %q",
+			description, mockWorkflowService.lastConfig.ProjectDescription)
+	}
+
+	// Verify datasource_id was fetched from project config
+	if mockWorkflowService.lastConfig.DatasourceID != datasourceID {
+		t.Errorf("expected datasource_id %s from project config, got %s",
+			datasourceID, mockWorkflowService.lastConfig.DatasourceID)
+	}
+}
+
+// TestStartExtraction_NoDatasourceConfigured verifies that the handler
+// returns a 400 error when no datasource is configured for the project.
+func TestStartExtraction_NoDatasourceConfigured(t *testing.T) {
+	handler, mockWorkflowService, mockProjService := newTestOntologyHandler()
+	mockProjService.defaultDatasourceID = uuid.Nil // No datasource configured
+	projectID := uuid.New()
+	description := "Healthcare data management system for patient records"
+
+	reqBody := StartExtractionRequest{
+		ProjectDescription: description,
+	}
+	body, _ := json.Marshal(reqBody)
+
+	req := createRequestWithProjectID("POST", "/api/projects/"+projectID.String()+"/ontology/extract", body, projectID)
+	rr := httptest.NewRecorder()
+
+	handler.StartExtraction(rr, req)
+
+	// Should fail with 400 Bad Request
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400 when no datasource configured, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Verify the error response contains the right error code
+	var errResp map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to parse error response: %v", err)
+	}
+
+	if errResp["error"] != "no_datasource_configured" {
+		t.Errorf("expected error code 'no_datasource_configured', got %q", errResp["error"])
+	}
+
+	// Service should NOT have been called
+	if mockWorkflowService.lastConfig != nil {
+		t.Error("service should not have been called when no datasource is configured")
+	}
+}
+
+// TestStartExtraction_EmptyBody_Success verifies the handler accepts empty body
+// since datasource_id comes from project config now.
+func TestStartExtraction_EmptyBody_Success(t *testing.T) {
+	handler, mockWorkflowService, mockProjService := newTestOntologyHandler()
+	projectID := uuid.New()
+	datasourceID := uuid.New()
+	mockProjService.defaultDatasourceID = datasourceID
+
+	req := createRequestWithProjectID("POST", "/api/projects/"+projectID.String()+"/ontology/extract", nil, projectID)
+	rr := httptest.NewRecorder()
+
+	handler.StartExtraction(rr, req)
+
+	// Should succeed - datasource comes from project config
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Verify config was passed to service with datasource from project
+	if mockWorkflowService.lastConfig == nil {
+		t.Fatal("expected config to be passed to service")
+	}
+	if mockWorkflowService.lastConfig.DatasourceID != datasourceID {
+		t.Errorf("expected datasource_id %s, got %s", datasourceID, mockWorkflowService.lastConfig.DatasourceID)
+	}
+}
+
+// ============================================================================
+// GetWorkflowStatus Tests - Entity Count Behavior
+// ============================================================================
+
+// TestGetWorkflowStatus_NoWorkflow_HasOntologyData verifies that when no workflow
+// exists but ontology data exists, the response includes entity counts from schema.
+func TestGetWorkflowStatus_NoWorkflow_HasOntologyData(t *testing.T) {
+	handler, mockWorkflowService, _ := newTestOntologyHandler()
+	projectID := uuid.New()
+
+	// No workflow, but ontology with 38 entity summaries exists
+	mockWorkflowService.workflow = nil
+	mockWorkflowService.ontology = &models.TieredOntology{
+		ID:        uuid.New(),
+		ProjectID: projectID,
+		EntitySummaries: map[string]*models.EntitySummary{
+			"users":    {TableName: "users"},
+			"orders":   {TableName: "orders"},
+			"products": {TableName: "products"},
+		},
+	}
+	mockWorkflowService.schemaEntityCount = 100 // Total from schema
+
+	req := createRequestWithProjectID("GET", "/api/projects/"+projectID.String()+"/ontology/workflow", nil, projectID)
+	rr := httptest.NewRecorder()
+
+	handler.GetWorkflowStatus(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var response ApiResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	data, ok := response.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected data to be map, got %T", response.Data)
+	}
+
+	// Verify ontology_ready and has_result are true
+	if data["ontology_ready"] != true {
+		t.Errorf("expected ontology_ready=true, got %v", data["ontology_ready"])
+	}
+	if data["has_result"] != true {
+		t.Errorf("expected has_result=true, got %v", data["has_result"])
+	}
+
+	// Verify entity counts: current=3 (ontology summaries), total=100 (from schema)
+	if data["current_entity"].(float64) != 3 {
+		t.Errorf("expected current_entity=3, got %v", data["current_entity"])
+	}
+	if data["total_entities"].(float64) != 100 {
+		t.Errorf("expected total_entities=100, got %v", data["total_entities"])
+	}
+}
+
+// TestGetWorkflowStatus_NoWorkflow_NoOntology verifies that when neither workflow
+// nor ontology exists, the response indicates idle state.
+func TestGetWorkflowStatus_NoWorkflow_NoOntology(t *testing.T) {
+	handler, mockWorkflowService, _ := newTestOntologyHandler()
+	projectID := uuid.New()
+
+	// No workflow, no ontology
+	mockWorkflowService.workflow = nil
+	mockWorkflowService.ontology = nil
+	mockWorkflowService.schemaEntityCount = 50
+
+	req := createRequestWithProjectID("GET", "/api/projects/"+projectID.String()+"/ontology/workflow", nil, projectID)
+	rr := httptest.NewRecorder()
+
+	handler.GetWorkflowStatus(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var response ApiResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	data, ok := response.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected data to be map, got %T", response.Data)
+	}
+
+	// Verify ontology_ready and has_result are false (or omitted due to omitempty)
+	if val, ok := data["ontology_ready"]; ok && val != false {
+		t.Errorf("expected ontology_ready=false or omitted, got %v", val)
+	}
+	if data["has_result"] != false {
+		t.Errorf("expected has_result=false, got %v", data["has_result"])
+	}
+
+	// Verify can_start_new is true (user can start extraction)
+	if data["can_start_new"] != true {
+		t.Errorf("expected can_start_new=true, got %v", data["can_start_new"])
+	}
+}
+
+// TestGetWorkflowStatus_EntityCountFallback verifies that when schema entity count
+// fails, the handler falls back to using current entity count.
+func TestGetWorkflowStatus_EntityCountFallback(t *testing.T) {
+	handler, mockWorkflowService, _ := newTestOntologyHandler()
+	projectID := uuid.New()
+
+	// No workflow, but ontology exists
+	mockWorkflowService.workflow = nil
+	mockWorkflowService.ontology = &models.TieredOntology{
+		ID:        uuid.New(),
+		ProjectID: projectID,
+		EntitySummaries: map[string]*models.EntitySummary{
+			"users":  {TableName: "users"},
+			"orders": {TableName: "orders"},
+		},
+	}
+	// Schema count fails (e.g., no datasource configured)
+	mockWorkflowService.schemaEntityCount = 0
+	mockWorkflowService.schemaEntityCountErr = fmt.Errorf("no datasource configured")
+
+	req := createRequestWithProjectID("GET", "/api/projects/"+projectID.String()+"/ontology/workflow", nil, projectID)
+	rr := httptest.NewRecorder()
+
+	handler.GetWorkflowStatus(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var response ApiResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	data, ok := response.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected data to be map, got %T", response.Data)
+	}
+
+	// When schema count fails, total should fall back to current (2)
+	if data["current_entity"].(float64) != 2 {
+		t.Errorf("expected current_entity=2, got %v", data["current_entity"])
+	}
+	if data["total_entities"].(float64) != 2 {
+		t.Errorf("expected total_entities=2 (fallback), got %v", data["total_entities"])
+	}
+}

--- a/pkg/handlers/queries_integration_test.go
+++ b/pkg/handlers/queries_integration_test.go
@@ -53,7 +53,7 @@ func setupQueriesIntegrationTest(t *testing.T) *queriesIntegrationTestContext {
 
 	// Create datasource repository and service
 	dsRepo := repositories.NewDatasourceRepository()
-	dsSvc := services.NewDatasourceService(dsRepo, encryptor, adapterFactory, zap.NewNop())
+	dsSvc := services.NewDatasourceService(dsRepo, encryptor, adapterFactory, nil, zap.NewNop())
 
 	// Create query repository and service
 	queryRepo := repositories.NewQueryRepository()

--- a/pkg/handlers/schema.go
+++ b/pkg/handlers/schema.go
@@ -25,8 +25,8 @@ type UpdateMetadataRequest struct {
 
 // SaveSelectionsRequest for bulk updating selection state.
 type SaveSelectionsRequest struct {
-	TableSelections  map[string]bool     `json:"table_selections"`  // "schema.table" -> selected
-	ColumnSelections map[string][]string `json:"column_selections"` // "schema.table" -> ["col1", "col2"]
+	TableSelections  map[uuid.UUID]bool        `json:"table_selections"`  // table_id -> selected
+	ColumnSelections map[uuid.UUID][]uuid.UUID `json:"column_selections"` // table_id -> [column_id, ...]
 }
 
 // --- Response Types ---

--- a/pkg/handlers/schema_test.go
+++ b/pkg/handlers/schema_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -379,8 +380,13 @@ func TestSchemaHandler_SaveSelections_Success(t *testing.T) {
 
 	projectID := uuid.New()
 	datasourceID := uuid.New()
+	tableID := uuid.New()
+	columnID1 := uuid.New()
+	columnID2 := uuid.New()
 
-	body := `{"table_selections": {"public.users": true}, "column_selections": {"public.users": ["id", "email"]}}`
+	// Use table and column UUIDs instead of names
+	body := fmt.Sprintf(`{"table_selections": {"%s": true}, "column_selections": {"%s": ["%s", "%s"]}}`,
+		tableID.String(), tableID.String(), columnID1.String(), columnID2.String())
 	req := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID.String()+"/datasources/"+datasourceID.String()+"/schema/selections", bytes.NewBufferString(body))
 	req.SetPathValue("pid", projectID.String())
 	req.SetPathValue("dsId", datasourceID.String())

--- a/pkg/handlers/wellknown.go
+++ b/pkg/handlers/wellknown.go
@@ -94,10 +94,4 @@ func (h *WellKnownHandler) OAuthDiscovery(w http.ResponseWriter, r *http.Request
 	if err := WriteJSON(w, http.StatusOK, metadata); err != nil {
 		h.logger.Error("Failed to encode OAuth metadata", zap.Error(err))
 	}
-
-	h.logger.Debug("Served OAuth discovery metadata",
-		zap.String("remote_addr", r.RemoteAddr),
-		zap.String("user_agent", r.UserAgent()),
-		zap.String("auth_server_url", validatedAuthURL),
-		zap.Bool("custom_auth_url", authURL != ""))
 }

--- a/pkg/llm/context.go
+++ b/pkg/llm/context.go
@@ -1,0 +1,80 @@
+package llm
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+type contextKey string
+
+const (
+	llmContextKey contextKey = "llm_context"
+)
+
+// WithContext returns a context with LLM recording context attached.
+// The context map is merged with any existing context.
+func WithContext(ctx context.Context, values map[string]any) context.Context {
+	existing := GetContext(ctx)
+	if existing == nil {
+		existing = make(map[string]any)
+	}
+	// Merge new values into existing
+	for k, v := range values {
+		existing[k] = v
+	}
+	return context.WithValue(ctx, llmContextKey, existing)
+}
+
+// GetContext retrieves the LLM recording context from context, if present.
+func GetContext(ctx context.Context) map[string]any {
+	if c, ok := ctx.Value(llmContextKey).(map[string]any); ok {
+		// Return a copy to prevent mutation
+		copy := make(map[string]any, len(c))
+		for k, v := range c {
+			copy[k] = v
+		}
+		return copy
+	}
+	return nil
+}
+
+// WithWorkflowID is a convenience function to add workflow_id to context.
+// Deprecated: Use WithContext for more flexible context passing.
+func WithWorkflowID(ctx context.Context, workflowID uuid.UUID) context.Context {
+	return WithContext(ctx, map[string]any{
+		"workflow_id": workflowID.String(),
+	})
+}
+
+// GetWorkflowID retrieves the workflow ID from context, if present.
+// Deprecated: Use GetContext and access "workflow_id" directly.
+func GetWorkflowID(ctx context.Context) *uuid.UUID {
+	c := GetContext(ctx)
+	if c == nil {
+		return nil
+	}
+	if idStr, ok := c["workflow_id"].(string); ok {
+		if id, err := uuid.Parse(idStr); err == nil {
+			return &id
+		}
+	}
+	return nil
+}
+
+// WithTaskContext is a convenience function to add ontology task context.
+func WithTaskContext(ctx context.Context, workflowID uuid.UUID, taskID, taskName, entityName string) context.Context {
+	values := map[string]any{
+		"workflow_id": workflowID.String(),
+	}
+	if taskID != "" {
+		values["task_id"] = taskID
+	}
+	if taskName != "" {
+		values["task_name"] = taskName
+	}
+	if entityName != "" {
+		values["entity_name"] = entityName
+	}
+	return WithContext(ctx, values)
+}

--- a/pkg/llm/context_test.go
+++ b/pkg/llm/context_test.go
@@ -1,0 +1,143 @@
+package llm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestWithWorkflowID_AddsIDToContext(t *testing.T) {
+	ctx := context.Background()
+	workflowID := uuid.New()
+
+	newCtx := WithWorkflowID(ctx, workflowID)
+
+	// Verify original context is not modified
+	if GetWorkflowID(ctx) != nil {
+		t.Error("original context should not have workflow ID")
+	}
+
+	// Verify new context has the workflow ID
+	gotID := GetWorkflowID(newCtx)
+	if gotID == nil {
+		t.Fatal("expected workflow ID in context")
+	}
+	if *gotID != workflowID {
+		t.Errorf("expected workflow ID %s, got %s", workflowID, *gotID)
+	}
+}
+
+func TestGetWorkflowID_ReturnsNilForEmptyContext(t *testing.T) {
+	ctx := context.Background()
+
+	gotID := GetWorkflowID(ctx)
+
+	if gotID != nil {
+		t.Errorf("expected nil for empty context, got %s", *gotID)
+	}
+}
+
+func TestGetWorkflowID_ReturnsNilForWrongType(t *testing.T) {
+	// Put an invalid workflow_id in context
+	ctx := WithContext(context.Background(), map[string]any{
+		"workflow_id": "not-a-valid-uuid",
+	})
+
+	gotID := GetWorkflowID(ctx)
+
+	if gotID != nil {
+		t.Error("expected nil when workflow_id is not a valid UUID")
+	}
+}
+
+func TestWithWorkflowID_CanBeOverwritten(t *testing.T) {
+	ctx := context.Background()
+	firstID := uuid.New()
+	secondID := uuid.New()
+
+	ctx = WithWorkflowID(ctx, firstID)
+	ctx = WithWorkflowID(ctx, secondID)
+
+	gotID := GetWorkflowID(ctx)
+	if gotID == nil {
+		t.Fatal("expected workflow ID in context")
+	}
+	if *gotID != secondID {
+		t.Errorf("expected second workflow ID %s, got %s", secondID, *gotID)
+	}
+}
+
+func TestWithContext_MergesValues(t *testing.T) {
+	ctx := context.Background()
+	workflowID := uuid.New()
+
+	// Add workflow ID
+	ctx = WithWorkflowID(ctx, workflowID)
+
+	// Add task name (should merge, not replace)
+	ctx = WithContext(ctx, map[string]any{
+		"task_name": "Analyze users",
+	})
+
+	// Both values should exist
+	c := GetContext(ctx)
+	if c == nil {
+		t.Fatal("expected context to exist")
+	}
+	if c["workflow_id"] != workflowID.String() {
+		t.Errorf("expected workflow_id %s, got %v", workflowID, c["workflow_id"])
+	}
+	if c["task_name"] != "Analyze users" {
+		t.Errorf("expected task_name 'Analyze users', got %v", c["task_name"])
+	}
+}
+
+func TestWithTaskContext_AddsAllFields(t *testing.T) {
+	ctx := context.Background()
+	workflowID := uuid.New()
+
+	ctx = WithTaskContext(ctx, workflowID, "task-123", "Analyze users", "users")
+
+	c := GetContext(ctx)
+	if c == nil {
+		t.Fatal("expected context to exist")
+	}
+	if c["workflow_id"] != workflowID.String() {
+		t.Errorf("expected workflow_id %s, got %v", workflowID, c["workflow_id"])
+	}
+	if c["task_id"] != "task-123" {
+		t.Errorf("expected task_id 'task-123', got %v", c["task_id"])
+	}
+	if c["task_name"] != "Analyze users" {
+		t.Errorf("expected task_name 'Analyze users', got %v", c["task_name"])
+	}
+	if c["entity_name"] != "users" {
+		t.Errorf("expected entity_name 'users', got %v", c["entity_name"])
+	}
+}
+
+func TestGetContext_ReturnsNilForEmptyContext(t *testing.T) {
+	ctx := context.Background()
+
+	c := GetContext(ctx)
+
+	if c != nil {
+		t.Errorf("expected nil for empty context, got %v", c)
+	}
+}
+
+func TestGetContext_ReturnsCopy(t *testing.T) {
+	ctx := WithContext(context.Background(), map[string]any{
+		"key": "value",
+	})
+
+	c := GetContext(ctx)
+	c["key"] = "modified"
+
+	// Original should not be modified
+	c2 := GetContext(ctx)
+	if c2["key"] != "value" {
+		t.Errorf("expected original value 'value', got %v", c2["key"])
+	}
+}

--- a/pkg/llm/conversation_recorder.go
+++ b/pkg/llm/conversation_recorder.go
@@ -1,0 +1,196 @@
+package llm
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
+)
+
+// TenantContextFunc acquires a tenant-scoped database connection for background work.
+// Returns the scoped context, a cleanup function (MUST be called), and any error.
+type TenantContextFunc func(ctx context.Context, projectID uuid.UUID) (context.Context, func(), error)
+
+// ConversationRecorder records LLM conversations to the database.
+type ConversationRecorder interface {
+	// Record queues a completed conversation for async persistence (legacy, for backwards compat).
+	Record(conv *models.LLMConversation)
+
+	// SavePending synchronously inserts a pending record before the LLM call starts.
+	// This enables tracking in-flight requests. Returns error if insert fails.
+	SavePending(ctx context.Context, conv *models.LLMConversation) error
+
+	// RecordCompletion queues an update for a pending record after the LLM call completes.
+	// This is async to avoid blocking the response.
+	RecordCompletion(conv *models.LLMConversation)
+}
+
+// recordOp represents a database operation for conversation recording.
+type recordOp struct {
+	conv     *models.LLMConversation
+	isUpdate bool // true = update existing record, false = insert new record
+}
+
+// AsyncConversationRecorder records conversations asynchronously to avoid blocking LLM calls.
+type AsyncConversationRecorder struct {
+	repo         repositories.ConversationRepository
+	getTenantCtx TenantContextFunc
+	logger       *zap.Logger
+	queue        chan recordOp
+	done         chan struct{}
+}
+
+// NewAsyncConversationRecorder creates a new async recorder.
+// queueSize controls the buffer size - if full, records are dropped with a warning.
+func NewAsyncConversationRecorder(
+	repo repositories.ConversationRepository,
+	getTenantCtx TenantContextFunc,
+	logger *zap.Logger,
+	queueSize int,
+) *AsyncConversationRecorder {
+	if queueSize <= 0 {
+		queueSize = 100
+	}
+
+	r := &AsyncConversationRecorder{
+		repo:         repo,
+		getTenantCtx: getTenantCtx,
+		logger:       logger.Named("conversation-recorder"),
+		queue:        make(chan recordOp, queueSize),
+		done:         make(chan struct{}),
+	}
+
+	go r.processQueue()
+
+	return r
+}
+
+// Record queues a conversation for async persistence.
+// Non-blocking - if queue is full, the record is dropped with a warning.
+func (r *AsyncConversationRecorder) Record(conv *models.LLMConversation) {
+	select {
+	case r.queue <- recordOp{conv: conv, isUpdate: false}:
+		// Queued successfully
+	default:
+		r.logger.Warn("Conversation record queue full, dropping entry",
+			zap.String("project_id", conv.ProjectID.String()),
+			zap.String("model", conv.Model))
+	}
+}
+
+// SavePending synchronously inserts a pending record before the LLM call starts.
+// This enables tracking in-flight requests by querying for status='pending'.
+func (r *AsyncConversationRecorder) SavePending(ctx context.Context, conv *models.LLMConversation) error {
+	// Ensure status is pending
+	conv.Status = models.LLMConversationStatusPending
+
+	// Synchronous save - we need the record to exist before the LLM call
+	if err := r.repo.Save(ctx, conv); err != nil {
+		r.logger.Error("Failed to save pending LLM conversation",
+			zap.String("project_id", conv.ProjectID.String()),
+			zap.String("model", conv.Model),
+			zap.Error(err))
+		return err
+	}
+
+	r.logger.Debug("Saved pending LLM conversation",
+		zap.String("id", conv.ID.String()),
+		zap.String("project_id", conv.ProjectID.String()),
+		zap.String("model", conv.Model))
+
+	return nil
+}
+
+// RecordCompletion queues an update for a pending record after the LLM call completes.
+// Non-blocking - if queue is full, the update is dropped with a warning.
+func (r *AsyncConversationRecorder) RecordCompletion(conv *models.LLMConversation) {
+	select {
+	case r.queue <- recordOp{conv: conv, isUpdate: true}:
+		// Queued successfully
+	default:
+		r.logger.Warn("Conversation completion queue full, dropping update",
+			zap.String("id", conv.ID.String()),
+			zap.String("project_id", conv.ProjectID.String()))
+	}
+}
+
+// Close stops the recorder and waits for pending records to be saved.
+func (r *AsyncConversationRecorder) Close() {
+	close(r.queue)
+	<-r.done
+}
+
+// processQueue processes queued conversation operations (saves and updates).
+func (r *AsyncConversationRecorder) processQueue() {
+	defer close(r.done)
+
+	for op := range r.queue {
+		if op.isUpdate {
+			r.updateConversation(op.conv)
+		} else {
+			r.saveConversation(op.conv)
+		}
+	}
+}
+
+// saveConversation persists a single conversation record.
+func (r *AsyncConversationRecorder) saveConversation(conv *models.LLMConversation) {
+	// Acquire tenant-scoped context
+	ctx, cleanup, err := r.getTenantCtx(context.Background(), conv.ProjectID)
+	if err != nil {
+		r.logger.Error("Failed to acquire tenant context for conversation save",
+			zap.String("project_id", conv.ProjectID.String()),
+			zap.Error(err))
+		return
+	}
+	defer cleanup()
+
+	// Save to database
+	if err := r.repo.Save(ctx, conv); err != nil {
+		r.logger.Error("Failed to save LLM conversation",
+			zap.String("project_id", conv.ProjectID.String()),
+			zap.String("model", conv.Model),
+			zap.Error(err))
+		return
+	}
+
+	r.logger.Debug("Saved LLM conversation",
+		zap.String("project_id", conv.ProjectID.String()),
+		zap.String("model", conv.Model),
+		zap.Int("duration_ms", conv.DurationMs))
+}
+
+// updateConversation updates an existing conversation record with completion data.
+func (r *AsyncConversationRecorder) updateConversation(conv *models.LLMConversation) {
+	// Acquire tenant-scoped context
+	ctx, cleanup, err := r.getTenantCtx(context.Background(), conv.ProjectID)
+	if err != nil {
+		r.logger.Error("Failed to acquire tenant context for conversation update",
+			zap.String("id", conv.ID.String()),
+			zap.String("project_id", conv.ProjectID.String()),
+			zap.Error(err))
+		return
+	}
+	defer cleanup()
+
+	// Update in database
+	if err := r.repo.Update(ctx, conv); err != nil {
+		r.logger.Error("Failed to update LLM conversation",
+			zap.String("id", conv.ID.String()),
+			zap.String("project_id", conv.ProjectID.String()),
+			zap.String("status", conv.Status),
+			zap.Error(err))
+		return
+	}
+
+	r.logger.Debug("Updated LLM conversation",
+		zap.String("id", conv.ID.String()),
+		zap.String("project_id", conv.ProjectID.String()),
+		zap.String("status", conv.Status),
+		zap.Int("duration_ms", conv.DurationMs))
+}
+
+var _ ConversationRecorder = (*AsyncConversationRecorder)(nil)

--- a/pkg/llm/conversation_recorder_test.go
+++ b/pkg/llm/conversation_recorder_test.go
@@ -1,0 +1,301 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+)
+
+// mockConversationRepo tracks saved and updated conversations for testing.
+type mockConversationRepo struct {
+	mu        sync.Mutex
+	saved     []*models.LLMConversation
+	updated   []*models.LLMConversation
+	saveErr   error
+	updateErr error
+}
+
+func (m *mockConversationRepo) Save(ctx context.Context, conv *models.LLMConversation) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	m.saved = append(m.saved, conv)
+	return nil
+}
+
+func (m *mockConversationRepo) Update(ctx context.Context, conv *models.LLMConversation) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	m.updated = append(m.updated, conv)
+	return nil
+}
+
+func (m *mockConversationRepo) GetByProject(ctx context.Context, projectID uuid.UUID, limit int) ([]*models.LLMConversation, error) {
+	return nil, nil
+}
+
+func (m *mockConversationRepo) GetByContext(ctx context.Context, projectID uuid.UUID, key, value string) ([]*models.LLMConversation, error) {
+	return nil, nil
+}
+
+func (m *mockConversationRepo) GetByConversationID(ctx context.Context, conversationID uuid.UUID) ([]*models.LLMConversation, error) {
+	return nil, nil
+}
+
+func (m *mockConversationRepo) getSaved() []*models.LLMConversation {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.saved
+}
+
+func (m *mockConversationRepo) getUpdated() []*models.LLMConversation {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.updated
+}
+
+func TestAsyncConversationRecorder_RecordsSingleConversation(t *testing.T) {
+	repo := &mockConversationRepo{}
+	logger := zap.NewNop()
+
+	// Simple tenant context function that just returns the context
+	getTenantCtx := func(ctx context.Context, projectID uuid.UUID) (context.Context, func(), error) {
+		return ctx, func() {}, nil
+	}
+
+	recorder := NewAsyncConversationRecorder(repo, getTenantCtx, logger, 10)
+
+	conv := &models.LLMConversation{
+		ID:        uuid.New(),
+		ProjectID: uuid.New(),
+		Model:     "gpt-4",
+		Status:    models.LLMConversationStatusSuccess,
+	}
+
+	recorder.Record(conv)
+	recorder.Close() // Close waits for pending records
+
+	saved := repo.getSaved()
+	if len(saved) != 1 {
+		t.Fatalf("expected 1 saved conversation, got %d", len(saved))
+	}
+	if saved[0].ID != conv.ID {
+		t.Errorf("expected ID %s, got %s", conv.ID, saved[0].ID)
+	}
+}
+
+func TestAsyncConversationRecorder_RecordsMultipleConversations(t *testing.T) {
+	repo := &mockConversationRepo{}
+	logger := zap.NewNop()
+
+	getTenantCtx := func(ctx context.Context, projectID uuid.UUID) (context.Context, func(), error) {
+		return ctx, func() {}, nil
+	}
+
+	recorder := NewAsyncConversationRecorder(repo, getTenantCtx, logger, 10)
+
+	// Record multiple conversations
+	for i := 0; i < 5; i++ {
+		recorder.Record(&models.LLMConversation{
+			ID:        uuid.New(),
+			ProjectID: uuid.New(),
+			Model:     "gpt-4",
+			Status:    models.LLMConversationStatusSuccess,
+		})
+	}
+
+	recorder.Close()
+
+	saved := repo.getSaved()
+	if len(saved) != 5 {
+		t.Errorf("expected 5 saved conversations, got %d", len(saved))
+	}
+}
+
+func TestAsyncConversationRecorder_DropsWhenQueueFull(t *testing.T) {
+	repo := &mockConversationRepo{}
+	logger := zap.NewNop()
+
+	// Use a blocking tenant context to simulate slow saves
+	blockCh := make(chan struct{})
+	getTenantCtx := func(ctx context.Context, projectID uuid.UUID) (context.Context, func(), error) {
+		<-blockCh // Block until we're ready
+		return ctx, func() {}, nil
+	}
+
+	// Very small queue size
+	recorder := NewAsyncConversationRecorder(repo, getTenantCtx, logger, 2)
+
+	// Fill the queue
+	for i := 0; i < 5; i++ {
+		recorder.Record(&models.LLMConversation{
+			ID:        uuid.New(),
+			ProjectID: uuid.New(),
+		})
+	}
+
+	// Unblock and close
+	close(blockCh)
+	recorder.Close()
+
+	// We should have at most 2 saved (the queue size) plus 1 that might have been processing
+	saved := repo.getSaved()
+	if len(saved) > 3 {
+		t.Errorf("expected at most 3 saved conversations (queue was full), got %d", len(saved))
+	}
+}
+
+func TestAsyncConversationRecorder_DefaultQueueSize(t *testing.T) {
+	repo := &mockConversationRepo{}
+	logger := zap.NewNop()
+
+	getTenantCtx := func(ctx context.Context, projectID uuid.UUID) (context.Context, func(), error) {
+		return ctx, func() {}, nil
+	}
+
+	// Pass 0 for queue size to use default
+	recorder := NewAsyncConversationRecorder(repo, getTenantCtx, logger, 0)
+
+	// Should be able to queue many items without blocking
+	for i := 0; i < 50; i++ {
+		recorder.Record(&models.LLMConversation{
+			ID:        uuid.New(),
+			ProjectID: uuid.New(),
+		})
+	}
+
+	recorder.Close() // Close waits for all records
+
+	saved := repo.getSaved()
+	if len(saved) != 50 {
+		t.Errorf("expected 50 saved conversations, got %d", len(saved))
+	}
+}
+
+func TestAsyncConversationRecorder_HandlesRepoError(t *testing.T) {
+	repo := &mockConversationRepo{
+		saveErr: errors.New("database connection failed"),
+	}
+	logger := zap.NewNop()
+
+	getTenantCtx := func(ctx context.Context, projectID uuid.UUID) (context.Context, func(), error) {
+		return ctx, func() {}, nil
+	}
+
+	recorder := NewAsyncConversationRecorder(repo, getTenantCtx, logger, 10)
+
+	recorder.Record(&models.LLMConversation{
+		ID:        uuid.New(),
+		ProjectID: uuid.New(),
+	})
+
+	recorder.Close()
+
+	// Should not panic or hang, just log the error
+	saved := repo.getSaved()
+	if len(saved) != 0 {
+		t.Errorf("expected 0 saved (error), got %d", len(saved))
+	}
+}
+
+func TestAsyncConversationRecorder_HandlesTenantContextError(t *testing.T) {
+	repo := &mockConversationRepo{}
+	logger := zap.NewNop()
+
+	getTenantCtx := func(ctx context.Context, projectID uuid.UUID) (context.Context, func(), error) {
+		return nil, nil, errors.New("failed to acquire connection")
+	}
+
+	recorder := NewAsyncConversationRecorder(repo, getTenantCtx, logger, 10)
+
+	recorder.Record(&models.LLMConversation{
+		ID:        uuid.New(),
+		ProjectID: uuid.New(),
+	})
+
+	recorder.Close()
+
+	// Should not panic or hang, just log the error
+	saved := repo.getSaved()
+	if len(saved) != 0 {
+		t.Errorf("expected 0 saved (context error), got %d", len(saved))
+	}
+}
+
+func TestAsyncConversationRecorder_CloseWaitsForPendingRecords(t *testing.T) {
+	repo := &mockConversationRepo{}
+	logger := zap.NewNop()
+
+	var saveCount int
+	var mu sync.Mutex
+
+	getTenantCtx := func(ctx context.Context, projectID uuid.UUID) (context.Context, func(), error) {
+		// Small delay to simulate real save
+		time.Sleep(10 * time.Millisecond)
+		mu.Lock()
+		saveCount++
+		mu.Unlock()
+		return ctx, func() {}, nil
+	}
+
+	recorder := NewAsyncConversationRecorder(repo, getTenantCtx, logger, 10)
+
+	// Queue records
+	for i := 0; i < 5; i++ {
+		recorder.Record(&models.LLMConversation{
+			ID:        uuid.New(),
+			ProjectID: uuid.New(),
+		})
+	}
+
+	// Close should wait for all pending records
+	recorder.Close()
+
+	mu.Lock()
+	count := saveCount
+	mu.Unlock()
+
+	if count != 5 {
+		t.Errorf("expected all 5 records to be processed before Close returns, got %d", count)
+	}
+}
+
+func TestAsyncConversationRecorder_CallsCleanupOnTenantContext(t *testing.T) {
+	repo := &mockConversationRepo{}
+	logger := zap.NewNop()
+
+	cleanupCalled := false
+	getTenantCtx := func(ctx context.Context, projectID uuid.UUID) (context.Context, func(), error) {
+		return ctx, func() { cleanupCalled = true }, nil
+	}
+
+	recorder := NewAsyncConversationRecorder(repo, getTenantCtx, logger, 10)
+
+	recorder.Record(&models.LLMConversation{
+		ID:        uuid.New(),
+		ProjectID: uuid.New(),
+	})
+
+	recorder.Close()
+
+	if !cleanupCalled {
+		t.Error("expected cleanup function to be called")
+	}
+}
+
+func TestAsyncConversationRecorder_ImplementsInterface(t *testing.T) {
+	// Compile-time check that AsyncConversationRecorder implements ConversationRecorder
+	var _ ConversationRecorder = (*AsyncConversationRecorder)(nil)
+}

--- a/pkg/llm/interfaces.go
+++ b/pkg/llm/interfaces.go
@@ -5,12 +5,21 @@ import (
 	"context"
 )
 
+// GenerateResponseResult contains the response content and usage metadata.
+type GenerateResponseResult struct {
+	Content          string
+	PromptTokens     int
+	CompletionTokens int
+	TotalTokens      int
+}
+
 // LLMClient defines the interface for LLM operations.
 // Combines both generative (chat completion) and embedding capabilities.
 // Use this interface for dependency injection to enable mocking in tests.
 type LLMClient interface {
-	// GenerateResponse generates a chat completion response.
-	GenerateResponse(ctx context.Context, prompt string, systemMessage string, temperature float64) (string, error)
+	// GenerateResponse generates a chat completion response with usage stats.
+	// Set thinking=true to enable chain-of-thought reasoning, false to disable it.
+	GenerateResponse(ctx context.Context, prompt string, systemMessage string, temperature float64, thinking bool) (*GenerateResponseResult, error)
 
 	// CreateEmbedding generates an embedding vector for the input text.
 	CreateEmbedding(ctx context.Context, input string, model string) ([]float32, error)

--- a/pkg/llm/json.go
+++ b/pkg/llm/json.go
@@ -1,0 +1,124 @@
+package llm
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// thinkTagPattern matches <think>...</think> tags that may appear at the start of LLM responses.
+var thinkTagPattern = regexp.MustCompile(`(?s)^[\s]*<think>.*?</think>[\s]*`)
+
+// thinkContentPattern extracts the content inside <think>...</think> tags.
+var thinkContentPattern = regexp.MustCompile(`(?s)<think>(.*?)</think>`)
+
+// ExtractThinking extracts the content from <think>...</think> tags in an LLM response.
+// Returns empty string if no thinking tags are found.
+func ExtractThinking(response string) string {
+	matches := thinkContentPattern.FindStringSubmatch(response)
+	if len(matches) >= 2 {
+		return strings.TrimSpace(matches[1])
+	}
+	return ""
+}
+
+// ExtractJSON extracts JSON content from an LLM response that may contain
+// <think> tags, markdown code blocks, or other formatting.
+func ExtractJSON(response string) (string, error) {
+	// Strip <think>...</think> tags from the start of the response
+	cleaned := thinkTagPattern.ReplaceAllString(response, "")
+
+	// Find the first occurrence of { or [ to determine JSON type
+	objStart := strings.IndexByte(cleaned, '{')
+	arrStart := strings.IndexByte(cleaned, '[')
+
+	// Try whichever comes first (or the one that exists)
+	if objStart >= 0 && (arrStart < 0 || objStart < arrStart) {
+		if jsonStr, ok := extractBalancedJSON(cleaned, '{', '}'); ok {
+			if json.Valid([]byte(jsonStr)) {
+				return jsonStr, nil
+			}
+		}
+	}
+
+	if arrStart >= 0 {
+		if jsonStr, ok := extractBalancedJSON(cleaned, '[', ']'); ok {
+			if json.Valid([]byte(jsonStr)) {
+				return jsonStr, nil
+			}
+		}
+	}
+
+	// Last resort: check if the entire cleaned response is valid JSON
+	trimmed := strings.TrimSpace(cleaned)
+	if json.Valid([]byte(trimmed)) {
+		return trimmed, nil
+	}
+
+	return "", fmt.Errorf("no valid JSON found in response")
+}
+
+// extractBalancedJSON finds the first balanced JSON structure starting with openChar.
+// It handles nested structures by counting bracket depth.
+func extractBalancedJSON(s string, openChar, closeChar byte) (string, bool) {
+	// Find the first occurrence of the opening bracket
+	start := strings.IndexByte(s, openChar)
+	if start == -1 {
+		return "", false
+	}
+
+	depth := 0
+	inString := false
+	escaped := false
+
+	for i := start; i < len(s); i++ {
+		c := s[i]
+
+		if escaped {
+			escaped = false
+			continue
+		}
+
+		if c == '\\' && inString {
+			escaped = true
+			continue
+		}
+
+		if c == '"' {
+			inString = !inString
+			continue
+		}
+
+		if inString {
+			continue
+		}
+
+		if c == openChar {
+			depth++
+		} else if c == closeChar {
+			depth--
+			if depth == 0 {
+				return s[start : i+1], true
+			}
+		}
+	}
+
+	return "", false
+}
+
+// ParseJSONResponse extracts JSON from a response and unmarshals it into the target.
+func ParseJSONResponse[T any](response string) (T, error) {
+	var result T
+
+	jsonStr, err := ExtractJSON(response)
+	if err != nil {
+		return result, err
+	}
+
+	if err := json.Unmarshal([]byte(jsonStr), &result); err != nil {
+		return result, fmt.Errorf("unmarshal JSON: %w", err)
+	}
+
+	return result, nil
+}

--- a/pkg/llm/json_test.go
+++ b/pkg/llm/json_test.go
@@ -1,0 +1,220 @@
+package llm
+
+import (
+	"testing"
+)
+
+func TestExtractJSON_PlainObject(t *testing.T) {
+	input := `{"name": "test", "value": 123}`
+	result, err := ExtractJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != input {
+		t.Errorf("expected %q, got %q", input, result)
+	}
+}
+
+func TestExtractJSON_PlainArray(t *testing.T) {
+	input := `[{"name": "test"}, {"name": "test2"}]`
+	result, err := ExtractJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != input {
+		t.Errorf("expected %q, got %q", input, result)
+	}
+}
+
+func TestExtractJSON_NestedObject(t *testing.T) {
+	input := `{"outer": {"inner": {"deep": "value"}}}`
+	result, err := ExtractJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != input {
+		t.Errorf("expected %q, got %q", input, result)
+	}
+}
+
+func TestExtractJSON_NestedArraysAndObjects(t *testing.T) {
+	input := `{"items": [{"nested": {"array": [1, 2, 3]}}]}`
+	result, err := ExtractJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != input {
+		t.Errorf("expected %q, got %q", input, result)
+	}
+}
+
+func TestExtractJSON_WithThinkTags(t *testing.T) {
+	input := `<think>
+Let me analyze this request...
+I should return a JSON object.
+</think>
+{"name": "test", "value": 123}`
+
+	expected := `{"name": "test", "value": 123}`
+	result, err := ExtractJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestExtractJSON_WithThinkTagsAndNestedJSON(t *testing.T) {
+	input := `<think>
+Processing the schema...
+</think>
+{"entities": {"users": {"columns": ["id", "name"]}}}`
+
+	expected := `{"entities": {"users": {"columns": ["id", "name"]}}}`
+	result, err := ExtractJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestExtractJSON_WithLeadingWhitespaceAndThinkTags(t *testing.T) {
+	input := `
+<think>Some thinking here</think>
+  {"result": "success"}`
+
+	expected := `{"result": "success"}`
+	result, err := ExtractJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestExtractJSON_WithTextBeforeJSON(t *testing.T) {
+	input := `Here is the JSON response:
+{"name": "test"}`
+
+	expected := `{"name": "test"}`
+	result, err := ExtractJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestExtractJSON_WithTextAfterJSON(t *testing.T) {
+	input := `{"name": "test"}
+Let me know if you need anything else.`
+
+	expected := `{"name": "test"}`
+	result, err := ExtractJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestExtractJSON_BracketsInStrings(t *testing.T) {
+	input := `{"message": "Use {braces} and [brackets] in text", "count": 1}`
+	result, err := ExtractJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != input {
+		t.Errorf("expected %q, got %q", input, result)
+	}
+}
+
+func TestExtractJSON_EscapedQuotesInStrings(t *testing.T) {
+	input := `{"message": "He said \"hello\"", "valid": true}`
+	result, err := ExtractJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != input {
+		t.Errorf("expected %q, got %q", input, result)
+	}
+}
+
+func TestExtractJSON_ArrayBeforeObject(t *testing.T) {
+	// When array appears before object in the text, extract the array
+	input := `[{"item": 1}, {"item": 2}]`
+	result, err := ExtractJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != input {
+		t.Errorf("expected %q, got %q", input, result)
+	}
+}
+
+func TestExtractJSON_NoJSON(t *testing.T) {
+	input := `This is just plain text with no JSON.`
+	_, err := ExtractJSON(input)
+	if err == nil {
+		t.Error("expected error for input with no JSON")
+	}
+}
+
+func TestExtractJSON_InvalidJSON(t *testing.T) {
+	input := `{"unclosed": "object"`
+	_, err := ExtractJSON(input)
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestExtractJSON_EmptyInput(t *testing.T) {
+	input := ``
+	_, err := ExtractJSON(input)
+	if err == nil {
+		t.Error("expected error for empty input")
+	}
+}
+
+func TestParseJSONResponse_Object(t *testing.T) {
+	type testStruct struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+
+	input := `<think>thinking</think>{"name": "test", "value": 42}`
+	result, err := ParseJSONResponse[testStruct](input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Name != "test" {
+		t.Errorf("expected name 'test', got %q", result.Name)
+	}
+	if result.Value != 42 {
+		t.Errorf("expected value 42, got %d", result.Value)
+	}
+}
+
+func TestParseJSONResponse_Array(t *testing.T) {
+	type item struct {
+		ID string `json:"id"`
+	}
+
+	input := `[{"id": "a"}, {"id": "b"}]`
+	result, err := ParseJSONResponse[[]item](input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Errorf("expected 2 items, got %d", len(result))
+	}
+	if result[0].ID != "a" {
+		t.Errorf("expected first id 'a', got %q", result[0].ID)
+	}
+}

--- a/pkg/llm/mock.go
+++ b/pkg/llm/mock.go
@@ -2,14 +2,17 @@ package llm
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/google/uuid"
 )
 
 // MockLLMClient is a configurable mock for testing LLM functionality.
 // Set the function fields to control behavior in tests.
 type MockLLMClient struct {
 	// GenerateResponseFunc is called when GenerateResponse is invoked.
-	// If nil, returns empty string and nil error.
-	GenerateResponseFunc func(ctx context.Context, prompt string, systemMessage string, temperature float64) (string, error)
+	// If nil, returns empty result and nil error.
+	GenerateResponseFunc func(ctx context.Context, prompt string, systemMessage string, temperature float64, thinking bool) (*GenerateResponseResult, error)
 
 	// CreateEmbeddingFunc is called when CreateEmbedding is invoked.
 	// If nil, returns nil slice and nil error.
@@ -40,12 +43,12 @@ func NewMockLLMClient() *MockLLMClient {
 }
 
 // GenerateResponse implements LLMClient.
-func (m *MockLLMClient) GenerateResponse(ctx context.Context, prompt string, systemMessage string, temperature float64) (string, error) {
+func (m *MockLLMClient) GenerateResponse(ctx context.Context, prompt string, systemMessage string, temperature float64, thinking bool) (*GenerateResponseResult, error) {
 	m.GenerateResponseCalls++
 	if m.GenerateResponseFunc != nil {
-		return m.GenerateResponseFunc(ctx, prompt, systemMessage, temperature)
+		return m.GenerateResponseFunc(ctx, prompt, systemMessage, temperature, thinking)
 	}
-	return "", nil
+	return &GenerateResponseResult{}, nil
 }
 
 // CreateEmbedding implements LLMClient.
@@ -91,3 +94,95 @@ func (m *MockLLMClient) Reset() {
 
 // Ensure MockLLMClient implements LLMClient at compile time.
 var _ LLMClient = (*MockLLMClient)(nil)
+
+// MockToolExecutor is a configurable mock for testing tool execution.
+type MockToolExecutor struct {
+	// ExecuteToolFunc is called when ExecuteTool is invoked.
+	// If nil, returns empty string and nil error.
+	ExecuteToolFunc func(ctx context.Context, name string, arguments string) (string, error)
+
+	// Call tracking
+	ExecuteToolCalls []MockToolCall
+}
+
+// MockToolCall records a call to ExecuteTool.
+type MockToolCall struct {
+	Name      string
+	Arguments string
+}
+
+// NewMockToolExecutor creates a new mock tool executor.
+func NewMockToolExecutor() *MockToolExecutor {
+	return &MockToolExecutor{
+		ExecuteToolCalls: []MockToolCall{},
+	}
+}
+
+// ExecuteTool implements ToolExecutor.
+func (m *MockToolExecutor) ExecuteTool(ctx context.Context, name string, arguments string) (string, error) {
+	m.ExecuteToolCalls = append(m.ExecuteToolCalls, MockToolCall{Name: name, Arguments: arguments})
+	if m.ExecuteToolFunc != nil {
+		return m.ExecuteToolFunc(ctx, name, arguments)
+	}
+	return `{"success": true}`, nil
+}
+
+// Reset clears call tracking.
+func (m *MockToolExecutor) Reset() {
+	m.ExecuteToolCalls = []MockToolCall{}
+}
+
+// Ensure MockToolExecutor implements ToolExecutor at compile time.
+var _ ToolExecutor = (*MockToolExecutor)(nil)
+
+// MockClientFactory is a configurable mock for testing LLM client creation.
+type MockClientFactory struct {
+	// CreateForProjectFunc is called when CreateForProject is invoked.
+	// If nil, returns a new MockLLMClient.
+	CreateForProjectFunc func(ctx context.Context, projectID uuid.UUID) (LLMClient, error)
+
+	// CreateEmbeddingClientFunc is called when CreateEmbeddingClient is invoked.
+	// If nil, returns a new MockLLMClient.
+	CreateEmbeddingClientFunc func(ctx context.Context, projectID uuid.UUID) (LLMClient, error)
+
+	// CreateStreamingClientFunc is called when CreateStreamingClient is invoked.
+	// If nil, returns nil and an error.
+	CreateStreamingClientFunc func(ctx context.Context, projectID uuid.UUID) (*StreamingClient, error)
+
+	// MockClient is the default client returned if functions are not set.
+	MockClient *MockLLMClient
+}
+
+// NewMockClientFactory creates a new mock client factory.
+func NewMockClientFactory() *MockClientFactory {
+	return &MockClientFactory{
+		MockClient: NewMockLLMClient(),
+	}
+}
+
+// CreateForProject implements LLMClientFactory.
+func (f *MockClientFactory) CreateForProject(ctx context.Context, projectID uuid.UUID) (LLMClient, error) {
+	if f.CreateForProjectFunc != nil {
+		return f.CreateForProjectFunc(ctx, projectID)
+	}
+	return f.MockClient, nil
+}
+
+// CreateEmbeddingClient implements LLMClientFactory.
+func (f *MockClientFactory) CreateEmbeddingClient(ctx context.Context, projectID uuid.UUID) (LLMClient, error) {
+	if f.CreateEmbeddingClientFunc != nil {
+		return f.CreateEmbeddingClientFunc(ctx, projectID)
+	}
+	return f.MockClient, nil
+}
+
+// CreateStreamingClient implements LLMClientFactory.
+func (f *MockClientFactory) CreateStreamingClient(ctx context.Context, projectID uuid.UUID) (*StreamingClient, error) {
+	if f.CreateStreamingClientFunc != nil {
+		return f.CreateStreamingClientFunc(ctx, projectID)
+	}
+	return nil, fmt.Errorf("streaming client not configured in mock")
+}
+
+// Ensure MockClientFactory implements LLMClientFactory at compile time.
+var _ LLMClientFactory = (*MockClientFactory)(nil)

--- a/pkg/llm/recording_client.go
+++ b/pkg/llm/recording_client.go
@@ -1,0 +1,115 @@
+package llm
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+)
+
+// RecordingClient wraps an LLMClient to record all conversations to the database.
+type RecordingClient struct {
+	inner     LLMClient
+	recorder  ConversationRecorder
+	projectID uuid.UUID
+}
+
+// NewRecordingClient creates a new recording wrapper around an LLMClient.
+func NewRecordingClient(inner LLMClient, recorder ConversationRecorder, projectID uuid.UUID) *RecordingClient {
+	return &RecordingClient{
+		inner:     inner,
+		recorder:  recorder,
+		projectID: projectID,
+	}
+}
+
+// GenerateResponse calls the inner client and records the conversation.
+// It first inserts a "pending" record, then updates it with the response.
+func (c *RecordingClient) GenerateResponse(
+	ctx context.Context,
+	prompt string,
+	systemMessage string,
+	temperature float64,
+	thinking bool,
+) (*GenerateResponseResult, error) {
+	// Build request messages for recording (verbatim)
+	requestMessages := []any{
+		map[string]string{"role": "system", "content": systemMessage},
+		map[string]string{"role": "user", "content": prompt},
+	}
+
+	// Build the pending conversation record
+	conv := &models.LLMConversation{
+		ID:              uuid.New(),
+		ProjectID:       c.projectID,
+		Context:         GetContext(ctx),
+		Iteration:       1,
+		Endpoint:        c.inner.GetEndpoint(),
+		Model:           c.inner.GetModel(),
+		RequestMessages: requestMessages,
+		Temperature:     &temperature,
+		Status:          models.LLMConversationStatusPending,
+	}
+
+	// Insert pending record synchronously (enables in-flight tracking)
+	// If this fails, we still proceed with the LLM call - recording is best-effort
+	pendingSaved := c.recorder.SavePending(ctx, conv) == nil
+
+	start := time.Now()
+
+	// Call the inner client
+	result, err := c.inner.GenerateResponse(ctx, prompt, systemMessage, temperature, thinking)
+
+	duration := time.Since(start)
+
+	// Update the conversation record with response data
+	conv.DurationMs = int(duration.Milliseconds())
+
+	if err != nil {
+		conv.Status = models.LLMConversationStatusError
+		conv.ErrorMessage = err.Error()
+	} else {
+		conv.Status = models.LLMConversationStatusSuccess
+		if result != nil {
+			conv.ResponseContent = result.Content
+			conv.PromptTokens = &result.PromptTokens
+			conv.CompletionTokens = &result.CompletionTokens
+			conv.TotalTokens = &result.TotalTokens
+		}
+	}
+
+	// Record completion asynchronously
+	if pendingSaved {
+		// Update the existing pending record
+		c.recorder.RecordCompletion(conv)
+	} else {
+		// Fallback: insert as a new record (legacy behavior)
+		c.recorder.Record(conv)
+	}
+
+	return result, err
+}
+
+// CreateEmbedding delegates to the inner client (not recorded).
+func (c *RecordingClient) CreateEmbedding(ctx context.Context, input string, model string) ([]float32, error) {
+	return c.inner.CreateEmbedding(ctx, input, model)
+}
+
+// CreateEmbeddings delegates to the inner client (not recorded).
+func (c *RecordingClient) CreateEmbeddings(ctx context.Context, inputs []string, model string) ([][]float32, error) {
+	return c.inner.CreateEmbeddings(ctx, inputs, model)
+}
+
+// GetModel returns the inner client's model.
+func (c *RecordingClient) GetModel() string {
+	return c.inner.GetModel()
+}
+
+// GetEndpoint returns the inner client's endpoint.
+func (c *RecordingClient) GetEndpoint() string {
+	return c.inner.GetEndpoint()
+}
+
+var _ LLMClient = (*RecordingClient)(nil)

--- a/pkg/llm/recording_client_test.go
+++ b/pkg/llm/recording_client_test.go
@@ -1,0 +1,322 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+)
+
+// mockRecorder captures recorded conversations for testing.
+type mockRecorder struct {
+	pending     []*models.LLMConversation
+	completions []*models.LLMConversation
+	recordings  []*models.LLMConversation // Legacy Record calls
+	saveErr     error
+}
+
+func (m *mockRecorder) Record(conv *models.LLMConversation) {
+	m.recordings = append(m.recordings, conv)
+}
+
+func (m *mockRecorder) SavePending(ctx context.Context, conv *models.LLMConversation) error {
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	// Make a copy since the caller mutates the conv after this call
+	convCopy := *conv
+	m.pending = append(m.pending, &convCopy)
+	return nil
+}
+
+func (m *mockRecorder) RecordCompletion(conv *models.LLMConversation) {
+	// Make a copy for consistency
+	convCopy := *conv
+	m.completions = append(m.completions, &convCopy)
+}
+
+func TestRecordingClient_GenerateResponse_RecordsSuccess(t *testing.T) {
+	mockClient := NewMockLLMClient()
+	mockClient.Model = "gpt-4"
+	mockClient.Endpoint = "https://api.openai.com"
+	mockClient.GenerateResponseFunc = func(ctx context.Context, prompt, systemMessage string, temperature float64, thinking bool) (*GenerateResponseResult, error) {
+		return &GenerateResponseResult{
+			Content:          "Hello, world!",
+			PromptTokens:     10,
+			CompletionTokens: 5,
+			TotalTokens:      15,
+		}, nil
+	}
+
+	recorder := &mockRecorder{}
+	projectID := uuid.New()
+	client := NewRecordingClient(mockClient, recorder, projectID)
+
+	ctx := context.Background()
+	result, err := client.GenerateResponse(ctx, "Say hello", "You are helpful", 0.7, false)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Content != "Hello, world!" {
+		t.Errorf("expected 'Hello, world!', got '%s'", result.Content)
+	}
+
+	// Verify pending was saved first
+	if len(recorder.pending) != 1 {
+		t.Fatalf("expected 1 pending record, got %d", len(recorder.pending))
+	}
+
+	pendingConv := recorder.pending[0]
+	if pendingConv.Status != models.LLMConversationStatusPending {
+		t.Errorf("expected pending status 'pending', got '%s'", pendingConv.Status)
+	}
+	if pendingConv.ProjectID != projectID {
+		t.Errorf("expected project ID %s, got %s", projectID, pendingConv.ProjectID)
+	}
+	if pendingConv.Model != "gpt-4" {
+		t.Errorf("expected model 'gpt-4', got '%s'", pendingConv.Model)
+	}
+
+	// Verify completion was recorded
+	if len(recorder.completions) != 1 {
+		t.Fatalf("expected 1 completion, got %d", len(recorder.completions))
+	}
+
+	conv := recorder.completions[0]
+	if conv.Status != models.LLMConversationStatusSuccess {
+		t.Errorf("expected status 'success', got '%s'", conv.Status)
+	}
+	if conv.ResponseContent != "Hello, world!" {
+		t.Errorf("expected response 'Hello, world!', got '%s'", conv.ResponseContent)
+	}
+	if conv.ErrorMessage != "" {
+		t.Errorf("expected empty error message, got '%s'", conv.ErrorMessage)
+	}
+
+	// Verify token counts
+	if conv.PromptTokens == nil || *conv.PromptTokens != 10 {
+		t.Errorf("expected prompt tokens 10, got %v", conv.PromptTokens)
+	}
+	if conv.CompletionTokens == nil || *conv.CompletionTokens != 5 {
+		t.Errorf("expected completion tokens 5, got %v", conv.CompletionTokens)
+	}
+	if conv.TotalTokens == nil || *conv.TotalTokens != 15 {
+		t.Errorf("expected total tokens 15, got %v", conv.TotalTokens)
+	}
+
+	// Verify request messages are on the pending record
+	if len(pendingConv.RequestMessages) != 2 {
+		t.Fatalf("expected 2 request messages, got %d", len(pendingConv.RequestMessages))
+	}
+
+	// Verify duration is recorded on completion (may be 0 for fast mocks)
+	if conv.DurationMs < 0 {
+		t.Error("expected non-negative duration")
+	}
+
+	// Same ID should be used for pending and completion
+	if pendingConv.ID != conv.ID {
+		t.Errorf("expected same ID for pending and completion, got %s and %s", pendingConv.ID, conv.ID)
+	}
+}
+
+func TestRecordingClient_GenerateResponse_RecordsError(t *testing.T) {
+	mockClient := NewMockLLMClient()
+	mockClient.GenerateResponseFunc = func(ctx context.Context, prompt, systemMessage string, temperature float64, thinking bool) (*GenerateResponseResult, error) {
+		return nil, errors.New("API rate limit exceeded")
+	}
+
+	recorder := &mockRecorder{}
+	projectID := uuid.New()
+	client := NewRecordingClient(mockClient, recorder, projectID)
+
+	ctx := context.Background()
+	_, err := client.GenerateResponse(ctx, "Say hello", "You are helpful", 0.7, false)
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	// Verify pending was saved
+	if len(recorder.pending) != 1 {
+		t.Fatalf("expected 1 pending record, got %d", len(recorder.pending))
+	}
+
+	// Verify completion was recorded with error status
+	if len(recorder.completions) != 1 {
+		t.Fatalf("expected 1 completion, got %d", len(recorder.completions))
+	}
+
+	conv := recorder.completions[0]
+	if conv.Status != models.LLMConversationStatusError {
+		t.Errorf("expected status 'error', got '%s'", conv.Status)
+	}
+	if conv.ErrorMessage != "API rate limit exceeded" {
+		t.Errorf("expected error message 'API rate limit exceeded', got '%s'", conv.ErrorMessage)
+	}
+	if conv.ResponseContent != "" {
+		t.Errorf("expected empty response on error, got '%s'", conv.ResponseContent)
+	}
+
+	// Token counts should be nil on error
+	if conv.PromptTokens != nil {
+		t.Error("expected nil prompt tokens on error")
+	}
+}
+
+func TestRecordingClient_GenerateResponse_CapturesContext(t *testing.T) {
+	mockClient := NewMockLLMClient()
+	mockClient.GenerateResponseFunc = func(ctx context.Context, prompt, systemMessage string, temperature float64, thinking bool) (*GenerateResponseResult, error) {
+		return &GenerateResponseResult{Content: "OK"}, nil
+	}
+
+	recorder := &mockRecorder{}
+	projectID := uuid.New()
+	workflowID := uuid.New()
+	client := NewRecordingClient(mockClient, recorder, projectID)
+
+	ctx := WithTaskContext(context.Background(), workflowID, "task-123", "Analyze users", "users")
+	_, err := client.GenerateResponse(ctx, "Test", "System", 0.5, false)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Context is captured on the pending record
+	conv := recorder.pending[0]
+	if conv.Context == nil {
+		t.Fatal("expected context to be captured")
+	}
+	if conv.Context["workflow_id"] != workflowID.String() {
+		t.Errorf("expected workflow_id %s, got %v", workflowID, conv.Context["workflow_id"])
+	}
+	if conv.Context["task_id"] != "task-123" {
+		t.Errorf("expected task_id 'task-123', got %v", conv.Context["task_id"])
+	}
+	if conv.Context["task_name"] != "Analyze users" {
+		t.Errorf("expected task_name 'Analyze users', got %v", conv.Context["task_name"])
+	}
+	if conv.Context["entity_name"] != "users" {
+		t.Errorf("expected entity_name 'users', got %v", conv.Context["entity_name"])
+	}
+}
+
+func TestRecordingClient_GenerateResponse_NilContextWhenNotProvided(t *testing.T) {
+	mockClient := NewMockLLMClient()
+	mockClient.GenerateResponseFunc = func(ctx context.Context, prompt, systemMessage string, temperature float64, thinking bool) (*GenerateResponseResult, error) {
+		return &GenerateResponseResult{Content: "OK"}, nil
+	}
+
+	recorder := &mockRecorder{}
+	client := NewRecordingClient(mockClient, recorder, uuid.New())
+
+	ctx := context.Background() // No context
+	_, _ = client.GenerateResponse(ctx, "Test", "System", 0.5, false)
+
+	conv := recorder.pending[0]
+	if conv.Context != nil {
+		t.Error("expected nil context when not provided")
+	}
+}
+
+func TestRecordingClient_GenerateResponse_CapturesTemperature(t *testing.T) {
+	mockClient := NewMockLLMClient()
+	mockClient.GenerateResponseFunc = func(ctx context.Context, prompt, systemMessage string, temperature float64, thinking bool) (*GenerateResponseResult, error) {
+		return &GenerateResponseResult{Content: "OK"}, nil
+	}
+
+	recorder := &mockRecorder{}
+	client := NewRecordingClient(mockClient, recorder, uuid.New())
+
+	_, _ = client.GenerateResponse(context.Background(), "Test", "System", 0.42, false)
+
+	conv := recorder.pending[0]
+	if conv.Temperature == nil {
+		t.Fatal("expected temperature to be captured")
+	}
+	if *conv.Temperature != 0.42 {
+		t.Errorf("expected temperature 0.42, got %f", *conv.Temperature)
+	}
+}
+
+func TestRecordingClient_CreateEmbedding_DelegatesToInner(t *testing.T) {
+	mockClient := NewMockLLMClient()
+	expectedEmbedding := []float32{0.1, 0.2, 0.3}
+	mockClient.CreateEmbeddingFunc = func(ctx context.Context, input, model string) ([]float32, error) {
+		return expectedEmbedding, nil
+	}
+
+	recorder := &mockRecorder{}
+	client := NewRecordingClient(mockClient, recorder, uuid.New())
+
+	embedding, err := client.CreateEmbedding(context.Background(), "test input", "text-embedding-3-small")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(embedding) != 3 {
+		t.Errorf("expected 3 elements, got %d", len(embedding))
+	}
+
+	// Embeddings are not recorded
+	if len(recorder.recordings) != 0 {
+		t.Error("expected no recordings for embedding calls")
+	}
+}
+
+func TestRecordingClient_CreateEmbeddings_DelegatesToInner(t *testing.T) {
+	mockClient := NewMockLLMClient()
+	expectedEmbeddings := [][]float32{{0.1, 0.2}, {0.3, 0.4}}
+	mockClient.CreateEmbeddingsFunc = func(ctx context.Context, inputs []string, model string) ([][]float32, error) {
+		return expectedEmbeddings, nil
+	}
+
+	recorder := &mockRecorder{}
+	client := NewRecordingClient(mockClient, recorder, uuid.New())
+
+	embeddings, err := client.CreateEmbeddings(context.Background(), []string{"a", "b"}, "text-embedding-3-small")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(embeddings) != 2 {
+		t.Errorf("expected 2 embeddings, got %d", len(embeddings))
+	}
+
+	// Embeddings are not recorded
+	if len(recorder.recordings) != 0 {
+		t.Error("expected no recordings for embedding calls")
+	}
+}
+
+func TestRecordingClient_GetModel_DelegatesToInner(t *testing.T) {
+	mockClient := NewMockLLMClient()
+	mockClient.Model = "gpt-4-turbo"
+
+	recorder := &mockRecorder{}
+	client := NewRecordingClient(mockClient, recorder, uuid.New())
+
+	model := client.GetModel()
+
+	if model != "gpt-4-turbo" {
+		t.Errorf("expected 'gpt-4-turbo', got '%s'", model)
+	}
+}
+
+func TestRecordingClient_GetEndpoint_DelegatesToInner(t *testing.T) {
+	mockClient := NewMockLLMClient()
+	mockClient.Endpoint = "https://custom.endpoint.com"
+
+	recorder := &mockRecorder{}
+	client := NewRecordingClient(mockClient, recorder, uuid.New())
+
+	endpoint := client.GetEndpoint()
+
+	if endpoint != "https://custom.endpoint.com" {
+		t.Errorf("expected 'https://custom.endpoint.com', got '%s'", endpoint)
+	}
+}

--- a/pkg/llm/streaming.go
+++ b/pkg/llm/streaming.go
@@ -1,0 +1,493 @@
+// Package llm provides OpenAI-compatible LLM client functionality.
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/sashabaranov/go-openai"
+	"go.uber.org/zap"
+)
+
+// StreamEvent represents a streaming event from the LLM.
+type StreamEvent struct {
+	Type    StreamEventType `json:"type"`
+	Content string          `json:"content,omitempty"`
+	Data    any             `json:"data,omitempty"`
+}
+
+// StreamEventType defines types of streaming events.
+type StreamEventType string
+
+const (
+	StreamEventText       StreamEventType = "text"
+	StreamEventToolCall   StreamEventType = "tool_call"
+	StreamEventToolResult StreamEventType = "tool_result"
+	StreamEventDone       StreamEventType = "done"
+	StreamEventError      StreamEventType = "error"
+)
+
+// ToolCall represents a tool call from the LLM.
+type ToolCall struct {
+	ID       string       `json:"id"`
+	Type     string       `json:"type"`
+	Function ToolCallFunc `json:"function"`
+}
+
+// ToolCallFunc represents a function call within a tool call.
+type ToolCallFunc struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+// StreamingClient extends the basic LLM client with streaming and tool capabilities.
+type StreamingClient struct {
+	*Client
+	maxToolIterations int
+}
+
+// NewStreamingClient creates a new streaming-capable LLM client.
+func NewStreamingClient(cfg *Config, logger *zap.Logger) (*StreamingClient, error) {
+	client, err := NewClient(cfg, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	return &StreamingClient{
+		Client:            client,
+		maxToolIterations: 10,
+	}, nil
+}
+
+// StreamingRequest represents a request for streaming chat completion.
+type StreamingRequest struct {
+	Messages     []Message
+	Tools        []ToolDefinition
+	Temperature  float64
+	SystemPrompt string
+}
+
+// Message represents a chat message.
+type Message struct {
+	Role       string     `json:"role"`
+	Content    string     `json:"content"`
+	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string     `json:"tool_call_id,omitempty"`
+}
+
+// Message role constants.
+const (
+	RoleSystem    = "system"
+	RoleUser      = "user"
+	RoleAssistant = "assistant"
+	RoleTool      = "tool"
+)
+
+// ToolExecutor defines the interface for executing tools.
+type ToolExecutor interface {
+	ExecuteTool(ctx context.Context, name string, arguments string) (string, error)
+}
+
+// StreamWithTools performs streaming chat completion with tool support.
+// The eventChan receives events as they occur. The caller should consume
+// events until the channel is closed or a done/error event is received.
+func (c *StreamingClient) StreamWithTools(
+	ctx context.Context,
+	req *StreamingRequest,
+	executor ToolExecutor,
+	eventChan chan<- StreamEvent,
+) error {
+	messages := c.buildOpenAIMessages(req.Messages, req.SystemPrompt)
+	tools := c.buildOpenAITools(req.Tools)
+
+	temperature := float32(req.Temperature)
+	if temperature == 0 {
+		temperature = 0.7
+	}
+
+	for iteration := 0; iteration < c.maxToolIterations; iteration++ {
+		content, toolCalls, err := c.streamIteration(ctx, messages, tools, temperature, eventChan)
+		if err != nil {
+			eventChan <- StreamEvent{Type: StreamEventError, Content: err.Error()}
+			return err
+		}
+
+		// No tool calls means we're done
+		if len(toolCalls) == 0 {
+			eventChan <- StreamEvent{Type: StreamEventDone}
+			return nil
+		}
+
+		// Add assistant message with tool calls
+		assistantMsg := openai.ChatCompletionMessage{
+			Role:    openai.ChatMessageRoleAssistant,
+			Content: content,
+		}
+		for _, tc := range toolCalls {
+			assistantMsg.ToolCalls = append(assistantMsg.ToolCalls, openai.ToolCall{
+				ID:   tc.ID,
+				Type: openai.ToolTypeFunction,
+				Function: openai.FunctionCall{
+					Name:      tc.Function.Name,
+					Arguments: tc.Function.Arguments,
+				},
+			})
+		}
+		messages = append(messages, assistantMsg)
+
+		// Execute tools and add results
+		for _, tc := range toolCalls {
+			eventChan <- StreamEvent{
+				Type: StreamEventToolCall,
+				Data: tc,
+			}
+
+			result, execErr := executor.ExecuteTool(ctx, tc.Function.Name, tc.Function.Arguments)
+			if execErr != nil {
+				result = fmt.Sprintf("Error executing tool: %s", execErr.Error())
+			}
+
+			eventChan <- StreamEvent{
+				Type:    StreamEventToolResult,
+				Content: result,
+				Data:    map[string]string{"tool_call_id": tc.ID, "name": tc.Function.Name},
+			}
+
+			messages = append(messages, openai.ChatCompletionMessage{
+				Role:       openai.ChatMessageRoleTool,
+				Content:    result,
+				ToolCallID: tc.ID,
+			})
+		}
+	}
+
+	return fmt.Errorf("exceeded maximum tool iterations (%d)", c.maxToolIterations)
+}
+
+// streamIteration performs a single streaming request and returns content and tool calls.
+func (c *StreamingClient) streamIteration(
+	ctx context.Context,
+	messages []openai.ChatCompletionMessage,
+	tools []openai.Tool,
+	temperature float32,
+	eventChan chan<- StreamEvent,
+) (string, []ToolCall, error) {
+	start := time.Now()
+
+	c.logger.Debug("Starting stream iteration",
+		zap.Int("message_count", len(messages)),
+		zap.Int("tool_count", len(tools)))
+
+	stream, err := c.client.CreateChatCompletionStream(ctx, openai.ChatCompletionRequest{
+		Model:       c.model,
+		Messages:    messages,
+		Tools:       tools,
+		Temperature: temperature,
+		Stream:      true,
+	})
+	if err != nil {
+		c.logger.Error("Failed to create stream", zap.Error(err))
+		return "", nil, c.parseError(err)
+	}
+	defer stream.Close()
+
+	var contentBuilder strings.Builder
+	toolCallsMap := make(map[int]*ToolCall)
+
+	for {
+		response, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			c.logger.Error("Stream receive error", zap.Error(err))
+			return "", nil, c.parseError(err)
+		}
+
+		if len(response.Choices) == 0 {
+			continue
+		}
+
+		delta := response.Choices[0].Delta
+
+		// Handle text content
+		if delta.Content != "" {
+			contentBuilder.WriteString(delta.Content)
+			eventChan <- StreamEvent{
+				Type:    StreamEventText,
+				Content: delta.Content,
+			}
+		}
+
+		// Handle tool calls (accumulated across chunks)
+		for _, tc := range delta.ToolCalls {
+			idx := 0
+			if tc.Index != nil {
+				idx = *tc.Index
+			}
+
+			if existing, exists := toolCallsMap[idx]; !exists {
+				toolCallsMap[idx] = &ToolCall{
+					ID:   tc.ID,
+					Type: string(tc.Type),
+					Function: ToolCallFunc{
+						Name:      tc.Function.Name,
+						Arguments: tc.Function.Arguments,
+					},
+				}
+			} else {
+				// Accumulate arguments across chunks
+				existing.Function.Arguments += tc.Function.Arguments
+			}
+		}
+	}
+
+	// Convert content to string
+	content := contentBuilder.String()
+
+	// If no native tool calls, try parsing text-based tool calls
+	if len(toolCallsMap) == 0 && content != "" {
+		parsedToolCalls := c.parseTextToolCalls(content)
+		if len(parsedToolCalls) > 0 {
+			// Clean the content to remove tool call markup
+			content = c.cleanModelOutput(content)
+			for i, tc := range parsedToolCalls {
+				toolCallsMap[i] = &tc
+			}
+		}
+	}
+
+	// Convert map to slice
+	var toolCalls []ToolCall
+	for i := 0; i < len(toolCallsMap); i++ {
+		if tc, ok := toolCallsMap[i]; ok {
+			toolCalls = append(toolCalls, *tc)
+		}
+	}
+
+	c.logger.Info("Stream iteration completed",
+		zap.Duration("elapsed", time.Since(start)),
+		zap.Int("content_length", len(content)),
+		zap.Int("tool_calls", len(toolCalls)))
+
+	return content, toolCalls, nil
+}
+
+// parseTextToolCalls parses tool calls from text output (for non-native tool calling models).
+func (c *StreamingClient) parseTextToolCalls(content string) []ToolCall {
+	var toolCalls []ToolCall
+
+	// XML format: <tool_call>{"name": "...", "arguments": {...}}</tool_call>
+	toolCallRegex := regexp.MustCompile(`<tool_call>\s*(\{[\s\S]*?\})\s*</tool_call>`)
+	matches := toolCallRegex.FindAllStringSubmatch(content, -1)
+
+	for i, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+
+		var toolCallJSON struct {
+			Name      string         `json:"name"`
+			Arguments map[string]any `json:"arguments"`
+		}
+
+		if err := json.Unmarshal([]byte(match[1]), &toolCallJSON); err != nil {
+			c.logger.Debug("Failed to parse text tool call", zap.Error(err))
+			continue
+		}
+
+		argsJSON, err := json.Marshal(toolCallJSON.Arguments)
+		if err != nil {
+			continue
+		}
+
+		toolCalls = append(toolCalls, ToolCall{
+			ID:   fmt.Sprintf("text_tool_%d", i),
+			Type: "function",
+			Function: ToolCallFunc{
+				Name:      toolCallJSON.Name,
+				Arguments: string(argsJSON),
+			},
+		})
+	}
+
+	return toolCalls
+}
+
+// cleanModelOutput removes tool call markup and thinking blocks from model output.
+func (c *StreamingClient) cleanModelOutput(content string) string {
+	// Remove <think>...</think> blocks
+	thinkRegex := regexp.MustCompile(`<think>[\s\S]*?</think>`)
+	content = thinkRegex.ReplaceAllString(content, "")
+
+	// Remove tool call blocks
+	toolCallRegex := regexp.MustCompile(`<tool_call>[\s\S]*?</tool_call>`)
+	content = toolCallRegex.ReplaceAllString(content, "")
+
+	// Collapse multiple newlines
+	multiNewline := regexp.MustCompile(`\n{3,}`)
+	content = multiNewline.ReplaceAllString(content, "\n\n")
+
+	return strings.TrimSpace(content)
+}
+
+// buildOpenAIMessages converts our message format to OpenAI format.
+func (c *StreamingClient) buildOpenAIMessages(messages []Message, systemPrompt string) []openai.ChatCompletionMessage {
+	var result []openai.ChatCompletionMessage
+
+	// Add system message if provided
+	if systemPrompt != "" {
+		result = append(result, openai.ChatCompletionMessage{
+			Role:    openai.ChatMessageRoleSystem,
+			Content: systemPrompt,
+		})
+	}
+
+	for _, msg := range messages {
+		oaiMsg := openai.ChatCompletionMessage{
+			Role:       msg.Role,
+			Content:    msg.Content,
+			ToolCallID: msg.ToolCallID,
+		}
+
+		for _, tc := range msg.ToolCalls {
+			oaiMsg.ToolCalls = append(oaiMsg.ToolCalls, openai.ToolCall{
+				ID:   tc.ID,
+				Type: openai.ToolTypeFunction,
+				Function: openai.FunctionCall{
+					Name:      tc.Function.Name,
+					Arguments: tc.Function.Arguments,
+				},
+			})
+		}
+
+		result = append(result, oaiMsg)
+	}
+
+	return result
+}
+
+// buildOpenAITools converts our tool definitions to OpenAI format.
+func (c *StreamingClient) buildOpenAITools(tools []ToolDefinition) []openai.Tool {
+	if len(tools) == 0 {
+		return nil
+	}
+
+	result := make([]openai.Tool, len(tools))
+	for i, def := range tools {
+		paramsJSON, _ := json.Marshal(def.Parameters)
+		result[i] = openai.Tool{
+			Type: openai.ToolTypeFunction,
+			Function: &openai.FunctionDefinition{
+				Name:        def.Name,
+				Description: def.Description,
+				Parameters:  json.RawMessage(paramsJSON),
+			},
+		}
+	}
+
+	return result
+}
+
+// GenerateWithTools performs a non-streaming chat completion with tool support.
+// Useful for question answering where streaming is not needed.
+func (c *StreamingClient) GenerateWithTools(
+	ctx context.Context,
+	req *StreamingRequest,
+	executor ToolExecutor,
+) (string, error) {
+	messages := c.buildOpenAIMessages(req.Messages, req.SystemPrompt)
+	tools := c.buildOpenAITools(req.Tools)
+
+	temperature := float32(req.Temperature)
+	if temperature == 0 {
+		temperature = 0.3 // Lower temp for deterministic tool use
+	}
+
+	for iteration := 0; iteration < c.maxToolIterations; iteration++ {
+		c.logger.Debug("Non-streaming iteration",
+			zap.Int("iteration", iteration),
+			zap.Int("message_count", len(messages)))
+
+		resp, err := c.client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+			Model:       c.model,
+			Messages:    messages,
+			Tools:       tools,
+			Temperature: temperature,
+		})
+		if err != nil {
+			return "", c.parseError(err)
+		}
+
+		if len(resp.Choices) == 0 {
+			return "", fmt.Errorf("no choices in response")
+		}
+
+		choice := resp.Choices[0]
+		content := choice.Message.Content
+
+		// Check for text-based tool calls if no native ones
+		var toolCalls []ToolCall
+		if len(choice.Message.ToolCalls) == 0 && content != "" {
+			toolCalls = c.parseTextToolCalls(content)
+			if len(toolCalls) > 0 {
+				content = c.cleanModelOutput(content)
+			}
+		} else {
+			for _, tc := range choice.Message.ToolCalls {
+				toolCalls = append(toolCalls, ToolCall{
+					ID:   tc.ID,
+					Type: string(tc.Type),
+					Function: ToolCallFunc{
+						Name:      tc.Function.Name,
+						Arguments: tc.Function.Arguments,
+					},
+				})
+			}
+		}
+
+		// No tool calls means we're done
+		if len(toolCalls) == 0 {
+			return content, nil
+		}
+
+		// Add assistant message with tool calls
+		assistantMsg := openai.ChatCompletionMessage{
+			Role:    openai.ChatMessageRoleAssistant,
+			Content: content,
+		}
+		for _, tc := range toolCalls {
+			assistantMsg.ToolCalls = append(assistantMsg.ToolCalls, openai.ToolCall{
+				ID:   tc.ID,
+				Type: openai.ToolTypeFunction,
+				Function: openai.FunctionCall{
+					Name:      tc.Function.Name,
+					Arguments: tc.Function.Arguments,
+				},
+			})
+		}
+		messages = append(messages, assistantMsg)
+
+		// Execute tools and add results
+		for _, tc := range toolCalls {
+			result, execErr := executor.ExecuteTool(ctx, tc.Function.Name, tc.Function.Arguments)
+			if execErr != nil {
+				result = fmt.Sprintf("Error executing tool: %s", execErr.Error())
+			}
+
+			messages = append(messages, openai.ChatCompletionMessage{
+				Role:       openai.ChatMessageRoleTool,
+				Content:    result,
+				ToolCallID: tc.ID,
+			})
+		}
+	}
+
+	return "", fmt.Errorf("exceeded maximum tool iterations (%d)", c.maxToolIterations)
+}

--- a/pkg/llm/tool_executor_test.go
+++ b/pkg/llm/tool_executor_test.go
@@ -1,0 +1,762 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/adapters/datasource"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
+)
+
+// ============================================================================
+// Mock Repositories
+// ============================================================================
+
+type mockOntologyRepo struct {
+	ontology *models.TieredOntology
+	err      error
+}
+
+func (m *mockOntologyRepo) Create(ctx context.Context, ontology *models.TieredOntology) error {
+	return m.err
+}
+
+func (m *mockOntologyRepo) GetActive(ctx context.Context, projectID uuid.UUID) (*models.TieredOntology, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.ontology, nil
+}
+
+func (m *mockOntologyRepo) GetByVersion(ctx context.Context, projectID uuid.UUID, version int) (*models.TieredOntology, error) {
+	return m.ontology, m.err
+}
+
+func (m *mockOntologyRepo) UpdateDomainSummary(ctx context.Context, projectID uuid.UUID, summary *models.DomainSummary) error {
+	return m.err
+}
+
+func (m *mockOntologyRepo) UpdateEntitySummary(ctx context.Context, projectID uuid.UUID, tableName string, summary *models.EntitySummary) error {
+	if m.ontology != nil && m.ontology.EntitySummaries != nil {
+		m.ontology.EntitySummaries[tableName] = summary
+	}
+	return m.err
+}
+
+func (m *mockOntologyRepo) UpdateEntitySummaries(ctx context.Context, projectID uuid.UUID, summaries map[string]*models.EntitySummary) error {
+	return m.err
+}
+
+func (m *mockOntologyRepo) UpdateColumnDetails(ctx context.Context, projectID uuid.UUID, tableName string, columns []models.ColumnDetail) error {
+	if m.ontology != nil && m.ontology.ColumnDetails != nil {
+		m.ontology.ColumnDetails[tableName] = columns
+	}
+	return m.err
+}
+
+func (m *mockOntologyRepo) SetActive(ctx context.Context, projectID uuid.UUID, version int) error {
+	return m.err
+}
+
+func (m *mockOntologyRepo) DeactivateAll(ctx context.Context, projectID uuid.UUID) error {
+	return m.err
+}
+
+func (m *mockOntologyRepo) GetNextVersion(ctx context.Context, projectID uuid.UUID) (int, error) {
+	return 1, m.err
+}
+
+func (m *mockOntologyRepo) UpdateMetadata(ctx context.Context, projectID uuid.UUID, metadata map[string]any) error {
+	if m.ontology != nil {
+		if m.ontology.Metadata == nil {
+			m.ontology.Metadata = make(map[string]any)
+		}
+		for k, v := range metadata {
+			m.ontology.Metadata[k] = v
+		}
+	}
+	return m.err
+}
+
+func (m *mockOntologyRepo) DeleteByProject(ctx context.Context, projectID uuid.UUID) error {
+	return m.err
+}
+
+func (m *mockOntologyRepo) WriteCleanOntology(ctx context.Context, projectID uuid.UUID) error {
+	return m.err
+}
+
+type mockWorkflowStateRepo struct {
+	questions   []models.WorkflowQuestion
+	entityState *models.WorkflowEntityState
+	workflow    *models.OntologyWorkflow
+	states      []*models.WorkflowEntityState
+	err         error
+	answeredIDs map[string]string
+}
+
+func newMockWorkflowStateRepo() *mockWorkflowStateRepo {
+	return &mockWorkflowStateRepo{
+		answeredIDs: make(map[string]string),
+	}
+}
+
+func (m *mockWorkflowStateRepo) Create(ctx context.Context, state *models.WorkflowEntityState) error {
+	return m.err
+}
+
+func (m *mockWorkflowStateRepo) CreateBatch(ctx context.Context, states []*models.WorkflowEntityState) error {
+	return m.err
+}
+
+func (m *mockWorkflowStateRepo) GetByID(ctx context.Context, id uuid.UUID) (*models.WorkflowEntityState, error) {
+	return m.entityState, m.err
+}
+
+func (m *mockWorkflowStateRepo) Update(ctx context.Context, state *models.WorkflowEntityState) error {
+	return m.err
+}
+
+func (m *mockWorkflowStateRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	return m.err
+}
+
+func (m *mockWorkflowStateRepo) ListByWorkflow(ctx context.Context, workflowID uuid.UUID) ([]*models.WorkflowEntityState, error) {
+	return m.states, m.err
+}
+
+func (m *mockWorkflowStateRepo) ListByStatus(ctx context.Context, workflowID uuid.UUID, status models.WorkflowEntityStatus) ([]*models.WorkflowEntityState, error) {
+	return m.states, m.err
+}
+
+func (m *mockWorkflowStateRepo) GetByEntity(ctx context.Context, workflowID uuid.UUID, entityType models.WorkflowEntityType, entityKey string) (*models.WorkflowEntityState, error) {
+	return m.entityState, m.err
+}
+
+func (m *mockWorkflowStateRepo) DeleteByWorkflow(ctx context.Context, workflowID uuid.UUID) error {
+	return m.err
+}
+
+func (m *mockWorkflowStateRepo) UpdateStatus(ctx context.Context, id uuid.UUID, status models.WorkflowEntityStatus, lastError *string) error {
+	return m.err
+}
+
+func (m *mockWorkflowStateRepo) UpdateStateData(ctx context.Context, id uuid.UUID, stateData *models.WorkflowStateData) error {
+	return m.err
+}
+
+func (m *mockWorkflowStateRepo) IncrementRetryCount(ctx context.Context, id uuid.UUID) error {
+	return m.err
+}
+
+func (m *mockWorkflowStateRepo) AddQuestionsToEntity(ctx context.Context, id uuid.UUID, questions []models.WorkflowQuestion) error {
+	return m.err
+}
+
+func (m *mockWorkflowStateRepo) UpdateQuestionInEntity(ctx context.Context, id uuid.UUID, questionID string, status string, answer string) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.answeredIDs[questionID] = answer
+	return nil
+}
+
+func (m *mockWorkflowStateRepo) RecordAnswerInEntity(ctx context.Context, id uuid.UUID, answer models.WorkflowAnswer) error {
+	return m.err
+}
+
+func (m *mockWorkflowStateRepo) GetNextPendingQuestion(ctx context.Context, workflowID uuid.UUID) (*models.WorkflowQuestion, uuid.UUID, error) {
+	if len(m.questions) > 0 {
+		return &m.questions[0], uuid.New(), m.err
+	}
+	return nil, uuid.Nil, m.err
+}
+
+func (m *mockWorkflowStateRepo) GetPendingQuestions(ctx context.Context, projectID uuid.UUID, limit int) ([]models.WorkflowQuestion, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if limit > 0 && len(m.questions) > limit {
+		return m.questions[:limit], nil
+	}
+	return m.questions, nil
+}
+
+func (m *mockWorkflowStateRepo) GetPendingQuestionsCount(ctx context.Context, workflowID uuid.UUID) (required int, optional int, err error) {
+	return len(m.questions), 0, m.err
+}
+
+func (m *mockWorkflowStateRepo) GetPendingQuestionsCountByProject(ctx context.Context, projectID uuid.UUID) (int, error) {
+	return len(m.questions), m.err
+}
+
+func (m *mockWorkflowStateRepo) FindQuestionByID(ctx context.Context, questionID string) (*models.WorkflowQuestion, *models.WorkflowEntityState, *models.OntologyWorkflow, error) {
+	if m.err != nil {
+		return nil, nil, nil, m.err
+	}
+	for i := range m.questions {
+		if m.questions[i].ID == questionID {
+			return &m.questions[i], m.entityState, m.workflow, nil
+		}
+	}
+	return nil, nil, nil, fmt.Errorf("question not found: %s", questionID)
+}
+
+// Ensure mockWorkflowStateRepo implements repositories.WorkflowStateRepository
+var _ repositories.WorkflowStateRepository = (*mockWorkflowStateRepo)(nil)
+
+type mockKnowledgeRepo struct {
+	facts   []*models.KnowledgeFact
+	fact    *models.KnowledgeFact
+	err     error
+	upserts []*models.KnowledgeFact
+}
+
+func (m *mockKnowledgeRepo) Upsert(ctx context.Context, fact *models.KnowledgeFact) error {
+	if m.err != nil {
+		return m.err
+	}
+	fact.ID = uuid.New()
+	m.upserts = append(m.upserts, fact)
+	return nil
+}
+
+func (m *mockKnowledgeRepo) GetByProject(ctx context.Context, projectID uuid.UUID) ([]*models.KnowledgeFact, error) {
+	return m.facts, m.err
+}
+
+func (m *mockKnowledgeRepo) GetByType(ctx context.Context, projectID uuid.UUID, factType string) ([]*models.KnowledgeFact, error) {
+	return m.facts, m.err
+}
+
+func (m *mockKnowledgeRepo) GetByKey(ctx context.Context, projectID uuid.UUID, factType, key string) (*models.KnowledgeFact, error) {
+	return m.fact, m.err
+}
+
+func (m *mockKnowledgeRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	return m.err
+}
+
+type mockSchemaRepo struct {
+	tables  []*models.SchemaTable
+	columns []*models.SchemaColumn
+	err     error
+}
+
+func (m *mockSchemaRepo) ListTablesByDatasource(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.SchemaTable, error) {
+	return m.tables, m.err
+}
+
+func (m *mockSchemaRepo) GetTableByID(ctx context.Context, projectID, tableID uuid.UUID) (*models.SchemaTable, error) {
+	return nil, m.err
+}
+
+func (m *mockSchemaRepo) GetTableByName(ctx context.Context, projectID, datasourceID uuid.UUID, schemaName, tableName string) (*models.SchemaTable, error) {
+	return nil, m.err
+}
+
+func (m *mockSchemaRepo) FindTableByName(ctx context.Context, projectID, datasourceID uuid.UUID, tableName string) (*models.SchemaTable, error) {
+	for _, t := range m.tables {
+		if t.TableName == tableName {
+			return t, nil
+		}
+	}
+	return nil, m.err
+}
+
+func (m *mockSchemaRepo) UpsertTable(ctx context.Context, table *models.SchemaTable) error {
+	return m.err
+}
+
+func (m *mockSchemaRepo) SoftDeleteRemovedTables(ctx context.Context, projectID, datasourceID uuid.UUID, activeTableKeys []repositories.TableKey) (int64, error) {
+	return 0, m.err
+}
+
+func (m *mockSchemaRepo) UpdateTableSelection(ctx context.Context, projectID, tableID uuid.UUID, isSelected bool) error {
+	return m.err
+}
+
+func (m *mockSchemaRepo) UpdateTableMetadata(ctx context.Context, projectID, tableID uuid.UUID, businessName, description *string) error {
+	return m.err
+}
+
+func (m *mockSchemaRepo) ListColumnsByTable(ctx context.Context, projectID, tableID uuid.UUID) ([]*models.SchemaColumn, error) {
+	return m.columns, m.err
+}
+
+func (m *mockSchemaRepo) ListColumnsByDatasource(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.SchemaColumn, error) {
+	return m.columns, m.err
+}
+
+func (m *mockSchemaRepo) GetColumnByID(ctx context.Context, projectID, columnID uuid.UUID) (*models.SchemaColumn, error) {
+	return nil, m.err
+}
+
+func (m *mockSchemaRepo) GetColumnByName(ctx context.Context, tableID uuid.UUID, columnName string) (*models.SchemaColumn, error) {
+	return nil, m.err
+}
+
+func (m *mockSchemaRepo) UpsertColumn(ctx context.Context, column *models.SchemaColumn) error {
+	return m.err
+}
+
+func (m *mockSchemaRepo) SoftDeleteRemovedColumns(ctx context.Context, tableID uuid.UUID, activeColumnNames []string) (int64, error) {
+	return 0, m.err
+}
+
+func (m *mockSchemaRepo) UpdateColumnSelection(ctx context.Context, projectID, columnID uuid.UUID, isSelected bool) error {
+	return m.err
+}
+
+func (m *mockSchemaRepo) UpdateColumnStats(ctx context.Context, columnID uuid.UUID, distinctCount, nullCount *int64) error {
+	return m.err
+}
+
+func (m *mockSchemaRepo) UpdateColumnMetadata(ctx context.Context, projectID, columnID uuid.UUID, businessName, description *string) error {
+	return m.err
+}
+
+func (m *mockSchemaRepo) ListRelationshipsByDatasource(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.SchemaRelationship, error) {
+	return nil, m.err
+}
+
+func (m *mockSchemaRepo) GetRelationshipByID(ctx context.Context, projectID, relationshipID uuid.UUID) (*models.SchemaRelationship, error) {
+	return nil, m.err
+}
+
+func (m *mockSchemaRepo) GetRelationshipByColumns(ctx context.Context, sourceColumnID, targetColumnID uuid.UUID) (*models.SchemaRelationship, error) {
+	return nil, m.err
+}
+
+func (m *mockSchemaRepo) UpsertRelationship(ctx context.Context, rel *models.SchemaRelationship) error {
+	return m.err
+}
+
+func (m *mockSchemaRepo) UpdateRelationshipApproval(ctx context.Context, projectID, relationshipID uuid.UUID, isApproved bool) error {
+	return m.err
+}
+
+func (m *mockSchemaRepo) SoftDeleteRelationship(ctx context.Context, projectID, relationshipID uuid.UUID) error {
+	return m.err
+}
+
+func (m *mockSchemaRepo) SoftDeleteOrphanedRelationships(ctx context.Context, projectID, datasourceID uuid.UUID) (int64, error) {
+	return 0, m.err
+}
+
+func (m *mockSchemaRepo) GetRelationshipDetails(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.RelationshipDetail, error) {
+	return nil, m.err
+}
+
+func (m *mockSchemaRepo) GetEmptyTables(ctx context.Context, projectID, datasourceID uuid.UUID) ([]string, error) {
+	return nil, m.err
+}
+
+func (m *mockSchemaRepo) GetOrphanTables(ctx context.Context, projectID, datasourceID uuid.UUID) ([]string, error) {
+	return nil, m.err
+}
+
+func (m *mockSchemaRepo) UpsertRelationshipWithMetrics(ctx context.Context, rel *models.SchemaRelationship, metrics *models.DiscoveryMetrics) error {
+	return m.err
+}
+
+func (m *mockSchemaRepo) GetJoinableColumns(ctx context.Context, projectID, tableID uuid.UUID) ([]*models.SchemaColumn, error) {
+	return nil, m.err
+}
+
+func (m *mockSchemaRepo) UpdateColumnJoinability(ctx context.Context, columnID uuid.UUID, rowCount, nonNullCount *int64, isJoinable *bool, joinabilityReason *string) error {
+	return m.err
+}
+
+func (m *mockSchemaRepo) GetPrimaryKeyColumns(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.SchemaColumn, error) {
+	return nil, m.err
+}
+
+func (m *mockSchemaRepo) GetRelationshipCandidates(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.RelationshipCandidate, error) {
+	return nil, m.err
+}
+
+type mockQueryExecutor struct {
+	result *datasource.QueryExecutionResult
+	err    error
+}
+
+func (m *mockQueryExecutor) ExecuteQuery(ctx context.Context, sqlQuery string, limit int) (*datasource.QueryExecutionResult, error) {
+	return m.result, m.err
+}
+
+func (m *mockQueryExecutor) ValidateQuery(ctx context.Context, sqlQuery string) error {
+	return m.err
+}
+
+func (m *mockQueryExecutor) Close() error {
+	return nil
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+func TestOntologyToolExecutor_UnknownTool(t *testing.T) {
+	executor := NewOntologyToolExecutor(&OntologyToolExecutorConfig{
+		ProjectID: uuid.New(),
+		Logger:    zap.NewNop(),
+	})
+
+	_, err := executor.ExecuteTool(context.Background(), "unknown_tool", "{}")
+	if err == nil {
+		t.Error("expected error for unknown tool")
+	}
+	if err.Error() != "unknown tool: unknown_tool" {
+		t.Errorf("unexpected error message: %s", err.Error())
+	}
+}
+
+func TestOntologyToolExecutor_StoreKnowledge(t *testing.T) {
+	projectID := uuid.New()
+	knowledgeRepo := &mockKnowledgeRepo{}
+
+	executor := NewOntologyToolExecutor(&OntologyToolExecutorConfig{
+		ProjectID:     projectID,
+		KnowledgeRepo: knowledgeRepo,
+		Logger:        zap.NewNop(),
+	})
+
+	args := `{"fact_type": "terminology", "key": "SKU", "value": "Stock Keeping Unit - unique product identifier"}`
+	result, err := executor.ExecuteTool(context.Background(), "store_knowledge", args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal([]byte(result), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if response["success"] != true {
+		t.Error("expected success to be true")
+	}
+	if response["fact_type"] != "terminology" {
+		t.Errorf("expected fact_type 'terminology', got %v", response["fact_type"])
+	}
+	if response["key"] != "SKU" {
+		t.Errorf("expected key 'SKU', got %v", response["key"])
+	}
+
+	// Verify the fact was stored
+	if len(knowledgeRepo.upserts) != 1 {
+		t.Fatalf("expected 1 upsert, got %d", len(knowledgeRepo.upserts))
+	}
+	if knowledgeRepo.upserts[0].Value != "Stock Keeping Unit - unique product identifier" {
+		t.Errorf("unexpected value stored: %s", knowledgeRepo.upserts[0].Value)
+	}
+}
+
+func TestOntologyToolExecutor_StoreKnowledge_InvalidFactType(t *testing.T) {
+	executor := NewOntologyToolExecutor(&OntologyToolExecutorConfig{
+		ProjectID:     uuid.New(),
+		KnowledgeRepo: &mockKnowledgeRepo{},
+		Logger:        zap.NewNop(),
+	})
+
+	args := `{"fact_type": "invalid_type", "key": "test", "value": "test value"}`
+	_, err := executor.ExecuteTool(context.Background(), "store_knowledge", args)
+	if err == nil {
+		t.Error("expected error for invalid fact type")
+	}
+}
+
+func TestOntologyToolExecutor_UpdateEntity(t *testing.T) {
+	projectID := uuid.New()
+	ontology := &models.TieredOntology{
+		ID:              uuid.New(),
+		ProjectID:       projectID,
+		EntitySummaries: make(map[string]*models.EntitySummary),
+		ColumnDetails:   make(map[string][]models.ColumnDetail),
+	}
+	ontologyRepo := &mockOntologyRepo{ontology: ontology}
+
+	executor := NewOntologyToolExecutor(&OntologyToolExecutorConfig{
+		ProjectID:    projectID,
+		OntologyRepo: ontologyRepo,
+		Logger:       zap.NewNop(),
+	})
+
+	args := `{"table_name": "orders", "business_name": "Sales Orders", "description": "Customer purchase orders", "domain": "sales"}`
+	result, err := executor.ExecuteTool(context.Background(), "update_entity", args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal([]byte(result), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if response["success"] != true {
+		t.Error("expected success to be true")
+	}
+	if response["table_name"] != "orders" {
+		t.Errorf("expected table_name 'orders', got %v", response["table_name"])
+	}
+
+	// Verify entity was updated
+	summary := ontology.EntitySummaries["orders"]
+	if summary == nil {
+		t.Fatal("expected entity summary to be created")
+	}
+	if summary.BusinessName != "Sales Orders" {
+		t.Errorf("expected business_name 'Sales Orders', got %s", summary.BusinessName)
+	}
+	if summary.Domain != "sales" {
+		t.Errorf("expected domain 'sales', got %s", summary.Domain)
+	}
+}
+
+func TestOntologyToolExecutor_UpdateColumn(t *testing.T) {
+	projectID := uuid.New()
+	ontology := &models.TieredOntology{
+		ID:              uuid.New(),
+		ProjectID:       projectID,
+		EntitySummaries: make(map[string]*models.EntitySummary),
+		ColumnDetails:   make(map[string][]models.ColumnDetail),
+	}
+	ontologyRepo := &mockOntologyRepo{ontology: ontology}
+
+	executor := NewOntologyToolExecutor(&OntologyToolExecutorConfig{
+		ProjectID:    projectID,
+		OntologyRepo: ontologyRepo,
+		Logger:       zap.NewNop(),
+	})
+
+	args := `{"table_name": "orders", "column_name": "order_date", "description": "Date when order was placed", "semantic_type": "date"}`
+	result, err := executor.ExecuteTool(context.Background(), "update_column", args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal([]byte(result), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if response["success"] != true {
+		t.Error("expected success to be true")
+	}
+
+	// Verify column was updated
+	columns := ontology.ColumnDetails["orders"]
+	if len(columns) != 1 {
+		t.Fatalf("expected 1 column, got %d", len(columns))
+	}
+	if columns[0].Name != "order_date" {
+		t.Errorf("expected column name 'order_date', got %s", columns[0].Name)
+	}
+	if columns[0].SemanticType != "date" {
+		t.Errorf("expected semantic type 'date', got %s", columns[0].SemanticType)
+	}
+}
+
+func TestOntologyToolExecutor_AnswerQuestion(t *testing.T) {
+	projectID := uuid.New()
+	questionID := uuid.New().String()
+	stateRepo := newMockWorkflowStateRepo()
+
+	// Set up mock data
+	stateRepo.questions = []models.WorkflowQuestion{
+		{ID: questionID, Text: "What is SKU?", Status: "pending"},
+	}
+	stateRepo.entityState = &models.WorkflowEntityState{ID: uuid.New()}
+	stateRepo.workflow = &models.OntologyWorkflow{ID: uuid.New()}
+
+	executor := NewOntologyToolExecutor(&OntologyToolExecutorConfig{
+		ProjectID: projectID,
+		StateRepo: stateRepo,
+		Logger:    zap.NewNop(),
+	})
+
+	args := `{"question_id": "` + questionID + `", "answer": "This is the answer"}`
+	result, err := executor.ExecuteTool(context.Background(), "answer_question", args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal([]byte(result), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if response["success"] != true {
+		t.Error("expected success to be true")
+	}
+
+	// Verify question was answered
+	if answer, ok := stateRepo.answeredIDs[questionID]; !ok || answer != "This is the answer" {
+		t.Errorf("question was not properly answered: %v", stateRepo.answeredIDs)
+	}
+}
+
+func TestOntologyToolExecutor_GetPendingQuestions(t *testing.T) {
+	projectID := uuid.New()
+	stateRepo := newMockWorkflowStateRepo()
+	stateRepo.questions = []models.WorkflowQuestion{
+		{ID: uuid.New().String(), Text: "What is SKU?", Category: "terminology", Priority: 1, Status: "pending"},
+		{ID: uuid.New().String(), Text: "What does order_status represent?", Category: "column", Priority: 2, Status: "pending"},
+	}
+
+	executor := NewOntologyToolExecutor(&OntologyToolExecutorConfig{
+		ProjectID: projectID,
+		StateRepo: stateRepo,
+		Logger:    zap.NewNop(),
+	})
+
+	args := `{"limit": 5}`
+	result, err := executor.ExecuteTool(context.Background(), "get_pending_questions", args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal([]byte(result), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	questions := response["questions"].([]any)
+	if len(questions) != 2 {
+		t.Errorf("expected 2 questions, got %d", len(questions))
+	}
+
+	count := response["count"].(float64)
+	if count != 2 {
+		t.Errorf("expected count 2, got %v", count)
+	}
+}
+
+func TestOntologyToolExecutor_QuerySchemaMetadata(t *testing.T) {
+	projectID := uuid.New()
+	datasourceID := uuid.New()
+	tableID := uuid.New()
+
+	schemaRepo := &mockSchemaRepo{
+		tables: []*models.SchemaTable{
+			{
+				ID:          tableID,
+				ProjectID:   projectID,
+				SchemaName:  "public",
+				TableName:   "orders",
+				RowCount:    ptr(int64(1000)),
+				Description: ptr("Customer orders table"),
+			},
+		},
+		columns: []*models.SchemaColumn{
+			{ColumnName: "id", DataType: "integer", IsPrimaryKey: true},
+			{ColumnName: "order_date", DataType: "date", IsNullable: false},
+		},
+	}
+
+	executor := NewOntologyToolExecutor(&OntologyToolExecutorConfig{
+		ProjectID:    projectID,
+		DatasourceID: datasourceID,
+		SchemaRepo:   schemaRepo,
+		Logger:       zap.NewNop(),
+	})
+
+	args := `{"table_name": "orders"}`
+	result, err := executor.ExecuteTool(context.Background(), "query_schema_metadata", args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal([]byte(result), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	tables := response["tables"].([]any)
+	if len(tables) != 1 {
+		t.Errorf("expected 1 table, got %d", len(tables))
+	}
+
+	tableCount := response["table_count"].(float64)
+	if tableCount != 1 {
+		t.Errorf("expected table_count 1, got %v", tableCount)
+	}
+}
+
+func TestOntologyToolExecutor_QueryColumnValues(t *testing.T) {
+	projectID := uuid.New()
+	datasourceID := uuid.New()
+
+	queryExecutor := &mockQueryExecutor{
+		result: &datasource.QueryExecutionResult{
+			Columns:  []string{"status"},
+			Rows:     []map[string]any{{"status": "pending"}, {"status": "shipped"}, {"status": "delivered"}},
+			RowCount: 3,
+		},
+	}
+
+	executor := NewOntologyToolExecutor(&OntologyToolExecutorConfig{
+		ProjectID:     projectID,
+		DatasourceID:  datasourceID,
+		QueryExecutor: queryExecutor,
+		Logger:        zap.NewNop(),
+	})
+
+	args := `{"table_name": "orders", "column_name": "status", "limit": 10}`
+	result, err := executor.ExecuteTool(context.Background(), "query_column_values", args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal([]byte(result), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	values := response["values"].([]any)
+	if len(values) != 3 {
+		t.Errorf("expected 3 values, got %d", len(values))
+	}
+
+	if response["table"] != "orders" {
+		t.Errorf("expected table 'orders', got %v", response["table"])
+	}
+	if response["column"] != "status" {
+		t.Errorf("expected column 'status', got %v", response["column"])
+	}
+}
+
+func TestOntologyToolExecutor_QueryColumnValues_NoExecutor(t *testing.T) {
+	executor := NewOntologyToolExecutor(&OntologyToolExecutorConfig{
+		ProjectID: uuid.New(),
+		// No QueryExecutor
+		Logger: zap.NewNop(),
+	})
+
+	args := `{"table_name": "orders", "column_name": "status"}`
+	result, err := executor.ExecuteTool(context.Background(), "query_column_values", args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should return an error message in JSON, not fail
+	var response map[string]any
+	if err := json.Unmarshal([]byte(result), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if response["error"] == nil {
+		t.Error("expected error in response when no executor available")
+	}
+}
+
+// Helper function
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/pkg/llm/tools.go
+++ b/pkg/llm/tools.go
@@ -1,0 +1,242 @@
+// Package llm provides OpenAI-compatible LLM client functionality.
+package llm
+
+// ToolDefinition defines a tool that can be called by the LLM.
+type ToolDefinition struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Parameters  map[string]any `json:"parameters"`
+}
+
+// ParameterProperty defines a parameter property in JSON Schema format.
+type ParameterProperty struct {
+	Type        string   `json:"type"`
+	Description string   `json:"description,omitempty"`
+	Enum        []string `json:"enum,omitempty"`
+}
+
+// NewToolDefinition creates a new tool definition with standard JSON Schema parameters.
+func NewToolDefinition(name, description string, properties map[string]ParameterProperty, required []string) ToolDefinition {
+	props := make(map[string]any)
+	for k, v := range properties {
+		props[k] = map[string]any{
+			"type":        v.Type,
+			"description": v.Description,
+		}
+		if len(v.Enum) > 0 {
+			props[k].(map[string]any)["enum"] = v.Enum
+		}
+	}
+
+	return ToolDefinition{
+		Name:        name,
+		Description: description,
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": props,
+			"required":   required,
+		},
+	}
+}
+
+// GetOntologyChatTools returns the tool definitions for ontology chat.
+func GetOntologyChatTools() []ToolDefinition {
+	return []ToolDefinition{
+		NewToolDefinition(
+			"query_column_values",
+			"Query sample values from a specific column in the database to understand its contents",
+			map[string]ParameterProperty{
+				"table_name": {
+					Type:        "string",
+					Description: "The name of the table to query",
+				},
+				"column_name": {
+					Type:        "string",
+					Description: "The name of the column to get sample values from",
+				},
+				"limit": {
+					Type:        "integer",
+					Description: "Maximum number of sample values to return (default 10)",
+				},
+			},
+			[]string{"table_name", "column_name"},
+		),
+		NewToolDefinition(
+			"query_schema_metadata",
+			"Get detailed metadata about tables and columns in the schema",
+			map[string]ParameterProperty{
+				"table_name": {
+					Type:        "string",
+					Description: "Optional: specific table name to get metadata for. If not provided, returns all tables.",
+				},
+			},
+			[]string{},
+		),
+		NewToolDefinition(
+			"store_knowledge",
+			"Store a piece of business knowledge or terminology learned from the conversation",
+			map[string]ParameterProperty{
+				"fact_type": {
+					Type:        "string",
+					Description: "The type of knowledge being stored",
+					Enum:        []string{"terminology", "business_rule", "data_relationship", "constraint", "context"},
+				},
+				"key": {
+					Type:        "string",
+					Description: "A short key or identifier for this knowledge (e.g., 'SKU', 'order_status_values')",
+				},
+				"value": {
+					Type:        "string",
+					Description: "The actual knowledge or definition",
+				},
+				"context": {
+					Type:        "string",
+					Description: "Optional additional context about where this knowledge applies",
+				},
+			},
+			[]string{"fact_type", "key", "value"},
+		),
+		NewToolDefinition(
+			"update_entity",
+			"Update the business description or properties of a table/entity in the ontology",
+			map[string]ParameterProperty{
+				"table_name": {
+					Type:        "string",
+					Description: "The technical name of the table to update",
+				},
+				"business_name": {
+					Type:        "string",
+					Description: "The business-friendly name for this entity",
+				},
+				"description": {
+					Type:        "string",
+					Description: "A business description of what this entity represents",
+				},
+				"domain": {
+					Type:        "string",
+					Description: "The business domain this entity belongs to",
+				},
+				"synonyms": {
+					Type:        "array",
+					Description: "Alternative names or terms used to refer to this entity",
+				},
+			},
+			[]string{"table_name"},
+		),
+		NewToolDefinition(
+			"update_column",
+			"Update the business description or properties of a column in the ontology",
+			map[string]ParameterProperty{
+				"table_name": {
+					Type:        "string",
+					Description: "The name of the table containing the column",
+				},
+				"column_name": {
+					Type:        "string",
+					Description: "The technical name of the column to update",
+				},
+				"business_name": {
+					Type:        "string",
+					Description: "The business-friendly name for this column",
+				},
+				"description": {
+					Type:        "string",
+					Description: "A business description of what this column represents",
+				},
+				"semantic_type": {
+					Type:        "string",
+					Description: "The semantic type of this column",
+					Enum:        []string{"identifier", "name", "description", "amount", "quantity", "date", "timestamp", "status", "flag", "code", "reference", "other"},
+				},
+			},
+			[]string{"table_name", "column_name"},
+		),
+		NewToolDefinition(
+			"answer_question",
+			"Record an answer to a pending ontology question based on what was learned in the conversation",
+			map[string]ParameterProperty{
+				"question_id": {
+					Type:        "string",
+					Description: "The UUID of the question being answered",
+				},
+				"answer": {
+					Type:        "string",
+					Description: "The answer to record",
+				},
+			},
+			[]string{"question_id", "answer"},
+		),
+		NewToolDefinition(
+			"get_pending_questions",
+			"Retrieve the list of pending questions that need answers to improve the ontology",
+			map[string]ParameterProperty{
+				"limit": {
+					Type:        "integer",
+					Description: "Maximum number of questions to return (default 5)",
+				},
+			},
+			[]string{},
+		),
+	}
+}
+
+// GetQuestionAnswererTools returns tools for the question answering service.
+// This is a subset focused on information gathering and knowledge storage.
+func GetQuestionAnswererTools() []ToolDefinition {
+	return []ToolDefinition{
+		NewToolDefinition(
+			"query_column_values",
+			"Query sample values from a specific column to help answer questions about data",
+			map[string]ParameterProperty{
+				"table_name": {
+					Type:        "string",
+					Description: "The name of the table to query",
+				},
+				"column_name": {
+					Type:        "string",
+					Description: "The name of the column to get sample values from",
+				},
+				"limit": {
+					Type:        "integer",
+					Description: "Maximum number of sample values to return (default 10)",
+				},
+			},
+			[]string{"table_name", "column_name"},
+		),
+		NewToolDefinition(
+			"query_schema_metadata",
+			"Get detailed metadata about tables and columns",
+			map[string]ParameterProperty{
+				"table_name": {
+					Type:        "string",
+					Description: "Optional: specific table name to get metadata for",
+				},
+			},
+			[]string{},
+		),
+		NewToolDefinition(
+			"store_knowledge",
+			"Store business knowledge learned from the user's answer",
+			map[string]ParameterProperty{
+				"fact_type": {
+					Type:        "string",
+					Description: "The type of knowledge being stored",
+					Enum:        []string{"terminology", "business_rule", "data_relationship", "constraint", "context"},
+				},
+				"key": {
+					Type:        "string",
+					Description: "A short key or identifier for this knowledge",
+				},
+				"value": {
+					Type:        "string",
+					Description: "The actual knowledge or definition",
+				},
+				"context": {
+					Type:        "string",
+					Description: "Optional additional context",
+				},
+			},
+			[]string{"fact_type", "key", "value"},
+		),
+	}
+}

--- a/pkg/middleware/logging.go
+++ b/pkg/middleware/logging.go
@@ -1,0 +1,46 @@
+package middleware
+
+import (
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// RequestLogger returns middleware that logs HTTP requests at DEBUG level.
+// Pass nil logger to disable logging (makes it optional/injectable).
+func RequestLogger(logger *zap.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		// If no logger provided, pass through without logging
+		if logger == nil {
+			return next
+		}
+
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+
+			// Wrap response writer to capture status code
+			wrapped := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+
+			next.ServeHTTP(wrapped, r)
+
+			logger.Debug("HTTP request",
+				zap.String("method", r.Method),
+				zap.String("path", r.URL.Path),
+				zap.Int("status", wrapped.statusCode),
+				zap.Duration("duration", time.Since(start)),
+				zap.String("remote_addr", r.RemoteAddr),
+			)
+		})
+	}
+}
+
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}

--- a/pkg/models/llm_conversation.go
+++ b/pkg/models/llm_conversation.go
@@ -1,0 +1,49 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// LLMConversation represents a single LLM API call with verbatim input/output.
+type LLMConversation struct {
+	ID             uuid.UUID      `json:"id"`
+	ProjectID      uuid.UUID      `json:"project_id"`
+	Context        map[string]any `json:"context,omitempty"` // Caller-specific context (workflow_id, task_name, etc.)
+	ConversationID *uuid.UUID     `json:"conversation_id,omitempty"`
+	Iteration      int            `json:"iteration"`
+
+	// Model info
+	Endpoint string `json:"endpoint"`
+	Model    string `json:"model"`
+
+	// Request (VERBATIM)
+	RequestMessages []any    `json:"request_messages"`
+	RequestTools    []any    `json:"request_tools,omitempty"`
+	Temperature     *float64 `json:"temperature,omitempty"`
+
+	// Response (VERBATIM)
+	ResponseContent   string `json:"response_content,omitempty"`
+	ResponseToolCalls []any  `json:"response_tool_calls,omitempty"`
+
+	// Metrics
+	PromptTokens     *int `json:"prompt_tokens,omitempty"`
+	CompletionTokens *int `json:"completion_tokens,omitempty"`
+	TotalTokens      *int `json:"total_tokens,omitempty"`
+	DurationMs       int  `json:"duration_ms"`
+
+	// Status
+	Status       string `json:"status"`
+	ErrorMessage string `json:"error_message,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// Status values for LLM conversations.
+const (
+	LLMConversationStatusPending = "pending" // Request sent, awaiting response
+	LLMConversationStatusSuccess = "success"
+	LLMConversationStatusError   = "error"
+	LLMConversationStatusTimeout = "timeout"
+)

--- a/pkg/models/ontology.go
+++ b/pkg/models/ontology.go
@@ -1,0 +1,188 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ============================================================================
+// Tiered Ontology - Domain Layer (Tier 0)
+// ============================================================================
+
+// DomainSummary represents the top-level business context (~500 tokens).
+// Provides high-level understanding without detailed column information.
+type DomainSummary struct {
+	Description       string             `json:"description"`
+	Domains           []string           `json:"domains"`
+	RelationshipGraph []RelationshipEdge `json:"relationship_graph,omitempty"`
+	SampleQuestions   []string           `json:"sample_questions,omitempty"`
+}
+
+// RelationshipEdge represents a connection between entities in the domain graph.
+type RelationshipEdge struct {
+	From        string `json:"from"`
+	To          string `json:"to"`
+	Label       string `json:"label,omitempty"`
+	Cardinality string `json:"cardinality,omitempty"`
+}
+
+// ============================================================================
+// Tiered Ontology - Entity Layer (Tier 1)
+// ============================================================================
+
+// EntitySummary represents a per-table business summary (~75 tokens each).
+type EntitySummary struct {
+	TableName     string      `json:"table_name"`
+	BusinessName  string      `json:"business_name"`
+	Description   string      `json:"description"`
+	Domain        string      `json:"domain"`
+	Synonyms      []string    `json:"synonyms,omitempty"`
+	KeyColumns    []KeyColumn `json:"key_columns,omitempty"`
+	ColumnCount   int         `json:"column_count"`
+	Relationships []string    `json:"relationships,omitempty"`
+}
+
+// KeyColumn represents an important column in an entity summary.
+type KeyColumn struct {
+	Name     string   `json:"name"`
+	Synonyms []string `json:"synonyms,omitempty"`
+}
+
+// ============================================================================
+// Tiered Ontology - Column Layer (Tier 2)
+// ============================================================================
+
+// ColumnDetail represents detailed semantic information for a column.
+type ColumnDetail struct {
+	Name         string      `json:"name"`
+	Description  string      `json:"description,omitempty"`
+	Synonyms     []string    `json:"synonyms,omitempty"`
+	SemanticType string      `json:"semantic_type,omitempty"`
+	Role         string      `json:"role,omitempty"` // dimension, measure, identifier, attribute
+	EnumValues   []EnumValue `json:"enum_values,omitempty"`
+	IsPrimaryKey bool        `json:"is_primary_key"`
+	IsForeignKey bool        `json:"is_foreign_key"`
+	ForeignTable string      `json:"foreign_table,omitempty"`
+}
+
+// EnumValue represents a known value in an enumeration column.
+type EnumValue struct {
+	Value       string `json:"value"`
+	Label       string `json:"label,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// Column roles
+const (
+	ColumnRoleDimension  = "dimension"
+	ColumnRoleMeasure    = "measure"
+	ColumnRoleIdentifier = "identifier"
+	ColumnRoleAttribute  = "attribute"
+)
+
+// Business domains for classification
+const (
+	DomainSales      = "sales"
+	DomainFinance    = "finance"
+	DomainOperations = "operations"
+	DomainCustomer   = "customer"
+	DomainProduct    = "product"
+	DomainAnalytics  = "analytics"
+	DomainHR         = "hr"
+	DomainInventory  = "inventory"
+	DomainMarketing  = "marketing"
+	DomainUnknown    = "unknown"
+)
+
+// ValidDomains contains all valid business domain values.
+var ValidDomains = []string{
+	DomainSales,
+	DomainFinance,
+	DomainOperations,
+	DomainCustomer,
+	DomainProduct,
+	DomainAnalytics,
+	DomainHR,
+	DomainInventory,
+	DomainMarketing,
+	DomainUnknown,
+}
+
+// ============================================================================
+// Tiered Ontology - Complete Structure
+// ============================================================================
+
+// TieredOntology represents the complete hierarchical ontology structure.
+type TieredOntology struct {
+	ID              uuid.UUID                 `json:"id"`
+	ProjectID       uuid.UUID                 `json:"project_id"`
+	Version         int                       `json:"version"`
+	IsActive        bool                      `json:"is_active"`
+	DomainSummary   *DomainSummary            `json:"domain_summary,omitempty"`
+	EntitySummaries map[string]*EntitySummary `json:"entity_summaries,omitempty"` // table_name -> summary
+	ColumnDetails   map[string][]ColumnDetail `json:"column_details,omitempty"`   // table_name -> columns
+	Metadata        map[string]any            `json:"metadata,omitempty"`
+	CreatedAt       time.Time                 `json:"created_at"`
+	UpdatedAt       time.Time                 `json:"updated_at"`
+}
+
+// GetEntitySummary returns the summary for a specific table, or nil if not found.
+func (o *TieredOntology) GetEntitySummary(tableName string) *EntitySummary {
+	if o.EntitySummaries == nil {
+		return nil
+	}
+	return o.EntitySummaries[tableName]
+}
+
+// GetColumnDetails returns the column details for a specific table, or nil if not found.
+func (o *TieredOntology) GetColumnDetails(tableName string) []ColumnDetail {
+	if o.ColumnDetails == nil {
+		return nil
+	}
+	return o.ColumnDetails[tableName]
+}
+
+// TableCount returns the number of tables in the ontology.
+func (o *TieredOntology) TableCount() int {
+	if o.EntitySummaries == nil {
+		return 0
+	}
+	return len(o.EntitySummaries)
+}
+
+// ColumnCount returns the total number of columns across all tables.
+func (o *TieredOntology) ColumnCount() int {
+	if o.ColumnDetails == nil {
+		return 0
+	}
+	count := 0
+	for _, columns := range o.ColumnDetails {
+		count += len(columns)
+	}
+	return count
+}
+
+// TotalEntityCount returns the total number of entities: 1 (global) + tables + columns.
+func (o *TieredOntology) TotalEntityCount() int {
+	return 1 + o.TableCount() + o.ColumnCount()
+}
+
+// ============================================================================
+// Description Processing Types
+// ============================================================================
+
+// DomainContext contains the LLM-refined domain understanding.
+// This is derived from user description + schema analysis.
+type DomainContext struct {
+	Summary        string            `json:"summary"`
+	PrimaryDomains []string          `json:"primary_domains"`
+	KeyTerminology map[string]string `json:"key_terminology"`
+}
+
+// EntityHint provides pre-seeded context for a table from user description.
+type EntityHint struct {
+	BusinessName string   `json:"business_name,omitempty"`
+	Domain       string   `json:"domain,omitempty"`
+	Synonyms     []string `json:"synonyms,omitempty"`
+}

--- a/pkg/models/ontology_chat.go
+++ b/pkg/models/ontology_chat.go
@@ -1,0 +1,312 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ============================================================================
+// Chat Roles
+// ============================================================================
+
+// ChatRole represents the role of a chat message sender.
+type ChatRole string
+
+const (
+	ChatRoleUser      ChatRole = "user"
+	ChatRoleAssistant ChatRole = "assistant"
+	ChatRoleSystem    ChatRole = "system"
+	ChatRoleTool      ChatRole = "tool"
+)
+
+// ValidChatRoles contains all valid chat role values.
+var ValidChatRoles = []ChatRole{
+	ChatRoleUser,
+	ChatRoleAssistant,
+	ChatRoleSystem,
+	ChatRoleTool,
+}
+
+// IsValidChatRole checks if the given role is valid.
+func IsValidChatRole(r ChatRole) bool {
+	for _, v := range ValidChatRoles {
+		if v == r {
+			return true
+		}
+	}
+	return false
+}
+
+// ============================================================================
+// Tool Calls
+// ============================================================================
+
+// ToolCall represents an LLM tool call request.
+type ToolCall struct {
+	ID       string           `json:"id"`
+	Type     string           `json:"type"`
+	Function ToolCallFunction `json:"function"`
+}
+
+// ToolCallFunction contains the function name and arguments for a tool call.
+type ToolCallFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"` // JSON string
+}
+
+// ============================================================================
+// Chat Message
+// ============================================================================
+
+// ChatMessage represents a message in the ontology chat interface.
+type ChatMessage struct {
+	ID         uuid.UUID      `json:"id"`
+	ProjectID  uuid.UUID      `json:"project_id"`
+	OntologyID uuid.UUID      `json:"ontology_id"`
+	Role       ChatRole       `json:"role"`
+	Content    string         `json:"content"`
+	ToolCalls  []ToolCall     `json:"tool_calls,omitempty"`
+	ToolCallID string         `json:"tool_call_id,omitempty"`
+	Metadata   map[string]any `json:"metadata,omitempty"`
+	CreatedAt  time.Time      `json:"created_at"`
+}
+
+// IsFromUser returns true if the message is from a user.
+func (m *ChatMessage) IsFromUser() bool {
+	return m.Role == ChatRoleUser
+}
+
+// IsFromAssistant returns true if the message is from the assistant.
+func (m *ChatMessage) IsFromAssistant() bool {
+	return m.Role == ChatRoleAssistant
+}
+
+// IsToolResponse returns true if the message is a tool response.
+func (m *ChatMessage) IsToolResponse() bool {
+	return m.Role == ChatRoleTool
+}
+
+// HasToolCalls returns true if the message contains tool calls.
+func (m *ChatMessage) HasToolCalls() bool {
+	return len(m.ToolCalls) > 0
+}
+
+// ============================================================================
+// Chat Events (for SSE streaming)
+// ============================================================================
+
+// ChatEventType represents the type of a streaming chat event.
+type ChatEventType string
+
+const (
+	ChatEventText            ChatEventType = "text"
+	ChatEventToolCall        ChatEventType = "tool_call"
+	ChatEventToolResult      ChatEventType = "tool_result"
+	ChatEventOntologyUpdate  ChatEventType = "ontology_update"
+	ChatEventKnowledgeStored ChatEventType = "knowledge_stored"
+	ChatEventDone            ChatEventType = "done"
+	ChatEventError           ChatEventType = "error"
+)
+
+// ChatEvent represents a streaming event from the chat service.
+type ChatEvent struct {
+	Type    ChatEventType `json:"type"`
+	Content string        `json:"content,omitempty"`
+	Data    any           `json:"data,omitempty"`
+}
+
+// NewTextEvent creates a text streaming event.
+func NewTextEvent(content string) ChatEvent {
+	return ChatEvent{Type: ChatEventText, Content: content}
+}
+
+// NewToolCallEvent creates a tool call event.
+func NewToolCallEvent(toolCall ToolCall) ChatEvent {
+	return ChatEvent{Type: ChatEventToolCall, Data: toolCall}
+}
+
+// NewToolResultEvent creates a tool result event.
+func NewToolResultEvent(toolID string, result any) ChatEvent {
+	return ChatEvent{
+		Type:    ChatEventToolResult,
+		Content: toolID,
+		Data:    result,
+	}
+}
+
+// NewOntologyUpdateEvent creates an ontology update event.
+func NewOntologyUpdateEvent(tableName string, update any) ChatEvent {
+	return ChatEvent{
+		Type:    ChatEventOntologyUpdate,
+		Content: tableName,
+		Data:    update,
+	}
+}
+
+// NewKnowledgeStoredEvent creates a knowledge stored event.
+func NewKnowledgeStoredEvent(fact *KnowledgeFact) ChatEvent {
+	return ChatEvent{Type: ChatEventKnowledgeStored, Data: fact}
+}
+
+// NewDoneEvent creates a completion event.
+func NewDoneEvent() ChatEvent {
+	return ChatEvent{Type: ChatEventDone}
+}
+
+// NewErrorEvent creates an error event.
+func NewErrorEvent(err string) ChatEvent {
+	return ChatEvent{Type: ChatEventError, Content: err}
+}
+
+// ============================================================================
+// Chat Initialization Response
+// ============================================================================
+
+// ChatInitResponse contains the response for chat initialization.
+type ChatInitResponse struct {
+	OpeningMessage       string `json:"opening_message"`
+	PendingQuestionCount int    `json:"pending_question_count"`
+	HasExistingHistory   bool   `json:"has_existing_history"`
+}
+
+// ============================================================================
+// Knowledge Facts
+// ============================================================================
+
+// Knowledge fact types
+const (
+	FactTypeFiscalYear   = "fiscal_year"
+	FactTypeBusinessRule = "business_rule"
+	FactTypeTerminology  = "terminology"
+	FactTypeConvention   = "convention"
+	FactTypeEnumeration  = "enumeration"
+	FactTypeRelationship = "relationship"
+)
+
+// ValidFactTypes contains all valid fact type values.
+var ValidFactTypes = []string{
+	FactTypeFiscalYear,
+	FactTypeBusinessRule,
+	FactTypeTerminology,
+	FactTypeConvention,
+	FactTypeEnumeration,
+	FactTypeRelationship,
+}
+
+// IsValidFactType checks if the given fact type is valid.
+func IsValidFactType(t string) bool {
+	for _, v := range ValidFactTypes {
+		if v == t {
+			return true
+		}
+	}
+	return false
+}
+
+// KnowledgeFact represents a learned business fact about the project.
+type KnowledgeFact struct {
+	ID        uuid.UUID `json:"id"`
+	ProjectID uuid.UUID `json:"project_id"`
+	FactType  string    `json:"fact_type"`
+	Key       string    `json:"key"`
+	Value     string    `json:"value"`
+	Context   string    `json:"context,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// ============================================================================
+// Chat Tool Definitions (for LLM)
+// ============================================================================
+
+// ChatTool represents a tool definition for the chat LLM.
+type ChatTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Parameters  map[string]any `json:"parameters"`
+}
+
+// Available chat tools
+var ChatToolDefinitions = []ChatTool{
+	{
+		Name:        "query_column_values",
+		Description: "Query actual values from a column in the datasource",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"table_name":  map[string]any{"type": "string", "description": "Name of the table"},
+				"column_name": map[string]any{"type": "string", "description": "Name of the column"},
+				"limit":       map[string]any{"type": "integer", "description": "Max values to return", "default": 20},
+			},
+			"required": []string{"table_name", "column_name"},
+		},
+	},
+	{
+		Name:        "query_schema_metadata",
+		Description: "Get metadata about tables or columns from schema analysis",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"table_name":  map[string]any{"type": "string", "description": "Name of the table"},
+				"column_name": map[string]any{"type": "string", "description": "Optional column name"},
+			},
+			"required": []string{"table_name"},
+		},
+	},
+	{
+		Name:        "update_entity",
+		Description: "Update an entity's description, synonyms, or column information in the ontology",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"table_name":    map[string]any{"type": "string", "description": "Name of the table/entity"},
+				"business_name": map[string]any{"type": "string", "description": "Updated business name"},
+				"description":   map[string]any{"type": "string", "description": "Updated description"},
+				"synonyms":      map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Synonyms to add"},
+				"column_updates": map[string]any{
+					"type": "array",
+					"items": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"column_name": map[string]any{"type": "string"},
+							"description": map[string]any{"type": "string"},
+							"synonyms":    map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+						},
+					},
+					"description": "Column-level updates",
+				},
+			},
+			"required": []string{"table_name"},
+		},
+	},
+	{
+		Name:        "store_knowledge",
+		Description: "Store a project-level business fact or convention",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"fact_type": map[string]any{
+					"type":        "string",
+					"enum":        ValidFactTypes,
+					"description": "Type of fact being stored",
+				},
+				"key":     map[string]any{"type": "string", "description": "Unique key for the fact"},
+				"value":   map[string]any{"type": "string", "description": "The fact value"},
+				"context": map[string]any{"type": "string", "description": "Additional context about the fact"},
+			},
+			"required": []string{"fact_type", "key", "value"},
+		},
+	},
+	{
+		Name:        "update_domain",
+		Description: "Update the domain summary description or sample questions",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"description":      map[string]any{"type": "string", "description": "Updated domain description"},
+				"sample_questions": map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Sample business questions"},
+			},
+		},
+	},
+}

--- a/pkg/models/ontology_question.go
+++ b/pkg/models/ontology_question.go
@@ -1,0 +1,197 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ============================================================================
+// Question Status
+// ============================================================================
+
+// QuestionStatus represents the current status of an ontology question.
+type QuestionStatus string
+
+const (
+	QuestionStatusPending  QuestionStatus = "pending"
+	QuestionStatusSkipped  QuestionStatus = "skipped"
+	QuestionStatusAnswered QuestionStatus = "answered"
+	QuestionStatusDeleted  QuestionStatus = "deleted"
+)
+
+// ValidQuestionStatuses contains all valid question status values.
+var ValidQuestionStatuses = []QuestionStatus{
+	QuestionStatusPending,
+	QuestionStatusSkipped,
+	QuestionStatusAnswered,
+	QuestionStatusDeleted,
+}
+
+// IsValidQuestionStatus checks if the given status is valid.
+func IsValidQuestionStatus(s QuestionStatus) bool {
+	for _, v := range ValidQuestionStatuses {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// ============================================================================
+// Question Categories
+// ============================================================================
+
+// Question category constants
+const (
+	QuestionCategoryBusinessRules = "business_rules"
+	QuestionCategoryRelationship  = "relationship"
+	QuestionCategoryTerminology   = "terminology"
+	QuestionCategoryEnumeration   = "enumeration"
+	QuestionCategoryTemporal      = "temporal"
+	QuestionCategoryDataQuality   = "data_quality"
+)
+
+// ValidQuestionCategories contains all valid question category values.
+var ValidQuestionCategories = []string{
+	QuestionCategoryBusinessRules,
+	QuestionCategoryRelationship,
+	QuestionCategoryTerminology,
+	QuestionCategoryEnumeration,
+	QuestionCategoryTemporal,
+	QuestionCategoryDataQuality,
+}
+
+// ============================================================================
+// Detected Patterns
+// ============================================================================
+
+// Detected pattern constants (why a question was generated)
+const (
+	PatternCentralEntity  = "central_entity"
+	PatternStatusColumn   = "status_column"
+	PatternTypeColumn     = "type_column"
+	PatternEnumColumn     = "enum_column"
+	PatternFKRelationship = "fk_relationship"
+	PatternOrphanTable    = "orphan_table"
+	PatternTimeSeries     = "time_series"
+)
+
+// ============================================================================
+// Question Model
+// ============================================================================
+
+// QuestionAffects tracks which schema elements a question relates to.
+type QuestionAffects struct {
+	Tables  []string `json:"tables,omitempty"`
+	Columns []string `json:"columns,omitempty"` // Format: "table.column"
+}
+
+// OntologyQuestion represents a question generated during ontology extraction.
+type OntologyQuestion struct {
+	ID               uuid.UUID        `json:"id"`
+	ProjectID        uuid.UUID        `json:"project_id"`
+	OntologyID       uuid.UUID        `json:"ontology_id"`
+	WorkflowID       *uuid.UUID       `json:"workflow_id,omitempty"`
+	ParentQuestionID *uuid.UUID       `json:"parent_question_id,omitempty"` // For follow-up traceability
+	Text             string           `json:"text"`
+	Priority         int              `json:"priority"`    // 1=highest, 5=lowest
+	IsRequired       bool             `json:"is_required"` // Required = entity not complete until answered
+	Category         string           `json:"category,omitempty"`
+	Reasoning        string           `json:"reasoning,omitempty"`
+	Affects          *QuestionAffects `json:"affects,omitempty"`
+	DetectedPattern  string           `json:"detected_pattern,omitempty"`
+	Status           QuestionStatus   `json:"status"`
+	Answer           string           `json:"answer,omitempty"`
+	AnsweredBy       *uuid.UUID       `json:"answered_by,omitempty"`
+	AnsweredAt       *time.Time       `json:"answered_at,omitempty"`
+	CreatedAt        time.Time        `json:"created_at"`
+	UpdatedAt        time.Time        `json:"updated_at"`
+}
+
+// IsPending returns true if the question has not been answered or skipped.
+func (q *OntologyQuestion) IsPending() bool {
+	return q.Status == QuestionStatusPending
+}
+
+// IsSkipped returns true if the question was skipped by the user.
+func (q *OntologyQuestion) IsSkipped() bool {
+	return q.Status == QuestionStatusSkipped
+}
+
+// IsAnswered returns true if the question was answered.
+func (q *OntologyQuestion) IsAnswered() bool {
+	return q.Status == QuestionStatusAnswered
+}
+
+// IsDeleted returns true if the question was soft-deleted.
+func (q *OntologyQuestion) IsDeleted() bool {
+	return q.Status == QuestionStatusDeleted
+}
+
+// AffectedTableNames returns the list of affected table names.
+func (q *OntologyQuestion) AffectedTableNames() []string {
+	if q.Affects == nil {
+		return nil
+	}
+	return q.Affects.Tables
+}
+
+// AffectedColumnNames returns the list of affected column names.
+func (q *OntologyQuestion) AffectedColumnNames() []string {
+	if q.Affects == nil {
+		return nil
+	}
+	return q.Affects.Columns
+}
+
+// ============================================================================
+// Question Generation Input
+// ============================================================================
+
+// QuestionGenerationInput provides context for LLM question generation.
+type QuestionGenerationInput struct {
+	Tables        []TableContext `json:"tables"`
+	Relationships []RelContext   `json:"relationships"`
+}
+
+// TableContext provides table information for question generation.
+type TableContext struct {
+	Name         string          `json:"name"`
+	RowCount     int64           `json:"row_count"`
+	IsSelected   bool            `json:"is_selected"`
+	Columns      []ColumnContext `json:"columns"`
+	RelatedCount int             `json:"related_count"`
+}
+
+// ColumnContext provides column information for question generation.
+type ColumnContext struct {
+	Name          string `json:"name"`
+	DataType      string `json:"data_type"`
+	IsPrimaryKey  bool   `json:"is_pk,omitempty"`
+	IsForeignKey  bool   `json:"is_fk,omitempty"`
+	DistinctCount *int64 `json:"distinct,omitempty"`
+	NullCount     *int64 `json:"nulls,omitempty"`
+}
+
+// RelContext provides relationship information for question generation.
+type RelContext struct {
+	SourceTable  string `json:"source"`
+	TargetTable  string `json:"target"`
+	SourceColumn string `json:"source_col"`
+	TargetColumn string `json:"target_col"`
+}
+
+// ============================================================================
+// Answer Processing Result
+// ============================================================================
+
+// AnswerResult contains the result of processing a question answer.
+type AnswerResult struct {
+	QuestionID     uuid.UUID         `json:"question_id"`
+	FollowUp       *string           `json:"follow_up,omitempty"`
+	NextQuestion   *OntologyQuestion `json:"next_question,omitempty"`
+	AllComplete    bool              `json:"all_complete"`
+	ActionsSummary string            `json:"actions_summary,omitempty"`
+	Thinking       string            `json:"thinking,omitempty"`
+}

--- a/pkg/models/ontology_workflow.go
+++ b/pkg/models/ontology_workflow.go
@@ -1,0 +1,226 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ============================================================================
+// Workflow States
+// ============================================================================
+
+// WorkflowState represents the current state of an ontology extraction workflow.
+type WorkflowState string
+
+const (
+	WorkflowStatePending       WorkflowState = "pending"
+	WorkflowStateRunning       WorkflowState = "running"
+	WorkflowStatePaused        WorkflowState = "paused"
+	WorkflowStateAwaitingInput WorkflowState = "awaiting_input" // Questions need answers
+	WorkflowStateCompleted     WorkflowState = "completed"
+	WorkflowStateFailed        WorkflowState = "failed"
+)
+
+// ValidWorkflowStates contains all valid workflow state values.
+var ValidWorkflowStates = []WorkflowState{
+	WorkflowStatePending,
+	WorkflowStateRunning,
+	WorkflowStatePaused,
+	WorkflowStateAwaitingInput,
+	WorkflowStateCompleted,
+	WorkflowStateFailed,
+}
+
+// IsValidWorkflowState checks if the given state is valid.
+func IsValidWorkflowState(s WorkflowState) bool {
+	for _, v := range ValidWorkflowStates {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// IsTerminal returns true if the workflow state is terminal (completed or failed).
+func (s WorkflowState) IsTerminal() bool {
+	return s == WorkflowStateCompleted || s == WorkflowStateFailed
+}
+
+// CanTransitionTo returns true if transitioning from this state to the target is valid.
+func (s WorkflowState) CanTransitionTo(target WorkflowState) bool {
+	switch s {
+	case WorkflowStatePending:
+		return target == WorkflowStateRunning || target == WorkflowStateFailed
+	case WorkflowStateRunning:
+		return target == WorkflowStatePaused || target == WorkflowStateAwaitingInput ||
+			target == WorkflowStateCompleted || target == WorkflowStateFailed
+	case WorkflowStatePaused:
+		return target == WorkflowStateRunning || target == WorkflowStateFailed
+	case WorkflowStateAwaitingInput:
+		// Can continue (running), complete, or fail
+		return target == WorkflowStateRunning || target == WorkflowStateCompleted || target == WorkflowStateFailed
+	case WorkflowStateCompleted, WorkflowStateFailed:
+		return target == WorkflowStatePending // Can restart
+	default:
+		return false
+	}
+}
+
+// ============================================================================
+// Workflow Progress
+// ============================================================================
+
+// WorkflowProgress tracks the progress of an ontology extraction workflow.
+type WorkflowProgress struct {
+	CurrentPhase    string  `json:"current_phase,omitempty"`
+	Current         int     `json:"current"`
+	Total           int     `json:"total"`
+	TokensPerSecond float64 `json:"tokens_per_second,omitempty"`
+	TimeRemainingMs int64   `json:"time_remaining_ms,omitempty"`
+	Message         string  `json:"message,omitempty"`
+	OntologyReady   bool    `json:"ontology_ready,omitempty"`
+}
+
+// Percentage returns the completion percentage (0-100).
+func (p *WorkflowProgress) Percentage() int {
+	if p == nil || p.Total == 0 {
+		return 0
+	}
+	return int(float64(p.Current) / float64(p.Total) * 100)
+}
+
+// Workflow phases
+const (
+	WorkflowPhaseInitializing          = "initializing"
+	WorkflowPhaseScanning              = "scanning"  // SQL-only data scanning phase
+	WorkflowPhaseAnalyzing             = "analyzing" // LLM analysis phase
+	WorkflowPhaseDescriptionProcessing = "description_processing"
+	WorkflowPhaseSchemaAnalysis        = "schema_analysis"
+	WorkflowPhaseDataProfiling         = "data_profiling"
+	WorkflowPhaseQuestionGeneration    = "question_generation"
+	WorkflowPhaseTier1Building         = "tier1_building"
+	WorkflowPhaseTier0Building         = "tier0_building"
+	WorkflowPhaseAwaitingInput         = "awaiting_input"
+	WorkflowPhaseCompleting            = "completing"
+)
+
+// ============================================================================
+// Workflow Tasks
+// ============================================================================
+
+// WorkflowTask represents a single task in the workflow queue.
+type WorkflowTask struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Status      string `json:"status"` // queued, processing, complete, failed
+	RequiresLLM bool   `json:"requires_llm"`
+	TableName   string `json:"table_name,omitempty"` // For per-table tasks
+	Error       string `json:"error,omitempty"`
+}
+
+// Task statuses
+const (
+	TaskStatusQueued     = "queued"
+	TaskStatusProcessing = "processing"
+	TaskStatusComplete   = "complete"
+	TaskStatusFailed     = "failed"
+	TaskStatusPaused     = "paused"
+)
+
+// Task types (used as Name field)
+const (
+	TaskTypeProfileTable      = "profile_table"
+	TaskTypeUnderstandSchema  = "understand_schema"
+	TaskTypeBuildTier0And1    = "build_tier0_and_tier1"
+	TaskTypeGenerateQuestions = "generate_questions"
+)
+
+// ============================================================================
+// Workflow Configuration
+// ============================================================================
+
+// WorkflowConfig contains configuration for an ontology extraction workflow.
+type WorkflowConfig struct {
+	DatasourceID       uuid.UUID   `json:"datasource_id"`
+	IncludeAllTables   bool        `json:"include_all_tables,omitempty"`
+	SelectedTableIDs   []uuid.UUID `json:"selected_table_ids,omitempty"`
+	SkipDataProfiling  bool        `json:"skip_data_profiling,omitempty"`
+	SkipQuestions      bool        `json:"skip_questions,omitempty"`
+	MaxTablesPerBatch  int         `json:"max_tables_per_batch,omitempty"`
+	ProjectDescription string      `json:"project_description,omitempty"`
+}
+
+// DefaultWorkflowConfig returns a default configuration.
+func DefaultWorkflowConfig() *WorkflowConfig {
+	return &WorkflowConfig{
+		IncludeAllTables:  true,
+		MaxTablesPerBatch: 20,
+	}
+}
+
+// ============================================================================
+// Ontology Workflow Model
+// ============================================================================
+
+// OntologyWorkflow represents an ontology extraction workflow.
+type OntologyWorkflow struct {
+	ID           uuid.UUID         `json:"id"`
+	ProjectID    uuid.UUID         `json:"project_id"`
+	OntologyID   uuid.UUID         `json:"ontology_id"`
+	State        WorkflowState     `json:"state"`
+	Progress     *WorkflowProgress `json:"progress,omitempty"`
+	TaskQueue    []WorkflowTask    `json:"task_queue,omitempty"`
+	Config       *WorkflowConfig   `json:"config,omitempty"`
+	ErrorMessage string            `json:"error_message,omitempty"`
+	StartedAt    *time.Time        `json:"started_at,omitempty"`
+	CompletedAt  *time.Time        `json:"completed_at,omitempty"`
+	CreatedAt    time.Time         `json:"created_at"`
+	UpdatedAt    time.Time         `json:"updated_at"`
+
+	// Ownership fields for multi-server robustness
+	OwnerID       *uuid.UUID `json:"owner_id,omitempty"`       // Server instance that owns this workflow
+	LastHeartbeat *time.Time `json:"last_heartbeat,omitempty"` // Last heartbeat from owner
+}
+
+// IsRunning returns true if the workflow is currently executing.
+func (w *OntologyWorkflow) IsRunning() bool {
+	return w.State == WorkflowStateRunning
+}
+
+// IsPaused returns true if the workflow is paused.
+func (w *OntologyWorkflow) IsPaused() bool {
+	return w.State == WorkflowStatePaused
+}
+
+// IsComplete returns true if the workflow completed successfully.
+func (w *OntologyWorkflow) IsComplete() bool {
+	return w.State == WorkflowStateCompleted
+}
+
+// HasFailed returns true if the workflow failed.
+func (w *OntologyWorkflow) HasFailed() bool {
+	return w.State == WorkflowStateFailed
+}
+
+// PendingTaskCount returns the number of tasks not yet complete.
+func (w *OntologyWorkflow) PendingTaskCount() int {
+	count := 0
+	for _, task := range w.TaskQueue {
+		if task.Status == TaskStatusQueued || task.Status == TaskStatusProcessing {
+			count++
+		}
+	}
+	return count
+}
+
+// CompletedTaskCount returns the number of completed tasks.
+func (w *OntologyWorkflow) CompletedTaskCount() int {
+	count := 0
+	for _, task := range w.TaskQueue {
+		if task.Status == TaskStatusComplete {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/models/workflow_state.go
+++ b/pkg/models/workflow_state.go
@@ -1,0 +1,295 @@
+package models
+
+import (
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ============================================================================
+// Workflow Entity Types
+// ============================================================================
+
+// WorkflowEntityType represents the type of entity being tracked in workflow state.
+type WorkflowEntityType string
+
+const (
+	WorkflowEntityTypeGlobal WorkflowEntityType = "global"
+	WorkflowEntityTypeTable  WorkflowEntityType = "table"
+	WorkflowEntityTypeColumn WorkflowEntityType = "column"
+)
+
+// ValidWorkflowEntityTypes contains all valid entity type values.
+var ValidWorkflowEntityTypes = []WorkflowEntityType{
+	WorkflowEntityTypeGlobal,
+	WorkflowEntityTypeTable,
+	WorkflowEntityTypeColumn,
+}
+
+// IsValidWorkflowEntityType checks if the given type is valid.
+func IsValidWorkflowEntityType(t WorkflowEntityType) bool {
+	for _, v := range ValidWorkflowEntityTypes {
+		if v == t {
+			return true
+		}
+	}
+	return false
+}
+
+// ============================================================================
+// Workflow Entity Status
+// ============================================================================
+
+// WorkflowEntityStatus represents the extraction status of an entity.
+// State machine:
+//
+//	pending → scanning → scanned → analyzing → complete
+//	                                    ↓
+//	                              needs_input → (answer) → analyzing
+//
+//	Any state can transition to: failed
+type WorkflowEntityStatus string
+
+const (
+	WorkflowEntityStatusPending    WorkflowEntityStatus = "pending"
+	WorkflowEntityStatusScanning   WorkflowEntityStatus = "scanning"
+	WorkflowEntityStatusScanned    WorkflowEntityStatus = "scanned"
+	WorkflowEntityStatusAnalyzing  WorkflowEntityStatus = "analyzing"
+	WorkflowEntityStatusComplete   WorkflowEntityStatus = "complete"
+	WorkflowEntityStatusNeedsInput WorkflowEntityStatus = "needs_input"
+	WorkflowEntityStatusFailed     WorkflowEntityStatus = "failed"
+)
+
+// ValidWorkflowEntityStatuses contains all valid status values.
+var ValidWorkflowEntityStatuses = []WorkflowEntityStatus{
+	WorkflowEntityStatusPending,
+	WorkflowEntityStatusScanning,
+	WorkflowEntityStatusScanned,
+	WorkflowEntityStatusAnalyzing,
+	WorkflowEntityStatusComplete,
+	WorkflowEntityStatusNeedsInput,
+	WorkflowEntityStatusFailed,
+}
+
+// IsValidWorkflowEntityStatus checks if the given status is valid.
+func IsValidWorkflowEntityStatus(s WorkflowEntityStatus) bool {
+	for _, v := range ValidWorkflowEntityStatuses {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// IsTerminal returns true if the status is a terminal state (complete or failed).
+func (s WorkflowEntityStatus) IsTerminal() bool {
+	return s == WorkflowEntityStatusComplete || s == WorkflowEntityStatusFailed
+}
+
+// CanTransitionTo returns true if transitioning from this status to the target is valid.
+func (s WorkflowEntityStatus) CanTransitionTo(target WorkflowEntityStatus) bool {
+	// Any state can transition to failed
+	if target == WorkflowEntityStatusFailed {
+		return true
+	}
+
+	switch s {
+	case WorkflowEntityStatusPending:
+		return target == WorkflowEntityStatusScanning
+	case WorkflowEntityStatusScanning:
+		return target == WorkflowEntityStatusScanned
+	case WorkflowEntityStatusScanned:
+		return target == WorkflowEntityStatusAnalyzing
+	case WorkflowEntityStatusAnalyzing:
+		return target == WorkflowEntityStatusComplete || target == WorkflowEntityStatusNeedsInput
+	case WorkflowEntityStatusNeedsInput:
+		return target == WorkflowEntityStatusAnalyzing
+	case WorkflowEntityStatusComplete, WorkflowEntityStatusFailed:
+		return false // Terminal states
+	default:
+		return false
+	}
+}
+
+// ============================================================================
+// Workflow Entity State Model
+// ============================================================================
+
+// WorkflowEntityState tracks the state of an entity during ontology extraction.
+// This is ephemeral data that is deleted when the workflow completes.
+// Note: Named WorkflowEntityState to avoid collision with WorkflowState (string type in ontology_workflow.go).
+type WorkflowEntityState struct {
+	ID              uuid.UUID            `json:"id"`
+	ProjectID       uuid.UUID            `json:"project_id"`
+	OntologyID      uuid.UUID            `json:"ontology_id"`
+	WorkflowID      uuid.UUID            `json:"workflow_id"`
+	EntityType      WorkflowEntityType   `json:"entity_type"`
+	EntityKey       string               `json:"entity_key"`
+	Status          WorkflowEntityStatus `json:"status"`
+	StateData       *WorkflowStateData   `json:"state_data,omitempty"`
+	DataFingerprint *string              `json:"data_fingerprint,omitempty"`
+	LastError       *string              `json:"last_error,omitempty"`
+	RetryCount      int                  `json:"retry_count"`
+	CreatedAt       time.Time            `json:"created_at"`
+	UpdatedAt       time.Time            `json:"updated_at"`
+}
+
+// WorkflowStateData contains all extraction state for an entity.
+// This JSONB field holds everything needed during extraction:
+// - gathered: Data from SQL scanning phase (column stats, sample values, etc.)
+// - llm_analysis: Intermediate LLM reasoning and conclusions
+// - questions: Questions generated for this entity
+// - answers: User answers (can cascade to update other entities)
+type WorkflowStateData struct {
+	Gathered    map[string]any     `json:"gathered,omitempty"`
+	LLMAnalysis map[string]any     `json:"llm_analysis,omitempty"`
+	Questions   []WorkflowQuestion `json:"questions,omitempty"`
+	Answers     []WorkflowAnswer   `json:"answers,omitempty"`
+}
+
+// ============================================================================
+// Workflow Data Types
+// ============================================================================
+
+// ColumnScanData holds statistics from SQL scanning (no LLM required).
+// This data is collected in the Scanning phase before LLM analysis.
+// Stored in WorkflowStateData.Gathered during extraction, not persisted to ontology.
+type ColumnScanData struct {
+	RowCount         int64     `json:"row_count"`
+	NonNullCount     int64     `json:"non_null_count"`
+	DistinctCount    int64     `json:"distinct_count"`
+	NullPercent      float64   `json:"null_percent"`
+	SampleValues     []string  `json:"sample_values,omitempty"`     // Up to 50 distinct values
+	IsEnumCandidate  bool      `json:"is_enum_candidate"`           // distinct_count <= 50 AND < 10% of rows
+	ValueFingerprint string    `json:"value_fingerprint,omitempty"` // SHA256 of sorted values for change detection
+	ScannedAt        time.Time `json:"scanned_at"`
+}
+
+// ============================================================================
+// Workflow Question/Answer Types
+// ============================================================================
+
+// WorkflowQuestion is the in-workflow question representation.
+// This is stored in state_data.questions and is ephemeral (deleted with workflow).
+type WorkflowQuestion struct {
+	ID              string           `json:"id"`
+	Text            string           `json:"text"`
+	Priority        int              `json:"priority"`
+	IsRequired      bool             `json:"is_required"`
+	Category        string           `json:"category,omitempty"`
+	Reasoning       string           `json:"reasoning,omitempty"`
+	Affects         *QuestionAffects `json:"affects,omitempty"`
+	DetectedPattern string           `json:"detected_pattern,omitempty"`
+	Status          string           `json:"status"` // pending, skipped, answered
+	Answer          string           `json:"answer,omitempty"`
+	AnsweredBy      string           `json:"answered_by,omitempty"`
+	AnsweredAt      *time.Time       `json:"answered_at,omitempty"`
+	ParentID        string           `json:"parent_id,omitempty"` // For follow-ups
+}
+
+// WorkflowAnswer records a user's answer with all actions taken.
+// This is stored in state_data.answers for audit trail.
+type WorkflowAnswer struct {
+	QuestionID     string    `json:"question_id"`
+	Answer         string    `json:"answer"`
+	AnsweredBy     string    `json:"answered_by"`
+	AnsweredAt     time.Time `json:"answered_at"`
+	EntityUpdates  []string  `json:"entity_updates,omitempty"`  // Summary of what was updated
+	ColumnUpdates  []string  `json:"column_updates,omitempty"`  // Summary of what was updated
+	KnowledgeFacts []string  `json:"knowledge_facts,omitempty"` // IDs of facts created
+	FollowUpID     string    `json:"follow_up_id,omitempty"`    // ID of follow-up if created
+}
+
+// IsPending returns true if the question is pending.
+func (q *WorkflowQuestion) IsPending() bool {
+	return q.Status == string(QuestionStatusPending)
+}
+
+// IsAnswered returns true if the question is answered.
+func (q *WorkflowQuestion) IsAnswered() bool {
+	return q.Status == string(QuestionStatusAnswered)
+}
+
+// ============================================================================
+// WorkflowEntityState Helper Methods
+// ============================================================================
+
+// IsGlobal returns true if this is a global entity.
+func (ws *WorkflowEntityState) IsGlobal() bool {
+	return ws.EntityType == WorkflowEntityTypeGlobal
+}
+
+// IsTable returns true if this is a table entity.
+func (ws *WorkflowEntityState) IsTable() bool {
+	return ws.EntityType == WorkflowEntityTypeTable
+}
+
+// IsColumn returns true if this is a column entity.
+func (ws *WorkflowEntityState) IsColumn() bool {
+	return ws.EntityType == WorkflowEntityTypeColumn
+}
+
+// TableName returns the table name from the entity key.
+// For global: returns ""
+// For table: returns the entity key (e.g., "orders")
+// For column: returns the table part (e.g., "orders" from "orders.status")
+func (ws *WorkflowEntityState) TableName() string {
+	switch ws.EntityType {
+	case WorkflowEntityTypeGlobal:
+		return ""
+	case WorkflowEntityTypeTable:
+		return ws.EntityKey
+	case WorkflowEntityTypeColumn:
+		parts := strings.SplitN(ws.EntityKey, ".", 2)
+		if len(parts) >= 1 {
+			return parts[0]
+		}
+		return ""
+	default:
+		return ""
+	}
+}
+
+// ColumnName returns the column name for column entities, empty string otherwise.
+func (ws *WorkflowEntityState) ColumnName() string {
+	if ws.EntityType != WorkflowEntityTypeColumn {
+		return ""
+	}
+	parts := strings.SplitN(ws.EntityKey, ".", 2)
+	if len(parts) == 2 {
+		return parts[1]
+	}
+	return ""
+}
+
+// ============================================================================
+// Entity Key Helpers
+// ============================================================================
+
+// GlobalEntityKey returns the entity key for the global entity.
+func GlobalEntityKey() string {
+	return ""
+}
+
+// TableEntityKey returns the entity key for a table entity.
+// Entity keys never include database schema prefix (e.g., use "orders" not "public.orders").
+func TableEntityKey(tableName string) string {
+	return tableName
+}
+
+// ColumnEntityKey returns the entity key for a column entity.
+// Format: "table_name.column_name" (e.g., "orders.status").
+func ColumnEntityKey(tableName, columnName string) string {
+	return tableName + "." + columnName
+}
+
+// ParseColumnEntityKey extracts table and column names from a column entity key.
+// Returns ("", "") if the key is not a valid column key.
+func ParseColumnEntityKey(entityKey string) (tableName, columnName string) {
+	parts := strings.SplitN(entityKey, ".", 2)
+	if len(parts) != 2 {
+		return "", ""
+	}
+	return parts[0], parts[1]
+}

--- a/pkg/repositories/conversation_repository.go
+++ b/pkg/repositories/conversation_repository.go
@@ -1,0 +1,294 @@
+package repositories
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+)
+
+// ConversationRepository provides data access for LLM conversation records.
+type ConversationRepository interface {
+	Save(ctx context.Context, conv *models.LLMConversation) error
+	Update(ctx context.Context, conv *models.LLMConversation) error
+	GetByProject(ctx context.Context, projectID uuid.UUID, limit int) ([]*models.LLMConversation, error)
+	GetByContext(ctx context.Context, projectID uuid.UUID, key, value string) ([]*models.LLMConversation, error)
+	GetByConversationID(ctx context.Context, conversationID uuid.UUID) ([]*models.LLMConversation, error)
+}
+
+type conversationRepository struct{}
+
+// NewConversationRepository creates a new ConversationRepository.
+func NewConversationRepository() ConversationRepository {
+	return &conversationRepository{}
+}
+
+var _ ConversationRepository = (*conversationRepository)(nil)
+
+func (r *conversationRepository) Save(ctx context.Context, conv *models.LLMConversation) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	conv.CreatedAt = time.Now()
+	if conv.ID == uuid.Nil {
+		conv.ID = uuid.New()
+	}
+
+	// Marshal JSONB fields
+	requestMessagesJSON, err := json.Marshal(conv.RequestMessages)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request_messages: %w", err)
+	}
+
+	var requestToolsJSON, responseToolCallsJSON, contextJSON []byte
+	if conv.RequestTools != nil {
+		requestToolsJSON, err = json.Marshal(conv.RequestTools)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request_tools: %w", err)
+		}
+	}
+	if conv.ResponseToolCalls != nil {
+		responseToolCallsJSON, err = json.Marshal(conv.ResponseToolCalls)
+		if err != nil {
+			return fmt.Errorf("failed to marshal response_tool_calls: %w", err)
+		}
+	}
+	if conv.Context != nil {
+		contextJSON, err = json.Marshal(conv.Context)
+		if err != nil {
+			return fmt.Errorf("failed to marshal context: %w", err)
+		}
+	}
+
+	// Use NULL for empty error_message (success cases)
+	var errorMessage *string
+	if conv.ErrorMessage != "" {
+		errorMessage = &conv.ErrorMessage
+	}
+
+	query := `
+		INSERT INTO engine_llm_conversations (
+			id, project_id, context, conversation_id, iteration,
+			endpoint, model, request_messages, request_tools, temperature,
+			response_content, response_tool_calls,
+			prompt_tokens, completion_tokens, total_tokens, duration_ms,
+			status, error_message, created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`
+
+	_, err = scope.Conn.Exec(ctx, query,
+		conv.ID, conv.ProjectID, contextJSON, conv.ConversationID, conv.Iteration,
+		conv.Endpoint, conv.Model, requestMessagesJSON, requestToolsJSON, conv.Temperature,
+		conv.ResponseContent, responseToolCallsJSON,
+		conv.PromptTokens, conv.CompletionTokens, conv.TotalTokens, conv.DurationMs,
+		conv.Status, errorMessage, conv.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to save llm conversation: %w", err)
+	}
+
+	return nil
+}
+
+func (r *conversationRepository) Update(ctx context.Context, conv *models.LLMConversation) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	// Marshal JSONB fields for response
+	var responseToolCallsJSON []byte
+	var err error
+	if conv.ResponseToolCalls != nil {
+		responseToolCallsJSON, err = json.Marshal(conv.ResponseToolCalls)
+		if err != nil {
+			return fmt.Errorf("failed to marshal response_tool_calls: %w", err)
+		}
+	}
+
+	// Use NULL for empty error_message (success cases)
+	var errorMessage *string
+	if conv.ErrorMessage != "" {
+		errorMessage = &conv.ErrorMessage
+	}
+
+	query := `
+		UPDATE engine_llm_conversations
+		SET response_content = $2,
+		    response_tool_calls = $3,
+		    prompt_tokens = $4,
+		    completion_tokens = $5,
+		    total_tokens = $6,
+		    duration_ms = $7,
+		    status = $8,
+		    error_message = $9
+		WHERE id = $1`
+
+	result, err := scope.Conn.Exec(ctx, query,
+		conv.ID,
+		conv.ResponseContent, responseToolCallsJSON,
+		conv.PromptTokens, conv.CompletionTokens, conv.TotalTokens, conv.DurationMs,
+		conv.Status, errorMessage,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update llm conversation: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("conversation not found: %s", conv.ID)
+	}
+
+	return nil
+}
+
+func (r *conversationRepository) GetByProject(ctx context.Context, projectID uuid.UUID, limit int) ([]*models.LLMConversation, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT id, project_id, context, conversation_id, iteration,
+		       endpoint, model, request_messages, request_tools, temperature,
+		       response_content, response_tool_calls,
+		       prompt_tokens, completion_tokens, total_tokens, duration_ms,
+		       status, error_message, created_at
+		FROM engine_llm_conversations
+		WHERE project_id = $1
+		ORDER BY created_at DESC
+		LIMIT $2`
+
+	rows, err := scope.Conn.Query(ctx, query, projectID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query conversations: %w", err)
+	}
+	defer rows.Close()
+
+	return scanConversationRows(rows)
+}
+
+// GetByContext queries conversations by a key-value pair in the context JSONB.
+// Example: GetByContext(ctx, projectID, "workflow_id", "uuid-string")
+func (r *conversationRepository) GetByContext(ctx context.Context, projectID uuid.UUID, key, value string) ([]*models.LLMConversation, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT id, project_id, context, conversation_id, iteration,
+		       endpoint, model, request_messages, request_tools, temperature,
+		       response_content, response_tool_calls,
+		       prompt_tokens, completion_tokens, total_tokens, duration_ms,
+		       status, error_message, created_at
+		FROM engine_llm_conversations
+		WHERE project_id = $1 AND context->>$2 = $3
+		ORDER BY created_at ASC`
+
+	rows, err := scope.Conn.Query(ctx, query, projectID, key, value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query conversations: %w", err)
+	}
+	defer rows.Close()
+
+	return scanConversationRows(rows)
+}
+
+func (r *conversationRepository) GetByConversationID(ctx context.Context, conversationID uuid.UUID) ([]*models.LLMConversation, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT id, project_id, context, conversation_id, iteration,
+		       endpoint, model, request_messages, request_tools, temperature,
+		       response_content, response_tool_calls,
+		       prompt_tokens, completion_tokens, total_tokens, duration_ms,
+		       status, error_message, created_at
+		FROM engine_llm_conversations
+		WHERE conversation_id = $1
+		ORDER BY iteration ASC`
+
+	rows, err := scope.Conn.Query(ctx, query, conversationID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query conversations: %w", err)
+	}
+	defer rows.Close()
+
+	return scanConversationRows(rows)
+}
+
+func scanConversationRows(rows pgx.Rows) ([]*models.LLMConversation, error) {
+	var conversations []*models.LLMConversation
+
+	for rows.Next() {
+		conv, err := scanConversationRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		conversations = append(conversations, conv)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	return conversations, nil
+}
+
+func scanConversationRow(row pgx.Row) (*models.LLMConversation, error) {
+	var conv models.LLMConversation
+	var contextJSON, requestMessagesJSON, requestToolsJSON, responseToolCallsJSON []byte
+	var errorMessage *string
+
+	err := row.Scan(
+		&conv.ID, &conv.ProjectID, &contextJSON, &conv.ConversationID, &conv.Iteration,
+		&conv.Endpoint, &conv.Model, &requestMessagesJSON, &requestToolsJSON, &conv.Temperature,
+		&conv.ResponseContent, &responseToolCallsJSON,
+		&conv.PromptTokens, &conv.CompletionTokens, &conv.TotalTokens, &conv.DurationMs,
+		&conv.Status, &errorMessage, &conv.CreatedAt,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, err
+		}
+		return nil, fmt.Errorf("failed to scan conversation: %w", err)
+	}
+
+	// Convert nullable error_message
+	if errorMessage != nil {
+		conv.ErrorMessage = *errorMessage
+	}
+
+	// Unmarshal JSONB fields
+	if len(contextJSON) > 0 {
+		if err := json.Unmarshal(contextJSON, &conv.Context); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal context: %w", err)
+		}
+	}
+	if len(requestMessagesJSON) > 0 {
+		if err := json.Unmarshal(requestMessagesJSON, &conv.RequestMessages); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal request_messages: %w", err)
+		}
+	}
+	if len(requestToolsJSON) > 0 {
+		if err := json.Unmarshal(requestToolsJSON, &conv.RequestTools); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal request_tools: %w", err)
+		}
+	}
+	if len(responseToolCallsJSON) > 0 {
+		if err := json.Unmarshal(responseToolCallsJSON, &conv.ResponseToolCalls); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal response_tool_calls: %w", err)
+		}
+	}
+
+	return &conv, nil
+}

--- a/pkg/repositories/conversation_repository_test.go
+++ b/pkg/repositories/conversation_repository_test.go
@@ -1,0 +1,512 @@
+//go:build integration
+
+package repositories
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/testhelpers"
+)
+
+// conversationTestContext holds test dependencies for conversation repository tests.
+type conversationTestContext struct {
+	t          *testing.T
+	engineDB   *testhelpers.EngineDB
+	repo       ConversationRepository
+	projectID  uuid.UUID
+	ontologyID uuid.UUID
+	workflowID uuid.UUID
+}
+
+// setupConversationTest initializes the test context with shared testcontainer.
+func setupConversationTest(t *testing.T) *conversationTestContext {
+	engineDB := testhelpers.GetEngineDB(t)
+	tc := &conversationTestContext{
+		t:          t,
+		engineDB:   engineDB,
+		repo:       NewConversationRepository(),
+		projectID:  uuid.MustParse("00000000-0000-0000-0000-000000000050"),
+		ontologyID: uuid.MustParse("00000000-0000-0000-0000-000000000052"),
+		workflowID: uuid.MustParse("00000000-0000-0000-0000-000000000051"),
+	}
+	tc.ensureTestData()
+	return tc
+}
+
+// ensureTestData creates the test project, ontology, and workflow if they don't exist.
+func (tc *conversationTestContext) ensureTestData() {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create scope for data setup: %v", err)
+	}
+	defer scope.Close()
+
+	// Create project
+	_, err = scope.Conn.Exec(ctx, `
+		INSERT INTO engine_projects (id, name, status)
+		VALUES ($1, $2, 'active')
+		ON CONFLICT (id) DO NOTHING
+	`, tc.projectID, "Conversation Test Project")
+	if err != nil {
+		tc.t.Fatalf("failed to ensure test project: %v", err)
+	}
+
+	// Create ontology (required for workflow FK)
+	now := time.Now()
+	_, err = scope.Conn.Exec(ctx, `
+		INSERT INTO engine_ontologies (id, project_id, is_active, created_at, updated_at)
+		VALUES ($1, $2, true, $3, $3)
+		ON CONFLICT (id) DO NOTHING
+	`, tc.ontologyID, tc.projectID, now)
+	if err != nil {
+		tc.t.Fatalf("failed to ensure test ontology: %v", err)
+	}
+
+	// Create workflow (config contains datasource_id)
+	_, err = scope.Conn.Exec(ctx, `
+		INSERT INTO engine_ontology_workflows (id, project_id, ontology_id, state, progress, task_queue, config, created_at, updated_at)
+		VALUES ($1, $2, $3, 'pending', '{}', '[]', '{}', $4, $4)
+		ON CONFLICT (id) DO NOTHING
+	`, tc.workflowID, tc.projectID, tc.ontologyID, now)
+	if err != nil {
+		tc.t.Fatalf("failed to ensure test workflow: %v", err)
+	}
+}
+
+// cleanup removes test conversations.
+func (tc *conversationTestContext) cleanup() {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create scope for cleanup: %v", err)
+	}
+	defer scope.Close()
+
+	_, _ = scope.Conn.Exec(ctx, "DELETE FROM engine_llm_conversations WHERE project_id = $1", tc.projectID)
+}
+
+// createTestContext returns a context with tenant scope.
+func (tc *conversationTestContext) createTestContext() (context.Context, func()) {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create tenant scope: %v", err)
+	}
+	ctx = database.SetTenantScope(ctx, scope)
+	return ctx, func() { scope.Close() }
+}
+
+// createTestConversation creates a conversation for testing.
+func (tc *conversationTestContext) createTestConversation(ctx context.Context, model string, status string) *models.LLMConversation {
+	tc.t.Helper()
+	temp := 0.7
+	promptTokens := 100
+	completionTokens := 50
+	totalTokens := 150
+
+	conv := &models.LLMConversation{
+		ID:               uuid.New(),
+		ProjectID:        tc.projectID,
+		Iteration:        1,
+		Endpoint:         "https://api.openai.com/v1",
+		Model:            model,
+		RequestMessages:  []any{map[string]string{"role": "user", "content": "Hello"}},
+		Temperature:      &temp,
+		ResponseContent:  "Hi there!",
+		PromptTokens:     &promptTokens,
+		CompletionTokens: &completionTokens,
+		TotalTokens:      &totalTokens,
+		DurationMs:       250,
+		Status:           status,
+	}
+
+	err := tc.repo.Save(ctx, conv)
+	if err != nil {
+		tc.t.Fatalf("failed to create test conversation: %v", err)
+	}
+	return conv
+}
+
+// ============================================================================
+// Save Tests
+// ============================================================================
+
+func TestConversationRepository_Save_Success(t *testing.T) {
+	tc := setupConversationTest(t)
+	defer tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	temp := 0.5
+	promptTokens := 10
+	completionTokens := 5
+	totalTokens := 15
+
+	conv := &models.LLMConversation{
+		ProjectID:       tc.projectID,
+		Context:         map[string]any{"workflow_id": tc.workflowID.String()},
+		Iteration:       1,
+		Endpoint:        "https://api.openai.com/v1",
+		Model:           "gpt-4",
+		RequestMessages: []any{map[string]string{"role": "system", "content": "Be helpful"}},
+		RequestTools: []any{map[string]any{
+			"type": "function",
+			"function": map[string]string{
+				"name":        "get_weather",
+				"description": "Get weather info",
+			},
+		}},
+		Temperature:       &temp,
+		ResponseContent:   "Hello!",
+		ResponseToolCalls: []any{map[string]string{"id": "call_1", "function": "get_weather"}},
+		PromptTokens:      &promptTokens,
+		CompletionTokens:  &completionTokens,
+		TotalTokens:       &totalTokens,
+		DurationMs:        150,
+		Status:            models.LLMConversationStatusSuccess,
+	}
+
+	err := tc.repo.Save(ctx, conv)
+	if err != nil {
+		t.Fatalf("failed to save conversation: %v", err)
+	}
+
+	// Verify ID was generated
+	if conv.ID == uuid.Nil {
+		t.Error("expected ID to be generated")
+	}
+
+	// Verify CreatedAt was set
+	if conv.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be set")
+	}
+}
+
+func TestConversationRepository_Save_WithError(t *testing.T) {
+	tc := setupConversationTest(t)
+	defer tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	conv := &models.LLMConversation{
+		ProjectID:       tc.projectID,
+		Iteration:       1,
+		Endpoint:        "https://api.openai.com/v1",
+		Model:           "gpt-4",
+		RequestMessages: []any{map[string]string{"role": "user", "content": "Hello"}},
+		DurationMs:      100,
+		Status:          models.LLMConversationStatusError,
+		ErrorMessage:    "Rate limit exceeded",
+		ResponseContent: "",
+	}
+
+	err := tc.repo.Save(ctx, conv)
+	if err != nil {
+		t.Fatalf("failed to save error conversation: %v", err)
+	}
+}
+
+func TestConversationRepository_Save_NullableFieldsAsNil(t *testing.T) {
+	tc := setupConversationTest(t)
+	defer tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Save with all nullable fields as nil
+	conv := &models.LLMConversation{
+		ProjectID:        tc.projectID,
+		Context:          nil, // nullable
+		ConversationID:   nil, // nullable
+		Iteration:        1,
+		Endpoint:         "https://api.openai.com/v1",
+		Model:            "gpt-4",
+		RequestMessages:  []any{map[string]string{"role": "user", "content": "Test"}},
+		RequestTools:     nil, // nullable
+		Temperature:      nil, // nullable
+		ResponseContent:  "Response",
+		PromptTokens:     nil, // nullable
+		CompletionTokens: nil,
+		TotalTokens:      nil,
+		DurationMs:       50,
+		Status:           models.LLMConversationStatusSuccess,
+		ErrorMessage:     "", // Should be stored as NULL
+	}
+
+	err := tc.repo.Save(ctx, conv)
+	if err != nil {
+		t.Fatalf("failed to save conversation with nil fields: %v", err)
+	}
+}
+
+// ============================================================================
+// GetByProject Tests
+// ============================================================================
+
+func TestConversationRepository_GetByProject_ReturnsConversations(t *testing.T) {
+	tc := setupConversationTest(t)
+	defer tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create test conversations
+	conv1 := tc.createTestConversation(ctx, "gpt-4", models.LLMConversationStatusSuccess)
+	time.Sleep(10 * time.Millisecond) // Ensure different timestamps
+	conv2 := tc.createTestConversation(ctx, "gpt-3.5-turbo", models.LLMConversationStatusSuccess)
+
+	// Fetch
+	conversations, err := tc.repo.GetByProject(ctx, tc.projectID, 10)
+	if err != nil {
+		t.Fatalf("failed to get conversations: %v", err)
+	}
+
+	if len(conversations) != 2 {
+		t.Fatalf("expected 2 conversations, got %d", len(conversations))
+	}
+
+	// Should be ordered by created_at DESC (newest first)
+	if conversations[0].ID != conv2.ID {
+		t.Error("expected newest conversation first")
+	}
+	if conversations[1].ID != conv1.ID {
+		t.Error("expected older conversation second")
+	}
+}
+
+func TestConversationRepository_GetByProject_RespectsLimit(t *testing.T) {
+	tc := setupConversationTest(t)
+	defer tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create 5 conversations
+	for i := 0; i < 5; i++ {
+		tc.createTestConversation(ctx, "gpt-4", models.LLMConversationStatusSuccess)
+	}
+
+	// Fetch with limit 3
+	conversations, err := tc.repo.GetByProject(ctx, tc.projectID, 3)
+	if err != nil {
+		t.Fatalf("failed to get conversations: %v", err)
+	}
+
+	if len(conversations) != 3 {
+		t.Errorf("expected 3 conversations (limit), got %d", len(conversations))
+	}
+}
+
+func TestConversationRepository_GetByProject_EmptyResult(t *testing.T) {
+	tc := setupConversationTest(t)
+	defer tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Don't create any conversations
+	conversations, err := tc.repo.GetByProject(ctx, tc.projectID, 10)
+	if err != nil {
+		t.Fatalf("failed to get conversations: %v", err)
+	}
+
+	if len(conversations) != 0 {
+		t.Errorf("expected 0 conversations, got %d", len(conversations))
+	}
+}
+
+// ============================================================================
+// GetByContext Tests
+// ============================================================================
+
+func TestConversationRepository_GetByContext_ReturnsConversations(t *testing.T) {
+	tc := setupConversationTest(t)
+	defer tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create conversations with context
+	for i := 0; i < 3; i++ {
+		conv := &models.LLMConversation{
+			ProjectID:       tc.projectID,
+			Context:         map[string]any{"workflow_id": tc.workflowID.String()},
+			Iteration:       i + 1,
+			Endpoint:        "https://api.openai.com/v1",
+			Model:           "gpt-4",
+			RequestMessages: []any{map[string]string{"role": "user", "content": "Test"}},
+			DurationMs:      100,
+			Status:          models.LLMConversationStatusSuccess,
+		}
+		if err := tc.repo.Save(ctx, conv); err != nil {
+			t.Fatalf("failed to save conversation: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Fetch by context key-value
+	conversations, err := tc.repo.GetByContext(ctx, tc.projectID, "workflow_id", tc.workflowID.String())
+	if err != nil {
+		t.Fatalf("failed to get conversations: %v", err)
+	}
+
+	if len(conversations) != 3 {
+		t.Fatalf("expected 3 conversations, got %d", len(conversations))
+	}
+
+	// Should be ordered by created_at ASC
+	for i, conv := range conversations {
+		if conv.Iteration != i+1 {
+			t.Errorf("expected iteration %d, got %d", i+1, conv.Iteration)
+		}
+	}
+}
+
+// ============================================================================
+// GetByConversationID Tests
+// ============================================================================
+
+func TestConversationRepository_GetByConversationID_ReturnsConversations(t *testing.T) {
+	tc := setupConversationTest(t)
+	defer tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	conversationID := uuid.New()
+
+	// Create conversations with same conversation ID (multi-turn)
+	for i := 0; i < 3; i++ {
+		conv := &models.LLMConversation{
+			ProjectID:       tc.projectID,
+			ConversationID:  &conversationID,
+			Iteration:       i + 1,
+			Endpoint:        "https://api.openai.com/v1",
+			Model:           "gpt-4",
+			RequestMessages: []any{map[string]string{"role": "user", "content": "Test"}},
+			DurationMs:      100,
+			Status:          models.LLMConversationStatusSuccess,
+		}
+		if err := tc.repo.Save(ctx, conv); err != nil {
+			t.Fatalf("failed to save conversation: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Fetch by conversation ID
+	conversations, err := tc.repo.GetByConversationID(ctx, conversationID)
+	if err != nil {
+		t.Fatalf("failed to get conversations: %v", err)
+	}
+
+	if len(conversations) != 3 {
+		t.Fatalf("expected 3 conversations, got %d", len(conversations))
+	}
+
+	// Should be ordered by iteration ASC
+	for i, conv := range conversations {
+		if conv.Iteration != i+1 {
+			t.Errorf("expected iteration %d, got %d", i+1, conv.Iteration)
+		}
+	}
+}
+
+// ============================================================================
+// JSONB Field Tests
+// ============================================================================
+
+func TestConversationRepository_JSONBFieldsRoundTrip(t *testing.T) {
+	tc := setupConversationTest(t)
+	defer tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Save with complex JSONB data
+	requestMessages := []any{
+		map[string]string{"role": "system", "content": "You are helpful"},
+		map[string]string{"role": "user", "content": "Hello"},
+	}
+	requestTools := []any{
+		map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name":        "get_weather",
+				"description": "Get the weather",
+				"parameters": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"location": map[string]string{"type": "string"},
+					},
+				},
+			},
+		},
+	}
+	responseToolCalls := []any{
+		map[string]any{
+			"id":   "call_123",
+			"type": "function",
+			"function": map[string]any{
+				"name":      "get_weather",
+				"arguments": `{"location": "NYC"}`,
+			},
+		},
+	}
+
+	conv := &models.LLMConversation{
+		ProjectID:         tc.projectID,
+		Iteration:         1,
+		Endpoint:          "https://api.openai.com/v1",
+		Model:             "gpt-4",
+		RequestMessages:   requestMessages,
+		RequestTools:      requestTools,
+		ResponseContent:   "Tool call response",
+		ResponseToolCalls: responseToolCalls,
+		DurationMs:        200,
+		Status:            models.LLMConversationStatusSuccess,
+	}
+
+	err := tc.repo.Save(ctx, conv)
+	if err != nil {
+		t.Fatalf("failed to save: %v", err)
+	}
+
+	// Fetch and verify
+	conversations, err := tc.repo.GetByProject(ctx, tc.projectID, 1)
+	if err != nil {
+		t.Fatalf("failed to get: %v", err)
+	}
+
+	if len(conversations) != 1 {
+		t.Fatalf("expected 1 conversation, got %d", len(conversations))
+	}
+
+	fetched := conversations[0]
+
+	// Verify request messages
+	if len(fetched.RequestMessages) != 2 {
+		t.Errorf("expected 2 request messages, got %d", len(fetched.RequestMessages))
+	}
+
+	// Verify request tools
+	if len(fetched.RequestTools) != 1 {
+		t.Errorf("expected 1 request tool, got %d", len(fetched.RequestTools))
+	}
+
+	// Verify response tool calls
+	if len(fetched.ResponseToolCalls) != 1 {
+		t.Errorf("expected 1 response tool call, got %d", len(fetched.ResponseToolCalls))
+	}
+}

--- a/pkg/repositories/knowledge_repository.go
+++ b/pkg/repositories/knowledge_repository.go
@@ -1,0 +1,219 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+)
+
+// KnowledgeRepository provides data access for ontology knowledge facts.
+type KnowledgeRepository interface {
+	Upsert(ctx context.Context, fact *models.KnowledgeFact) error
+	GetByProject(ctx context.Context, projectID uuid.UUID) ([]*models.KnowledgeFact, error)
+	GetByType(ctx context.Context, projectID uuid.UUID, factType string) ([]*models.KnowledgeFact, error)
+	GetByKey(ctx context.Context, projectID uuid.UUID, factType, key string) (*models.KnowledgeFact, error)
+	Delete(ctx context.Context, id uuid.UUID) error
+}
+
+type knowledgeRepository struct{}
+
+// NewKnowledgeRepository creates a new KnowledgeRepository.
+func NewKnowledgeRepository() KnowledgeRepository {
+	return &knowledgeRepository{}
+}
+
+var _ KnowledgeRepository = (*knowledgeRepository)(nil)
+
+func (r *knowledgeRepository) Upsert(ctx context.Context, fact *models.KnowledgeFact) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	now := time.Now()
+	fact.UpdatedAt = now
+	if fact.ID == uuid.Nil {
+		fact.ID = uuid.New()
+		fact.CreatedAt = now
+	}
+
+	query := `
+		INSERT INTO engine_project_knowledge (
+			id, project_id, fact_type, key, value, context, created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		ON CONFLICT (project_id, fact_type, key)
+		DO UPDATE SET
+			value = EXCLUDED.value,
+			context = EXCLUDED.context,
+			updated_at = EXCLUDED.updated_at
+		RETURNING id, created_at`
+
+	err := scope.Conn.QueryRow(ctx, query,
+		fact.ID, fact.ProjectID, fact.FactType, fact.Key, fact.Value, fact.Context,
+		fact.CreatedAt, fact.UpdatedAt,
+	).Scan(&fact.ID, &fact.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("failed to upsert knowledge fact: %w", err)
+	}
+
+	return nil
+}
+
+func (r *knowledgeRepository) GetByProject(ctx context.Context, projectID uuid.UUID) ([]*models.KnowledgeFact, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT id, project_id, fact_type, key, value, context, created_at, updated_at
+		FROM engine_project_knowledge
+		WHERE project_id = $1
+		ORDER BY fact_type, key`
+
+	rows, err := scope.Conn.Query(ctx, query, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get knowledge facts: %w", err)
+	}
+	defer rows.Close()
+
+	facts := make([]*models.KnowledgeFact, 0)
+	for rows.Next() {
+		f, err := scanKnowledgeFactRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		facts = append(facts, f)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating facts: %w", err)
+	}
+
+	return facts, nil
+}
+
+func (r *knowledgeRepository) GetByType(ctx context.Context, projectID uuid.UUID, factType string) ([]*models.KnowledgeFact, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT id, project_id, fact_type, key, value, context, created_at, updated_at
+		FROM engine_project_knowledge
+		WHERE project_id = $1 AND fact_type = $2
+		ORDER BY key`
+
+	rows, err := scope.Conn.Query(ctx, query, projectID, factType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get knowledge facts: %w", err)
+	}
+	defer rows.Close()
+
+	facts := make([]*models.KnowledgeFact, 0)
+	for rows.Next() {
+		f, err := scanKnowledgeFactRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		facts = append(facts, f)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating facts: %w", err)
+	}
+
+	return facts, nil
+}
+
+func (r *knowledgeRepository) GetByKey(ctx context.Context, projectID uuid.UUID, factType, key string) (*models.KnowledgeFact, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT id, project_id, fact_type, key, value, context, created_at, updated_at
+		FROM engine_project_knowledge
+		WHERE project_id = $1 AND fact_type = $2 AND key = $3`
+
+	row := scope.Conn.QueryRow(ctx, query, projectID, factType, key)
+	fact, err := scanKnowledgeFactRow(row)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil // Not found
+		}
+		return nil, err
+	}
+	return fact, nil
+}
+
+func (r *knowledgeRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `DELETE FROM engine_project_knowledge WHERE id = $1`
+
+	result, err := scope.Conn.Exec(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete knowledge fact: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("knowledge fact not found")
+	}
+
+	return nil
+}
+
+// ============================================================================
+// Helper Functions - Scan
+// ============================================================================
+
+func scanKnowledgeFactRow(row pgx.Row) (*models.KnowledgeFact, error) {
+	var f models.KnowledgeFact
+	var context *string
+
+	err := row.Scan(
+		&f.ID, &f.ProjectID, &f.FactType, &f.Key, &f.Value, &context,
+		&f.CreatedAt, &f.UpdatedAt,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, err
+		}
+		return nil, fmt.Errorf("failed to scan knowledge fact: %w", err)
+	}
+
+	if context != nil {
+		f.Context = *context
+	}
+
+	return &f, nil
+}
+
+func scanKnowledgeFactRows(rows pgx.Rows) (*models.KnowledgeFact, error) {
+	var f models.KnowledgeFact
+	var context *string
+
+	err := rows.Scan(
+		&f.ID, &f.ProjectID, &f.FactType, &f.Key, &f.Value, &context,
+		&f.CreatedAt, &f.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan knowledge fact: %w", err)
+	}
+
+	if context != nil {
+		f.Context = *context
+	}
+
+	return &f, nil
+}

--- a/pkg/repositories/knowledge_repository_test.go
+++ b/pkg/repositories/knowledge_repository_test.go
@@ -1,0 +1,550 @@
+//go:build integration
+
+package repositories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/testhelpers"
+)
+
+// knowledgeTestContext holds test dependencies for knowledge repository tests.
+type knowledgeTestContext struct {
+	t         *testing.T
+	engineDB  *testhelpers.EngineDB
+	repo      KnowledgeRepository
+	projectID uuid.UUID
+}
+
+// setupKnowledgeTest initializes the test context with shared testcontainer.
+func setupKnowledgeTest(t *testing.T) *knowledgeTestContext {
+	engineDB := testhelpers.GetEngineDB(t)
+	tc := &knowledgeTestContext{
+		t:         t,
+		engineDB:  engineDB,
+		repo:      NewKnowledgeRepository(),
+		projectID: uuid.MustParse("00000000-0000-0000-0000-000000000043"),
+	}
+	tc.ensureTestProject()
+	return tc
+}
+
+// ensureTestProject creates the test project if it doesn't exist.
+func (tc *knowledgeTestContext) ensureTestProject() {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create scope for project setup: %v", err)
+	}
+	defer scope.Close()
+
+	_, err = scope.Conn.Exec(ctx, `
+		INSERT INTO engine_projects (id, name, status)
+		VALUES ($1, $2, 'active')
+		ON CONFLICT (id) DO NOTHING
+	`, tc.projectID, "Knowledge Test Project")
+	if err != nil {
+		tc.t.Fatalf("failed to ensure test project: %v", err)
+	}
+}
+
+// cleanup removes test knowledge facts.
+func (tc *knowledgeTestContext) cleanup() {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create scope for cleanup: %v", err)
+	}
+	defer scope.Close()
+
+	_, _ = scope.Conn.Exec(ctx, "DELETE FROM engine_project_knowledge WHERE project_id = $1", tc.projectID)
+}
+
+// createTestContext returns a context with tenant scope.
+func (tc *knowledgeTestContext) createTestContext() (context.Context, func()) {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create tenant scope: %v", err)
+	}
+	ctx = database.SetTenantScope(ctx, scope)
+	return ctx, func() { scope.Close() }
+}
+
+// createTestFact creates a knowledge fact for testing.
+func (tc *knowledgeTestContext) createTestFact(ctx context.Context, factType, key, value string) *models.KnowledgeFact {
+	tc.t.Helper()
+	fact := &models.KnowledgeFact{
+		ProjectID: tc.projectID,
+		FactType:  factType,
+		Key:       key,
+		Value:     value,
+		Context:   "Test context",
+	}
+	err := tc.repo.Upsert(ctx, fact)
+	if err != nil {
+		tc.t.Fatalf("failed to create test fact: %v", err)
+	}
+	return fact
+}
+
+// ============================================================================
+// Upsert Tests (Insert)
+// ============================================================================
+
+func TestKnowledgeRepository_Upsert_Insert(t *testing.T) {
+	tc := setupKnowledgeTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	fact := &models.KnowledgeFact{
+		ProjectID: tc.projectID,
+		FactType:  models.FactTypeFiscalYear,
+		Key:       "start_month",
+		Value:     "July",
+		Context:   "Company follows July-June fiscal year",
+	}
+
+	err := tc.repo.Upsert(ctx, fact)
+	if err != nil {
+		t.Fatalf("Upsert failed: %v", err)
+	}
+
+	if fact.ID == uuid.Nil {
+		t.Error("expected ID to be set")
+	}
+	if fact.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be set")
+	}
+
+	// Verify by fetching
+	retrieved, err := tc.repo.GetByKey(ctx, tc.projectID, models.FactTypeFiscalYear, "start_month")
+	if err != nil {
+		t.Fatalf("GetByKey failed: %v", err)
+	}
+	if retrieved == nil {
+		t.Fatal("expected fact, got nil")
+	}
+	if retrieved.Value != "July" {
+		t.Errorf("expected value 'July', got %q", retrieved.Value)
+	}
+	if retrieved.Context != "Company follows July-June fiscal year" {
+		t.Errorf("expected context, got %q", retrieved.Context)
+	}
+}
+
+func TestKnowledgeRepository_Upsert_InsertWithoutContext(t *testing.T) {
+	tc := setupKnowledgeTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	fact := &models.KnowledgeFact{
+		ProjectID: tc.projectID,
+		FactType:  models.FactTypeTerminology,
+		Key:       "customer",
+		Value:     "A person or organization that purchases goods",
+		// No context
+	}
+
+	err := tc.repo.Upsert(ctx, fact)
+	if err != nil {
+		t.Fatalf("Upsert failed: %v", err)
+	}
+
+	retrieved, err := tc.repo.GetByKey(ctx, tc.projectID, models.FactTypeTerminology, "customer")
+	if err != nil {
+		t.Fatalf("GetByKey failed: %v", err)
+	}
+	if retrieved.Context != "" {
+		t.Errorf("expected empty context, got %q", retrieved.Context)
+	}
+}
+
+// ============================================================================
+// Upsert Tests (Update)
+// ============================================================================
+
+func TestKnowledgeRepository_Upsert_Update(t *testing.T) {
+	tc := setupKnowledgeTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create initial fact
+	original := tc.createTestFact(ctx, models.FactTypeBusinessRule, "discount_threshold", "100")
+	originalID := original.ID
+
+	// Upsert with same key should update
+	updated := &models.KnowledgeFact{
+		ProjectID: tc.projectID,
+		FactType:  models.FactTypeBusinessRule,
+		Key:       "discount_threshold",
+		Value:     "150", // Changed value
+		Context:   "Updated policy",
+	}
+
+	err := tc.repo.Upsert(ctx, updated)
+	if err != nil {
+		t.Fatalf("Upsert failed: %v", err)
+	}
+
+	// ID should be preserved (same record)
+	if updated.ID != originalID {
+		t.Errorf("expected same ID %v, got %v", originalID, updated.ID)
+	}
+
+	// CreatedAt should be preserved
+	if updated.CreatedAt != original.CreatedAt {
+		t.Errorf("expected same CreatedAt, but it changed")
+	}
+
+	// Verify value was updated
+	retrieved, err := tc.repo.GetByKey(ctx, tc.projectID, models.FactTypeBusinessRule, "discount_threshold")
+	if err != nil {
+		t.Fatalf("GetByKey failed: %v", err)
+	}
+	if retrieved.Value != "150" {
+		t.Errorf("expected updated value '150', got %q", retrieved.Value)
+	}
+	if retrieved.Context != "Updated policy" {
+		t.Errorf("expected updated context, got %q", retrieved.Context)
+	}
+}
+
+func TestKnowledgeRepository_Upsert_SameTypesDifferentKeys(t *testing.T) {
+	tc := setupKnowledgeTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create facts with same type but different keys
+	tc.createTestFact(ctx, models.FactTypeEnumeration, "status_active", "Account is active and in good standing")
+	tc.createTestFact(ctx, models.FactTypeEnumeration, "status_suspended", "Account is temporarily suspended")
+	tc.createTestFact(ctx, models.FactTypeEnumeration, "status_closed", "Account is permanently closed")
+
+	facts, err := tc.repo.GetByType(ctx, tc.projectID, models.FactTypeEnumeration)
+	if err != nil {
+		t.Fatalf("GetByType failed: %v", err)
+	}
+	if len(facts) != 3 {
+		t.Errorf("expected 3 facts, got %d", len(facts))
+	}
+}
+
+// ============================================================================
+// GetByProject Tests
+// ============================================================================
+
+func TestKnowledgeRepository_GetByProject_Success(t *testing.T) {
+	tc := setupKnowledgeTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestFact(ctx, models.FactTypeFiscalYear, "start_month", "January")
+	tc.createTestFact(ctx, models.FactTypeBusinessRule, "max_discount", "30%")
+	tc.createTestFact(ctx, models.FactTypeTerminology, "SKU", "Stock Keeping Unit")
+
+	facts, err := tc.repo.GetByProject(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetByProject failed: %v", err)
+	}
+	if len(facts) != 3 {
+		t.Errorf("expected 3 facts, got %d", len(facts))
+	}
+}
+
+func TestKnowledgeRepository_GetByProject_Empty(t *testing.T) {
+	tc := setupKnowledgeTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	facts, err := tc.repo.GetByProject(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetByProject failed: %v", err)
+	}
+	if len(facts) != 0 {
+		t.Errorf("expected 0 facts, got %d", len(facts))
+	}
+}
+
+func TestKnowledgeRepository_GetByProject_Ordering(t *testing.T) {
+	tc := setupKnowledgeTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create in non-alphabetical order
+	tc.createTestFact(ctx, models.FactTypeTerminology, "zebra", "Z animal")
+	tc.createTestFact(ctx, models.FactTypeBusinessRule, "alpha", "A rule")
+	tc.createTestFact(ctx, models.FactTypeTerminology, "apple", "A fruit")
+
+	facts, err := tc.repo.GetByProject(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetByProject failed: %v", err)
+	}
+
+	// Should be ordered by fact_type, then key
+	// business_rule < terminology (alphabetically)
+	if facts[0].FactType != models.FactTypeBusinessRule {
+		t.Errorf("expected first fact to be business_rule, got %q", facts[0].FactType)
+	}
+	// Then terminology facts ordered by key
+	if len(facts) == 3 {
+		if facts[1].Key != "apple" {
+			t.Errorf("expected second fact key 'apple', got %q", facts[1].Key)
+		}
+	}
+}
+
+// ============================================================================
+// GetByType Tests
+// ============================================================================
+
+func TestKnowledgeRepository_GetByType_Success(t *testing.T) {
+	tc := setupKnowledgeTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestFact(ctx, models.FactTypeTerminology, "API", "Application Programming Interface")
+	tc.createTestFact(ctx, models.FactTypeTerminology, "SDK", "Software Development Kit")
+	tc.createTestFact(ctx, models.FactTypeBusinessRule, "max_users", "100")
+
+	facts, err := tc.repo.GetByType(ctx, tc.projectID, models.FactTypeTerminology)
+	if err != nil {
+		t.Fatalf("GetByType failed: %v", err)
+	}
+	if len(facts) != 2 {
+		t.Errorf("expected 2 terminology facts, got %d", len(facts))
+	}
+	for _, f := range facts {
+		if f.FactType != models.FactTypeTerminology {
+			t.Errorf("expected only terminology facts, got %q", f.FactType)
+		}
+	}
+}
+
+func TestKnowledgeRepository_GetByType_Empty(t *testing.T) {
+	tc := setupKnowledgeTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestFact(ctx, models.FactTypeBusinessRule, "rule1", "value")
+
+	facts, err := tc.repo.GetByType(ctx, tc.projectID, models.FactTypeTerminology)
+	if err != nil {
+		t.Fatalf("GetByType failed: %v", err)
+	}
+	if len(facts) != 0 {
+		t.Errorf("expected 0 terminology facts, got %d", len(facts))
+	}
+}
+
+// ============================================================================
+// GetByKey Tests
+// ============================================================================
+
+func TestKnowledgeRepository_GetByKey_Success(t *testing.T) {
+	tc := setupKnowledgeTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestFact(ctx, models.FactTypeFiscalYear, "end_month", "June")
+
+	fact, err := tc.repo.GetByKey(ctx, tc.projectID, models.FactTypeFiscalYear, "end_month")
+	if err != nil {
+		t.Fatalf("GetByKey failed: %v", err)
+	}
+	if fact == nil {
+		t.Fatal("expected fact, got nil")
+	}
+	if fact.Value != "June" {
+		t.Errorf("expected value 'June', got %q", fact.Value)
+	}
+}
+
+func TestKnowledgeRepository_GetByKey_NotFound(t *testing.T) {
+	tc := setupKnowledgeTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	fact, err := tc.repo.GetByKey(ctx, tc.projectID, models.FactTypeFiscalYear, "nonexistent")
+	if err != nil {
+		t.Fatalf("GetByKey should not error for not found: %v", err)
+	}
+	if fact != nil {
+		t.Errorf("expected nil for not found, got %+v", fact)
+	}
+}
+
+func TestKnowledgeRepository_GetByKey_WrongType(t *testing.T) {
+	tc := setupKnowledgeTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestFact(ctx, models.FactTypeBusinessRule, "my_key", "value")
+
+	// Same key but different type should not be found
+	fact, err := tc.repo.GetByKey(ctx, tc.projectID, models.FactTypeTerminology, "my_key")
+	if err != nil {
+		t.Fatalf("GetByKey should not error: %v", err)
+	}
+	if fact != nil {
+		t.Errorf("expected nil for wrong type, got %+v", fact)
+	}
+}
+
+// ============================================================================
+// Delete Tests
+// ============================================================================
+
+func TestKnowledgeRepository_Delete_Success(t *testing.T) {
+	tc := setupKnowledgeTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	fact := tc.createTestFact(ctx, models.FactTypeConvention, "date_format", "YYYY-MM-DD")
+
+	err := tc.repo.Delete(ctx, fact.ID)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	// Verify deleted
+	retrieved, err := tc.repo.GetByKey(ctx, tc.projectID, models.FactTypeConvention, "date_format")
+	if err != nil {
+		t.Fatalf("GetByKey failed: %v", err)
+	}
+	if retrieved != nil {
+		t.Error("expected fact to be deleted")
+	}
+}
+
+func TestKnowledgeRepository_Delete_NotFound(t *testing.T) {
+	tc := setupKnowledgeTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	err := tc.repo.Delete(ctx, uuid.New())
+	if err == nil {
+		t.Error("expected error for non-existent fact")
+	}
+}
+
+// ============================================================================
+// All Fact Types Tests
+// ============================================================================
+
+func TestKnowledgeRepository_AllFactTypes(t *testing.T) {
+	tc := setupKnowledgeTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Test all supported fact types
+	factTypes := []struct {
+		factType string
+		key      string
+		value    string
+	}{
+		{models.FactTypeFiscalYear, "start", "January"},
+		{models.FactTypeBusinessRule, "max_discount", "25%"},
+		{models.FactTypeTerminology, "MRR", "Monthly Recurring Revenue"},
+		{models.FactTypeConvention, "currency", "USD"},
+		{models.FactTypeEnumeration, "order_status_pending", "Order has been placed but not processed"},
+		{models.FactTypeRelationship, "user_orders", "Users can have multiple orders"},
+	}
+
+	for _, ft := range factTypes {
+		tc.createTestFact(ctx, ft.factType, ft.key, ft.value)
+	}
+
+	facts, err := tc.repo.GetByProject(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetByProject failed: %v", err)
+	}
+	if len(facts) != len(factTypes) {
+		t.Errorf("expected %d facts, got %d", len(factTypes), len(facts))
+	}
+}
+
+// ============================================================================
+// No Tenant Scope Tests (RLS Enforcement)
+// ============================================================================
+
+func TestKnowledgeRepository_NoTenantScope(t *testing.T) {
+	tc := setupKnowledgeTest(t)
+	tc.cleanup()
+
+	ctx := context.Background() // No tenant scope
+
+	fact := &models.KnowledgeFact{
+		ProjectID: tc.projectID,
+		FactType:  models.FactTypeTerminology,
+		Key:       "test",
+		Value:     "value",
+	}
+
+	// Upsert should fail
+	err := tc.repo.Upsert(ctx, fact)
+	if err == nil {
+		t.Error("expected error for Upsert without tenant scope")
+	}
+
+	// GetByProject should fail
+	_, err = tc.repo.GetByProject(ctx, tc.projectID)
+	if err == nil {
+		t.Error("expected error for GetByProject without tenant scope")
+	}
+
+	// GetByType should fail
+	_, err = tc.repo.GetByType(ctx, tc.projectID, models.FactTypeTerminology)
+	if err == nil {
+		t.Error("expected error for GetByType without tenant scope")
+	}
+
+	// GetByKey should fail
+	_, err = tc.repo.GetByKey(ctx, tc.projectID, models.FactTypeTerminology, "test")
+	if err == nil {
+		t.Error("expected error for GetByKey without tenant scope")
+	}
+
+	// Delete should fail
+	err = tc.repo.Delete(ctx, uuid.New())
+	if err == nil {
+		t.Error("expected error for Delete without tenant scope")
+	}
+}

--- a/pkg/repositories/ontology_chat_repository.go
+++ b/pkg/repositories/ontology_chat_repository.go
@@ -1,0 +1,191 @@
+package repositories
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+)
+
+// OntologyChatRepository provides data access for ontology chat messages.
+type OntologyChatRepository interface {
+	SaveMessage(ctx context.Context, message *models.ChatMessage) error
+	GetHistory(ctx context.Context, projectID uuid.UUID, limit int) ([]*models.ChatMessage, error)
+	GetHistoryCount(ctx context.Context, projectID uuid.UUID) (int, error)
+	ClearHistory(ctx context.Context, projectID uuid.UUID) error
+}
+
+type ontologyChatRepository struct{}
+
+// NewOntologyChatRepository creates a new OntologyChatRepository.
+func NewOntologyChatRepository() OntologyChatRepository {
+	return &ontologyChatRepository{}
+}
+
+var _ OntologyChatRepository = (*ontologyChatRepository)(nil)
+
+func (r *ontologyChatRepository) SaveMessage(ctx context.Context, message *models.ChatMessage) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	message.CreatedAt = time.Now()
+	if message.ID == uuid.Nil {
+		message.ID = uuid.New()
+	}
+
+	toolCallsJSON, err := json.Marshal(message.ToolCalls)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tool_calls: %w", err)
+	}
+	if message.ToolCalls == nil {
+		toolCallsJSON = nil
+	}
+
+	metadataJSON, err := json.Marshal(message.Metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+	if message.Metadata == nil {
+		metadataJSON = []byte("{}")
+	}
+
+	query := `
+		INSERT INTO engine_ontology_chat_messages (
+			id, project_id, ontology_id, role, content, tool_calls, tool_call_id, metadata, created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
+
+	_, err = scope.Conn.Exec(ctx, query,
+		message.ID, message.ProjectID, message.OntologyID, message.Role, message.Content,
+		toolCallsJSON, message.ToolCallID, metadataJSON, message.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to save message: %w", err)
+	}
+
+	return nil
+}
+
+func (r *ontologyChatRepository) GetHistory(ctx context.Context, projectID uuid.UUID, limit int) ([]*models.ChatMessage, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	if limit <= 0 {
+		limit = 50 // Default limit
+	}
+
+	// Get messages in chronological order, but limit to most recent
+	query := `
+		SELECT id, project_id, ontology_id, role, content, tool_calls, tool_call_id, metadata, created_at
+		FROM engine_ontology_chat_messages
+		WHERE project_id = $1
+		ORDER BY created_at DESC
+		LIMIT $2`
+
+	rows, err := scope.Conn.Query(ctx, query, projectID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get chat history: %w", err)
+	}
+	defer rows.Close()
+
+	messages := make([]*models.ChatMessage, 0)
+	for rows.Next() {
+		m, err := scanChatMessageRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating messages: %w", err)
+	}
+
+	// Reverse to get chronological order
+	for i, j := 0, len(messages)-1; i < j; i, j = i+1, j-1 {
+		messages[i], messages[j] = messages[j], messages[i]
+	}
+
+	return messages, nil
+}
+
+func (r *ontologyChatRepository) GetHistoryCount(ctx context.Context, projectID uuid.UUID) (int, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return 0, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT COUNT(*)
+		FROM engine_ontology_chat_messages
+		WHERE project_id = $1`
+
+	var count int
+	err := scope.Conn.QueryRow(ctx, query, projectID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count chat messages: %w", err)
+	}
+
+	return count, nil
+}
+
+func (r *ontologyChatRepository) ClearHistory(ctx context.Context, projectID uuid.UUID) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `DELETE FROM engine_ontology_chat_messages WHERE project_id = $1`
+
+	_, err := scope.Conn.Exec(ctx, query, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to clear chat history: %w", err)
+	}
+
+	return nil
+}
+
+// ============================================================================
+// Helper Functions - Scan
+// ============================================================================
+
+func scanChatMessageRows(rows pgx.Rows) (*models.ChatMessage, error) {
+	var m models.ChatMessage
+	var toolCallsJSON, metadataJSON []byte
+	var toolCallID *string
+
+	err := rows.Scan(
+		&m.ID, &m.ProjectID, &m.OntologyID, &m.Role, &m.Content,
+		&toolCallsJSON, &toolCallID, &metadataJSON, &m.CreatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan message: %w", err)
+	}
+
+	if toolCallID != nil {
+		m.ToolCallID = *toolCallID
+	}
+
+	if len(toolCallsJSON) > 0 {
+		if err := json.Unmarshal(toolCallsJSON, &m.ToolCalls); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal tool_calls: %w", err)
+		}
+	}
+
+	if len(metadataJSON) > 0 {
+		m.Metadata = make(map[string]any)
+		if err := json.Unmarshal(metadataJSON, &m.Metadata); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal metadata: %w", err)
+		}
+	}
+
+	return &m, nil
+}

--- a/pkg/repositories/ontology_chat_repository_test.go
+++ b/pkg/repositories/ontology_chat_repository_test.go
@@ -1,0 +1,583 @@
+//go:build integration
+
+package repositories
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/testhelpers"
+)
+
+// chatTestContext holds test dependencies for chat repository tests.
+type chatTestContext struct {
+	t          *testing.T
+	engineDB   *testhelpers.EngineDB
+	repo       OntologyChatRepository
+	projectID  uuid.UUID
+	ontologyID uuid.UUID
+}
+
+// setupChatTest initializes the test context with shared testcontainer.
+func setupChatTest(t *testing.T) *chatTestContext {
+	engineDB := testhelpers.GetEngineDB(t)
+	tc := &chatTestContext{
+		t:          t,
+		engineDB:   engineDB,
+		repo:       NewOntologyChatRepository(),
+		projectID:  uuid.MustParse("00000000-0000-0000-0000-000000000042"),
+		ontologyID: uuid.MustParse("00000000-0000-0000-0000-000000000043"),
+	}
+	tc.ensureTestProject()
+	return tc
+}
+
+// ensureTestProject creates the test project and ontology if they don't exist.
+func (tc *chatTestContext) ensureTestProject() {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create scope for project setup: %v", err)
+	}
+	defer scope.Close()
+
+	_, err = scope.Conn.Exec(ctx, `
+		INSERT INTO engine_projects (id, name, status)
+		VALUES ($1, $2, 'active')
+		ON CONFLICT (id) DO NOTHING
+	`, tc.projectID, "Chat Test Project")
+	if err != nil {
+		tc.t.Fatalf("failed to ensure test project: %v", err)
+	}
+
+	// Create ontology (required for chat messages FK)
+	now := time.Now()
+	_, err = scope.Conn.Exec(ctx, `
+		INSERT INTO engine_ontologies (id, project_id, is_active, created_at, updated_at)
+		VALUES ($1, $2, true, $3, $3)
+		ON CONFLICT (id) DO NOTHING
+	`, tc.ontologyID, tc.projectID, now)
+	if err != nil {
+		tc.t.Fatalf("failed to ensure test ontology: %v", err)
+	}
+}
+
+// cleanup removes test chat messages.
+func (tc *chatTestContext) cleanup() {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create scope for cleanup: %v", err)
+	}
+	defer scope.Close()
+
+	_, _ = scope.Conn.Exec(ctx, "DELETE FROM engine_ontology_chat_messages WHERE project_id = $1", tc.projectID)
+}
+
+// createTestContext returns a context with tenant scope.
+func (tc *chatTestContext) createTestContext() (context.Context, func()) {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create tenant scope: %v", err)
+	}
+	ctx = database.SetTenantScope(ctx, scope)
+	return ctx, func() { scope.Close() }
+}
+
+// createTestMessage creates a chat message for testing.
+func (tc *chatTestContext) createTestMessage(ctx context.Context, role models.ChatRole, content string) *models.ChatMessage {
+	tc.t.Helper()
+	message := &models.ChatMessage{
+		ProjectID:  tc.projectID,
+		OntologyID: tc.ontologyID,
+		Role:       role,
+		Content:    content,
+	}
+	err := tc.repo.SaveMessage(ctx, message)
+	if err != nil {
+		tc.t.Fatalf("failed to create test message: %v", err)
+	}
+	// Small delay to ensure different timestamps
+	time.Sleep(10 * time.Millisecond)
+	return message
+}
+
+// ============================================================================
+// SaveMessage Tests
+// ============================================================================
+
+func TestChatRepository_SaveMessage_UserMessage(t *testing.T) {
+	tc := setupChatTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	message := &models.ChatMessage{
+		ProjectID:  tc.projectID,
+		OntologyID: tc.ontologyID,
+		Role:       models.ChatRoleUser,
+		Content:    "What does the accounts table represent?",
+		Metadata:   map[string]any{"source": "web"},
+	}
+
+	err := tc.repo.SaveMessage(ctx, message)
+	if err != nil {
+		t.Fatalf("SaveMessage failed: %v", err)
+	}
+
+	if message.ID == uuid.Nil {
+		t.Error("expected ID to be set")
+	}
+	if message.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be set")
+	}
+
+	// Verify by fetching history
+	history, err := tc.repo.GetHistory(ctx, tc.projectID, 10)
+	if err != nil {
+		t.Fatalf("GetHistory failed: %v", err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(history))
+	}
+	if history[0].Content != "What does the accounts table represent?" {
+		t.Errorf("expected content mismatch")
+	}
+	if history[0].Role != models.ChatRoleUser {
+		t.Errorf("expected role user, got %q", history[0].Role)
+	}
+}
+
+func TestChatRepository_SaveMessage_AssistantMessage(t *testing.T) {
+	tc := setupChatTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	message := &models.ChatMessage{
+		ProjectID:  tc.projectID,
+		OntologyID: tc.ontologyID,
+		Role:       models.ChatRoleAssistant,
+		Content:    "The accounts table represents customer accounts.",
+	}
+
+	err := tc.repo.SaveMessage(ctx, message)
+	if err != nil {
+		t.Fatalf("SaveMessage failed: %v", err)
+	}
+
+	history, err := tc.repo.GetHistory(ctx, tc.projectID, 10)
+	if err != nil {
+		t.Fatalf("GetHistory failed: %v", err)
+	}
+	if history[0].Role != models.ChatRoleAssistant {
+		t.Errorf("expected role assistant, got %q", history[0].Role)
+	}
+}
+
+func TestChatRepository_SaveMessage_WithToolCalls(t *testing.T) {
+	tc := setupChatTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	message := &models.ChatMessage{
+		ProjectID:  tc.projectID,
+		OntologyID: tc.ontologyID,
+		Role:       models.ChatRoleAssistant,
+		Content:    "",
+		ToolCalls: []models.ToolCall{
+			{
+				ID:   "call_123",
+				Type: "function",
+				Function: models.ToolCallFunction{
+					Name:      "query_column_values",
+					Arguments: `{"table_name": "accounts", "column_name": "status"}`,
+				},
+			},
+			{
+				ID:   "call_456",
+				Type: "function",
+				Function: models.ToolCallFunction{
+					Name:      "update_entity",
+					Arguments: `{"table_name": "accounts", "description": "Updated"}`,
+				},
+			},
+		},
+	}
+
+	err := tc.repo.SaveMessage(ctx, message)
+	if err != nil {
+		t.Fatalf("SaveMessage failed: %v", err)
+	}
+
+	history, err := tc.repo.GetHistory(ctx, tc.projectID, 10)
+	if err != nil {
+		t.Fatalf("GetHistory failed: %v", err)
+	}
+
+	if len(history[0].ToolCalls) != 2 {
+		t.Errorf("expected 2 tool calls, got %d", len(history[0].ToolCalls))
+	}
+	if history[0].ToolCalls[0].ID != "call_123" {
+		t.Errorf("expected tool call ID 'call_123', got %q", history[0].ToolCalls[0].ID)
+	}
+	if history[0].ToolCalls[0].Function.Name != "query_column_values" {
+		t.Errorf("expected function name 'query_column_values', got %q", history[0].ToolCalls[0].Function.Name)
+	}
+}
+
+func TestChatRepository_SaveMessage_ToolResult(t *testing.T) {
+	tc := setupChatTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	message := &models.ChatMessage{
+		ProjectID:  tc.projectID,
+		OntologyID: tc.ontologyID,
+		Role:       models.ChatRoleTool,
+		Content:    `["active", "inactive", "pending"]`,
+		ToolCallID: "call_123",
+	}
+
+	err := tc.repo.SaveMessage(ctx, message)
+	if err != nil {
+		t.Fatalf("SaveMessage failed: %v", err)
+	}
+
+	history, err := tc.repo.GetHistory(ctx, tc.projectID, 10)
+	if err != nil {
+		t.Fatalf("GetHistory failed: %v", err)
+	}
+
+	if history[0].Role != models.ChatRoleTool {
+		t.Errorf("expected role tool, got %q", history[0].Role)
+	}
+	if history[0].ToolCallID != "call_123" {
+		t.Errorf("expected tool_call_id 'call_123', got %q", history[0].ToolCallID)
+	}
+}
+
+// ============================================================================
+// GetHistory Tests
+// ============================================================================
+
+func TestChatRepository_GetHistory_Ordering(t *testing.T) {
+	tc := setupChatTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create messages in order
+	tc.createTestMessage(ctx, models.ChatRoleUser, "First message")
+	tc.createTestMessage(ctx, models.ChatRoleAssistant, "Second message")
+	tc.createTestMessage(ctx, models.ChatRoleUser, "Third message")
+
+	history, err := tc.repo.GetHistory(ctx, tc.projectID, 10)
+	if err != nil {
+		t.Fatalf("GetHistory failed: %v", err)
+	}
+
+	if len(history) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(history))
+	}
+
+	// Should be in chronological order
+	if history[0].Content != "First message" {
+		t.Errorf("expected first message, got %q", history[0].Content)
+	}
+	if history[1].Content != "Second message" {
+		t.Errorf("expected second message, got %q", history[1].Content)
+	}
+	if history[2].Content != "Third message" {
+		t.Errorf("expected third message, got %q", history[2].Content)
+	}
+}
+
+func TestChatRepository_GetHistory_Limit(t *testing.T) {
+	tc := setupChatTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create 5 messages
+	for i := 1; i <= 5; i++ {
+		tc.createTestMessage(ctx, models.ChatRoleUser, "Message")
+	}
+
+	// Request only 3
+	history, err := tc.repo.GetHistory(ctx, tc.projectID, 3)
+	if err != nil {
+		t.Fatalf("GetHistory failed: %v", err)
+	}
+
+	if len(history) != 3 {
+		t.Errorf("expected 3 messages with limit, got %d", len(history))
+	}
+}
+
+func TestChatRepository_GetHistory_DefaultLimit(t *testing.T) {
+	tc := setupChatTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestMessage(ctx, models.ChatRoleUser, "Test message")
+
+	// Limit 0 should use default
+	history, err := tc.repo.GetHistory(ctx, tc.projectID, 0)
+	if err != nil {
+		t.Fatalf("GetHistory failed: %v", err)
+	}
+
+	if len(history) != 1 {
+		t.Errorf("expected 1 message, got %d", len(history))
+	}
+}
+
+func TestChatRepository_GetHistory_Empty(t *testing.T) {
+	tc := setupChatTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	history, err := tc.repo.GetHistory(ctx, tc.projectID, 10)
+	if err != nil {
+		t.Fatalf("GetHistory failed: %v", err)
+	}
+	if len(history) != 0 {
+		t.Errorf("expected 0 messages, got %d", len(history))
+	}
+}
+
+// ============================================================================
+// GetHistoryCount Tests
+// ============================================================================
+
+func TestChatRepository_GetHistoryCount_Success(t *testing.T) {
+	tc := setupChatTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestMessage(ctx, models.ChatRoleUser, "Message 1")
+	tc.createTestMessage(ctx, models.ChatRoleAssistant, "Message 2")
+	tc.createTestMessage(ctx, models.ChatRoleUser, "Message 3")
+
+	count, err := tc.repo.GetHistoryCount(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetHistoryCount failed: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected count 3, got %d", count)
+	}
+}
+
+func TestChatRepository_GetHistoryCount_Empty(t *testing.T) {
+	tc := setupChatTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	count, err := tc.repo.GetHistoryCount(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetHistoryCount failed: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected count 0, got %d", count)
+	}
+}
+
+// ============================================================================
+// ClearHistory Tests
+// ============================================================================
+
+func TestChatRepository_ClearHistory_Success(t *testing.T) {
+	tc := setupChatTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestMessage(ctx, models.ChatRoleUser, "Message 1")
+	tc.createTestMessage(ctx, models.ChatRoleAssistant, "Message 2")
+
+	err := tc.repo.ClearHistory(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("ClearHistory failed: %v", err)
+	}
+
+	count, err := tc.repo.GetHistoryCount(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetHistoryCount failed: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 messages after clear, got %d", count)
+	}
+}
+
+func TestChatRepository_ClearHistory_Empty(t *testing.T) {
+	tc := setupChatTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Clear when already empty should not error
+	err := tc.repo.ClearHistory(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("ClearHistory on empty should not error: %v", err)
+	}
+}
+
+// ============================================================================
+// Conversation Flow Tests
+// ============================================================================
+
+func TestChatRepository_ConversationFlow(t *testing.T) {
+	tc := setupChatTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Simulate a realistic conversation flow
+
+	// 1. User asks question
+	tc.createTestMessage(ctx, models.ChatRoleUser, "What does the status column in accounts mean?")
+
+	// 2. Assistant responds with tool call
+	assistantMsg := &models.ChatMessage{
+		ProjectID:  tc.projectID,
+		OntologyID: tc.ontologyID,
+		Role:       models.ChatRoleAssistant,
+		Content:    "",
+		ToolCalls: []models.ToolCall{
+			{
+				ID:   "call_abc",
+				Type: "function",
+				Function: models.ToolCallFunction{
+					Name:      "query_column_values",
+					Arguments: `{"table_name": "accounts", "column_name": "status"}`,
+				},
+			},
+		},
+	}
+	err := tc.repo.SaveMessage(ctx, assistantMsg)
+	if err != nil {
+		t.Fatalf("SaveMessage failed: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	// 3. Tool result
+	toolMsg := &models.ChatMessage{
+		ProjectID:  tc.projectID,
+		OntologyID: tc.ontologyID,
+		Role:       models.ChatRoleTool,
+		Content:    `["active", "suspended", "closed"]`,
+		ToolCallID: "call_abc",
+	}
+	err = tc.repo.SaveMessage(ctx, toolMsg)
+	if err != nil {
+		t.Fatalf("SaveMessage failed: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	// 4. Assistant final response
+	tc.createTestMessage(ctx, models.ChatRoleAssistant, "The status column has three possible values: active, suspended, and closed.")
+
+	// Verify full conversation
+	history, err := tc.repo.GetHistory(ctx, tc.projectID, 10)
+	if err != nil {
+		t.Fatalf("GetHistory failed: %v", err)
+	}
+
+	if len(history) != 4 {
+		t.Fatalf("expected 4 messages in conversation, got %d", len(history))
+	}
+
+	// Verify order and roles
+	expectedRoles := []models.ChatRole{
+		models.ChatRoleUser,
+		models.ChatRoleAssistant,
+		models.ChatRoleTool,
+		models.ChatRoleAssistant,
+	}
+	for i, expected := range expectedRoles {
+		if history[i].Role != expected {
+			t.Errorf("message %d: expected role %q, got %q", i, expected, history[i].Role)
+		}
+	}
+
+	// Verify tool call is preserved
+	if len(history[1].ToolCalls) != 1 {
+		t.Errorf("expected tool call in assistant message")
+	}
+
+	// Verify tool result has tool_call_id
+	if history[2].ToolCallID != "call_abc" {
+		t.Errorf("expected tool_call_id 'call_abc', got %q", history[2].ToolCallID)
+	}
+}
+
+// ============================================================================
+// No Tenant Scope Tests (RLS Enforcement)
+// ============================================================================
+
+func TestChatRepository_NoTenantScope(t *testing.T) {
+	tc := setupChatTest(t)
+	tc.cleanup()
+
+	ctx := context.Background() // No tenant scope
+
+	message := &models.ChatMessage{
+		ProjectID:  tc.projectID,
+		OntologyID: tc.ontologyID,
+		Role:       models.ChatRoleUser,
+		Content:    "Test",
+	}
+
+	// SaveMessage should fail
+	err := tc.repo.SaveMessage(ctx, message)
+	if err == nil {
+		t.Error("expected error for SaveMessage without tenant scope")
+	}
+
+	// GetHistory should fail
+	_, err = tc.repo.GetHistory(ctx, tc.projectID, 10)
+	if err == nil {
+		t.Error("expected error for GetHistory without tenant scope")
+	}
+
+	// GetHistoryCount should fail
+	_, err = tc.repo.GetHistoryCount(ctx, tc.projectID)
+	if err == nil {
+		t.Error("expected error for GetHistoryCount without tenant scope")
+	}
+
+	// ClearHistory should fail
+	err = tc.repo.ClearHistory(ctx, tc.projectID)
+	if err == nil {
+		t.Error("expected error for ClearHistory without tenant scope")
+	}
+}

--- a/pkg/repositories/ontology_question_repository.go
+++ b/pkg/repositories/ontology_question_repository.go
@@ -1,0 +1,409 @@
+package repositories
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+)
+
+// OntologyQuestionRepository provides data access for ontology questions.
+type OntologyQuestionRepository interface {
+	// Create inserts a new question.
+	Create(ctx context.Context, question *models.OntologyQuestion) error
+
+	// CreateBatch inserts multiple questions in one transaction.
+	CreateBatch(ctx context.Context, questions []*models.OntologyQuestion) error
+
+	// GetByID retrieves a question by ID.
+	GetByID(ctx context.Context, id uuid.UUID) (*models.OntologyQuestion, error)
+
+	// ListPending returns all pending questions for a project, ordered by priority.
+	ListPending(ctx context.Context, projectID uuid.UUID) ([]*models.OntologyQuestion, error)
+
+	// GetNextPending returns the next pending question (highest priority first).
+	GetNextPending(ctx context.Context, projectID uuid.UUID) (*models.OntologyQuestion, error)
+
+	// GetPendingCounts returns counts of required and optional pending questions.
+	GetPendingCounts(ctx context.Context, projectID uuid.UUID) (*QuestionCounts, error)
+
+	// UpdateStatus updates the status of a question.
+	UpdateStatus(ctx context.Context, id uuid.UUID, status models.QuestionStatus) error
+
+	// SubmitAnswer records an answer for a question.
+	SubmitAnswer(ctx context.Context, id uuid.UUID, answer string, answeredBy *uuid.UUID) error
+}
+
+type ontologyQuestionRepository struct{}
+
+// NewOntologyQuestionRepository creates a new OntologyQuestionRepository.
+func NewOntologyQuestionRepository() OntologyQuestionRepository {
+	return &ontologyQuestionRepository{}
+}
+
+var _ OntologyQuestionRepository = (*ontologyQuestionRepository)(nil)
+
+func (r *ontologyQuestionRepository) Create(ctx context.Context, question *models.OntologyQuestion) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	now := time.Now()
+	question.UpdatedAt = now
+	if question.ID == uuid.Nil {
+		question.ID = uuid.New()
+	}
+	if question.CreatedAt.IsZero() {
+		question.CreatedAt = now
+	}
+	if question.Status == "" {
+		question.Status = models.QuestionStatusPending
+	}
+
+	affectsJSON, err := json.Marshal(question.Affects)
+	if err != nil {
+		return fmt.Errorf("marshal affects: %w", err)
+	}
+
+	query := `
+		INSERT INTO engine_ontology_questions (
+			id, project_id, ontology_id, text, reasoning, category,
+			priority, is_required, affects, source_entity_type, source_entity_key,
+			status, answer, answered_by, answered_at, created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`
+
+	var sourceEntityType, sourceEntityKey *string
+	// Extract source entity info from affects if available
+	if question.Affects != nil && len(question.Affects.Tables) > 0 {
+		t := "table"
+		sourceEntityType = &t
+		sourceEntityKey = &question.Affects.Tables[0]
+	}
+
+	_, err = scope.Conn.Exec(ctx, query,
+		question.ID, question.ProjectID, question.OntologyID,
+		question.Text, nullableString(question.Reasoning), nullableString(question.Category),
+		question.Priority, question.IsRequired, affectsJSON,
+		sourceEntityType, sourceEntityKey,
+		string(question.Status), nullableString(question.Answer),
+		question.AnsweredBy, question.AnsweredAt,
+		question.CreatedAt, question.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("insert question: %w", err)
+	}
+
+	return nil
+}
+
+func (r *ontologyQuestionRepository) CreateBatch(ctx context.Context, questions []*models.OntologyQuestion) error {
+	if len(questions) == 0 {
+		return nil
+	}
+
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	now := time.Now()
+
+	// Build batch insert
+	batch := &pgx.Batch{}
+	query := `
+		INSERT INTO engine_ontology_questions (
+			id, project_id, ontology_id, text, reasoning, category,
+			priority, is_required, affects, source_entity_type, source_entity_key,
+			status, answer, answered_by, answered_at, created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`
+
+	for _, q := range questions {
+		if q.ID == uuid.Nil {
+			q.ID = uuid.New()
+		}
+		if q.CreatedAt.IsZero() {
+			q.CreatedAt = now
+		}
+		q.UpdatedAt = now
+		if q.Status == "" {
+			q.Status = models.QuestionStatusPending
+		}
+
+		affectsJSON, err := json.Marshal(q.Affects)
+		if err != nil {
+			return fmt.Errorf("marshal affects: %w", err)
+		}
+
+		var sourceEntityType, sourceEntityKey *string
+		if q.Affects != nil && len(q.Affects.Tables) > 0 {
+			t := "table"
+			sourceEntityType = &t
+			sourceEntityKey = &q.Affects.Tables[0]
+		}
+
+		batch.Queue(query,
+			q.ID, q.ProjectID, q.OntologyID,
+			q.Text, nullableString(q.Reasoning), nullableString(q.Category),
+			q.Priority, q.IsRequired, affectsJSON,
+			sourceEntityType, sourceEntityKey,
+			string(q.Status), nullableString(q.Answer),
+			q.AnsweredBy, q.AnsweredAt,
+			q.CreatedAt, q.UpdatedAt,
+		)
+	}
+
+	br := scope.Conn.SendBatch(ctx, batch)
+	defer br.Close()
+
+	for range questions {
+		if _, err := br.Exec(); err != nil {
+			return fmt.Errorf("batch insert question: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *ontologyQuestionRepository) GetByID(ctx context.Context, id uuid.UUID) (*models.OntologyQuestion, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT id, project_id, ontology_id, text, reasoning, category,
+		       priority, is_required, affects, source_entity_type, source_entity_key,
+		       status, answer, answered_by, answered_at, created_at, updated_at
+		FROM engine_ontology_questions
+		WHERE id = $1`
+
+	row := scope.Conn.QueryRow(ctx, query, id)
+	q, err := scanQuestionRow(row)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get question by id: %w", err)
+	}
+	return q, nil
+}
+
+func (r *ontologyQuestionRepository) ListPending(ctx context.Context, projectID uuid.UUID) ([]*models.OntologyQuestion, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT id, project_id, ontology_id, text, reasoning, category,
+		       priority, is_required, affects, source_entity_type, source_entity_key,
+		       status, answer, answered_by, answered_at, created_at, updated_at
+		FROM engine_ontology_questions
+		WHERE project_id = $1 AND status = 'pending'
+		ORDER BY priority ASC, created_at ASC`
+
+	rows, err := scope.Conn.Query(ctx, query, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("list pending questions: %w", err)
+	}
+	defer rows.Close()
+
+	questions := make([]*models.OntologyQuestion, 0)
+	for rows.Next() {
+		q, err := scanQuestionRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		questions = append(questions, q)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating questions: %w", err)
+	}
+
+	return questions, nil
+}
+
+func (r *ontologyQuestionRepository) GetNextPending(ctx context.Context, projectID uuid.UUID) (*models.OntologyQuestion, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	// Return required questions first (priority 1-2), then by priority, then by creation order
+	query := `
+		SELECT id, project_id, ontology_id, text, reasoning, category,
+		       priority, is_required, affects, source_entity_type, source_entity_key,
+		       status, answer, answered_by, answered_at, created_at, updated_at
+		FROM engine_ontology_questions
+		WHERE project_id = $1 AND status = 'pending'
+		ORDER BY is_required DESC, priority ASC, created_at ASC
+		LIMIT 1`
+
+	row := scope.Conn.QueryRow(ctx, query, projectID)
+	q, err := scanQuestionRow(row)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get next pending question: %w", err)
+	}
+	return q, nil
+}
+
+func (r *ontologyQuestionRepository) GetPendingCounts(ctx context.Context, projectID uuid.UUID) (*QuestionCounts, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT
+			COUNT(*) FILTER (WHERE is_required = true) AS required,
+			COUNT(*) FILTER (WHERE is_required = false) AS optional
+		FROM engine_ontology_questions
+		WHERE project_id = $1 AND status = 'pending'`
+
+	var counts QuestionCounts
+	err := scope.Conn.QueryRow(ctx, query, projectID).Scan(&counts.Required, &counts.Optional)
+	if err != nil {
+		return nil, fmt.Errorf("get pending counts: %w", err)
+	}
+
+	return &counts, nil
+}
+
+func (r *ontologyQuestionRepository) UpdateStatus(ctx context.Context, id uuid.UUID, status models.QuestionStatus) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		UPDATE engine_ontology_questions
+		SET status = $2, updated_at = NOW()
+		WHERE id = $1`
+
+	result, err := scope.Conn.Exec(ctx, query, id, string(status))
+	if err != nil {
+		return fmt.Errorf("update question status: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("question not found: %s", id)
+	}
+
+	return nil
+}
+
+func (r *ontologyQuestionRepository) SubmitAnswer(ctx context.Context, id uuid.UUID, answer string, answeredBy *uuid.UUID) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		UPDATE engine_ontology_questions
+		SET status = 'answered', answer = $2, answered_by = $3, answered_at = NOW(), updated_at = NOW()
+		WHERE id = $1`
+
+	result, err := scope.Conn.Exec(ctx, query, id, answer, answeredBy)
+	if err != nil {
+		return fmt.Errorf("submit answer: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("question not found: %s", id)
+	}
+
+	return nil
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+func nullableString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func scanQuestionRow(row pgx.Row) (*models.OntologyQuestion, error) {
+	var q models.OntologyQuestion
+	var reasoning, category, sourceEntityType, sourceEntityKey, answer *string
+	var status string
+	var affectsJSON []byte
+
+	err := row.Scan(
+		&q.ID, &q.ProjectID, &q.OntologyID, &q.Text, &reasoning, &category,
+		&q.Priority, &q.IsRequired, &affectsJSON, &sourceEntityType, &sourceEntityKey,
+		&status, &answer, &q.AnsweredBy, &q.AnsweredAt, &q.CreatedAt, &q.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if reasoning != nil {
+		q.Reasoning = *reasoning
+	}
+	if category != nil {
+		q.Category = *category
+	}
+	if answer != nil {
+		q.Answer = *answer
+	}
+	q.Status = models.QuestionStatus(status)
+
+	if len(affectsJSON) > 0 {
+		var affects models.QuestionAffects
+		if err := json.Unmarshal(affectsJSON, &affects); err == nil {
+			q.Affects = &affects
+		}
+	}
+
+	return &q, nil
+}
+
+func scanQuestionRows(rows pgx.Rows) (*models.OntologyQuestion, error) {
+	var q models.OntologyQuestion
+	var reasoning, category, sourceEntityType, sourceEntityKey, answer *string
+	var status string
+	var affectsJSON []byte
+
+	err := rows.Scan(
+		&q.ID, &q.ProjectID, &q.OntologyID, &q.Text, &reasoning, &category,
+		&q.Priority, &q.IsRequired, &affectsJSON, &sourceEntityType, &sourceEntityKey,
+		&status, &answer, &q.AnsweredBy, &q.AnsweredAt, &q.CreatedAt, &q.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("scan question: %w", err)
+	}
+
+	if reasoning != nil {
+		q.Reasoning = *reasoning
+	}
+	if category != nil {
+		q.Category = *category
+	}
+	if answer != nil {
+		q.Answer = *answer
+	}
+	q.Status = models.QuestionStatus(status)
+
+	if len(affectsJSON) > 0 {
+		var affects models.QuestionAffects
+		if err := json.Unmarshal(affectsJSON, &affects); err == nil {
+			q.Affects = &affects
+		}
+	}
+
+	return &q, nil
+}

--- a/pkg/repositories/ontology_repository.go
+++ b/pkg/repositories/ontology_repository.go
@@ -1,0 +1,451 @@
+package repositories
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+)
+
+// OntologyRepository provides data access for tiered ontologies.
+type OntologyRepository interface {
+	Create(ctx context.Context, ontology *models.TieredOntology) error
+	GetActive(ctx context.Context, projectID uuid.UUID) (*models.TieredOntology, error)
+	GetByVersion(ctx context.Context, projectID uuid.UUID, version int) (*models.TieredOntology, error)
+	UpdateDomainSummary(ctx context.Context, projectID uuid.UUID, summary *models.DomainSummary) error
+	UpdateEntitySummary(ctx context.Context, projectID uuid.UUID, tableName string, summary *models.EntitySummary) error
+	UpdateEntitySummaries(ctx context.Context, projectID uuid.UUID, summaries map[string]*models.EntitySummary) error
+	UpdateColumnDetails(ctx context.Context, projectID uuid.UUID, tableName string, columns []models.ColumnDetail) error
+	UpdateMetadata(ctx context.Context, projectID uuid.UUID, metadata map[string]any) error
+	SetActive(ctx context.Context, projectID uuid.UUID, version int) error
+	DeactivateAll(ctx context.Context, projectID uuid.UUID) error
+	GetNextVersion(ctx context.Context, projectID uuid.UUID) (int, error)
+	DeleteByProject(ctx context.Context, projectID uuid.UUID) error
+	// WriteCleanOntology is a no-op (kept for orchestrator compatibility).
+	WriteCleanOntology(ctx context.Context, projectID uuid.UUID) error
+}
+
+type ontologyRepository struct{}
+
+// NewOntologyRepository creates a new OntologyRepository.
+func NewOntologyRepository() OntologyRepository {
+	return &ontologyRepository{}
+}
+
+var _ OntologyRepository = (*ontologyRepository)(nil)
+
+func (r *ontologyRepository) Create(ctx context.Context, ontology *models.TieredOntology) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	ontology.CreatedAt = time.Now()
+	if ontology.ID == uuid.Nil {
+		ontology.ID = uuid.New()
+	}
+
+	domainJSON, err := json.Marshal(ontology.DomainSummary)
+	if err != nil {
+		return fmt.Errorf("failed to marshal domain_summary: %w", err)
+	}
+	if ontology.DomainSummary == nil {
+		domainJSON = nil
+	}
+
+	entitiesJSON, err := json.Marshal(ontology.EntitySummaries)
+	if err != nil {
+		return fmt.Errorf("failed to marshal entity_summaries: %w", err)
+	}
+	if ontology.EntitySummaries == nil {
+		entitiesJSON = nil
+	}
+
+	columnsJSON, err := json.Marshal(ontology.ColumnDetails)
+	if err != nil {
+		return fmt.Errorf("failed to marshal column_details: %w", err)
+	}
+	if ontology.ColumnDetails == nil {
+		columnsJSON = nil
+	}
+
+	metadataJSON, err := json.Marshal(ontology.Metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+	if ontology.Metadata == nil {
+		metadataJSON = []byte("{}")
+	}
+
+	ontology.UpdatedAt = ontology.CreatedAt
+
+	query := `
+		INSERT INTO engine_ontologies (
+			id, project_id, version, is_active, domain_summary,
+			entity_summaries, column_details, metadata, created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`
+
+	_, err = scope.Conn.Exec(ctx, query,
+		ontology.ID, ontology.ProjectID, ontology.Version, ontology.IsActive,
+		domainJSON, entitiesJSON, columnsJSON, metadataJSON, ontology.CreatedAt, ontology.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create ontology: %w", err)
+	}
+
+	return nil
+}
+
+func (r *ontologyRepository) GetActive(ctx context.Context, projectID uuid.UUID) (*models.TieredOntology, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT id, project_id, version, is_active,
+		       domain_summary, entity_summaries, column_details, metadata, created_at, updated_at
+		FROM engine_ontologies
+		WHERE project_id = $1 AND is_active = true
+		ORDER BY version DESC
+		LIMIT 1`
+
+	row := scope.Conn.QueryRow(ctx, query, projectID)
+	ontology, err := scanOntologyRow(row)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil // No active ontology
+		}
+		return nil, err
+	}
+	return ontology, nil
+}
+
+func (r *ontologyRepository) GetByVersion(ctx context.Context, projectID uuid.UUID, version int) (*models.TieredOntology, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT id, project_id, version, is_active,
+		       domain_summary, entity_summaries, column_details, metadata, created_at, updated_at
+		FROM engine_ontologies
+		WHERE project_id = $1 AND version = $2`
+
+	row := scope.Conn.QueryRow(ctx, query, projectID, version)
+	ontology, err := scanOntologyRow(row)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, fmt.Errorf("ontology version not found")
+		}
+		return nil, err
+	}
+	return ontology, nil
+}
+
+func (r *ontologyRepository) UpdateDomainSummary(ctx context.Context, projectID uuid.UUID, summary *models.DomainSummary) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	domainJSON, err := json.Marshal(summary)
+	if err != nil {
+		return fmt.Errorf("failed to marshal domain_summary: %w", err)
+	}
+
+	query := `
+		UPDATE engine_ontologies
+		SET domain_summary = $2
+		WHERE project_id = $1 AND is_active = true`
+
+	result, err := scope.Conn.Exec(ctx, query, projectID, domainJSON)
+	if err != nil {
+		return fmt.Errorf("failed to update domain summary: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("no active ontology found")
+	}
+
+	return nil
+}
+
+func (r *ontologyRepository) UpdateEntitySummary(ctx context.Context, projectID uuid.UUID, tableName string, summary *models.EntitySummary) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	summaryJSON, err := json.Marshal(summary)
+	if err != nil {
+		return fmt.Errorf("failed to marshal entity summary: %w", err)
+	}
+
+	// Use JSONB set to update a single entity
+	query := `
+		UPDATE engine_ontologies
+		SET entity_summaries = COALESCE(entity_summaries, '{}'::jsonb) || jsonb_build_object($2::text, $3::jsonb)
+		WHERE project_id = $1 AND is_active = true`
+
+	result, err := scope.Conn.Exec(ctx, query, projectID, tableName, summaryJSON)
+	if err != nil {
+		return fmt.Errorf("failed to update entity summary: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("no active ontology found")
+	}
+
+	return nil
+}
+
+func (r *ontologyRepository) UpdateEntitySummaries(ctx context.Context, projectID uuid.UUID, summaries map[string]*models.EntitySummary) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	summariesJSON, err := json.Marshal(summaries)
+	if err != nil {
+		return fmt.Errorf("failed to marshal entity summaries: %w", err)
+	}
+
+	// Merge new summaries with existing ones
+	query := `
+		UPDATE engine_ontologies
+		SET entity_summaries = COALESCE(entity_summaries, '{}'::jsonb) || $2::jsonb
+		WHERE project_id = $1 AND is_active = true`
+
+	result, err := scope.Conn.Exec(ctx, query, projectID, summariesJSON)
+	if err != nil {
+		return fmt.Errorf("failed to update entity summaries: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("no active ontology found")
+	}
+
+	return nil
+}
+
+func (r *ontologyRepository) UpdateColumnDetails(ctx context.Context, projectID uuid.UUID, tableName string, columns []models.ColumnDetail) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	columnsJSON, err := json.Marshal(columns)
+	if err != nil {
+		return fmt.Errorf("failed to marshal column details: %w", err)
+	}
+
+	// Use JSONB set to update column details for a single table
+	query := `
+		UPDATE engine_ontologies
+		SET column_details = COALESCE(column_details, '{}'::jsonb) || jsonb_build_object($2::text, $3::jsonb)
+		WHERE project_id = $1 AND is_active = true`
+
+	result, err := scope.Conn.Exec(ctx, query, projectID, tableName, columnsJSON)
+	if err != nil {
+		return fmt.Errorf("failed to update column details: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("no active ontology found")
+	}
+
+	return nil
+}
+
+func (r *ontologyRepository) SetActive(ctx context.Context, projectID uuid.UUID, version int) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	// Deactivate all versions for this project
+	deactivateQuery := `
+		UPDATE engine_ontologies
+		SET is_active = false
+		WHERE project_id = $1`
+
+	_, err := scope.Conn.Exec(ctx, deactivateQuery, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to deactivate ontologies: %w", err)
+	}
+
+	// Activate the specified version
+	activateQuery := `
+		UPDATE engine_ontologies
+		SET is_active = true
+		WHERE project_id = $1 AND version = $2`
+
+	result, err := scope.Conn.Exec(ctx, activateQuery, projectID, version)
+	if err != nil {
+		return fmt.Errorf("failed to activate ontology: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("ontology version not found")
+	}
+
+	return nil
+}
+
+func (r *ontologyRepository) DeactivateAll(ctx context.Context, projectID uuid.UUID) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		UPDATE engine_ontologies
+		SET is_active = false
+		WHERE project_id = $1 AND is_active = true`
+
+	_, err := scope.Conn.Exec(ctx, query, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to deactivate ontologies: %w", err)
+	}
+
+	return nil
+}
+
+func (r *ontologyRepository) GetNextVersion(ctx context.Context, projectID uuid.UUID) (int, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return 0, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT COALESCE(MAX(version), 0) + 1
+		FROM engine_ontologies
+		WHERE project_id = $1`
+
+	var nextVersion int
+	err := scope.Conn.QueryRow(ctx, query, projectID).Scan(&nextVersion)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get next version: %w", err)
+	}
+
+	return nextVersion, nil
+}
+
+func (r *ontologyRepository) UpdateMetadata(ctx context.Context, projectID uuid.UUID, metadata map[string]any) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	// Merge new metadata with existing using JSONB concatenation
+	query := `
+		UPDATE engine_ontologies
+		SET metadata = COALESCE(metadata, '{}'::jsonb) || $2::jsonb,
+		    updated_at = NOW()
+		WHERE project_id = $1 AND is_active = true`
+
+	result, err := scope.Conn.Exec(ctx, query, projectID, metadataJSON)
+	if err != nil {
+		return fmt.Errorf("failed to update metadata: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("no active ontology found")
+	}
+
+	return nil
+}
+
+func (r *ontologyRepository) DeleteByProject(ctx context.Context, projectID uuid.UUID) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `DELETE FROM engine_ontologies WHERE project_id = $1`
+
+	_, err := scope.Conn.Exec(ctx, query, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to delete ontologies: %w", err)
+	}
+
+	return nil
+}
+
+// WriteCleanOntology is a no-op since workflow fields (Status, ScanData) were removed.
+// This method is kept for interface compatibility with the workflow orchestrator.
+func (r *ontologyRepository) WriteCleanOntology(ctx context.Context, projectID uuid.UUID) error {
+	// Verify active ontology exists
+	ontology, err := r.GetActive(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("get active ontology: %w", err)
+	}
+	if ontology == nil {
+		return fmt.Errorf("no active ontology found")
+	}
+	// No cleanup needed - ontology model no longer has workflow fields
+	return nil
+}
+
+// ============================================================================
+// Helper Functions - Scan
+// ============================================================================
+
+func scanOntologyRow(row pgx.Row) (*models.TieredOntology, error) {
+	var o models.TieredOntology
+	var domainJSON, entitiesJSON, columnsJSON, metadataJSON []byte
+
+	err := row.Scan(
+		&o.ID, &o.ProjectID, &o.Version, &o.IsActive,
+		&domainJSON, &entitiesJSON, &columnsJSON, &metadataJSON, &o.CreatedAt, &o.UpdatedAt,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, err
+		}
+		return nil, fmt.Errorf("failed to scan ontology: %w", err)
+	}
+
+	if len(domainJSON) > 0 {
+		o.DomainSummary = &models.DomainSummary{}
+		if err := json.Unmarshal(domainJSON, o.DomainSummary); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal domain_summary: %w", err)
+		}
+	}
+
+	if len(entitiesJSON) > 0 {
+		o.EntitySummaries = make(map[string]*models.EntitySummary)
+		if err := json.Unmarshal(entitiesJSON, &o.EntitySummaries); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal entity_summaries: %w", err)
+		}
+	}
+
+	if len(columnsJSON) > 0 {
+		o.ColumnDetails = make(map[string][]models.ColumnDetail)
+		if err := json.Unmarshal(columnsJSON, &o.ColumnDetails); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal column_details: %w", err)
+		}
+	}
+
+	if len(metadataJSON) > 0 {
+		o.Metadata = make(map[string]any)
+		if err := json.Unmarshal(metadataJSON, &o.Metadata); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal metadata: %w", err)
+		}
+	}
+
+	return &o, nil
+}

--- a/pkg/repositories/ontology_repository_test.go
+++ b/pkg/repositories/ontology_repository_test.go
@@ -1,0 +1,852 @@
+//go:build integration
+
+package repositories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/testhelpers"
+)
+
+// ontologyTestContext holds test dependencies for ontology repository tests.
+type ontologyTestContext struct {
+	t         *testing.T
+	engineDB  *testhelpers.EngineDB
+	repo      OntologyRepository
+	projectID uuid.UUID
+}
+
+// setupOntologyTest initializes the test context with shared testcontainer.
+func setupOntologyTest(t *testing.T) *ontologyTestContext {
+	engineDB := testhelpers.GetEngineDB(t)
+	tc := &ontologyTestContext{
+		t:         t,
+		engineDB:  engineDB,
+		repo:      NewOntologyRepository(),
+		projectID: uuid.MustParse("00000000-0000-0000-0000-000000000040"),
+	}
+	tc.ensureTestProject()
+	return tc
+}
+
+// ensureTestProject creates the test project if it doesn't exist.
+func (tc *ontologyTestContext) ensureTestProject() {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create scope for project setup: %v", err)
+	}
+	defer scope.Close()
+
+	_, err = scope.Conn.Exec(ctx, `
+		INSERT INTO engine_projects (id, name, status)
+		VALUES ($1, $2, 'active')
+		ON CONFLICT (id) DO NOTHING
+	`, tc.projectID, "Ontology Test Project")
+	if err != nil {
+		tc.t.Fatalf("failed to ensure test project: %v", err)
+	}
+}
+
+// cleanup removes test ontologies.
+func (tc *ontologyTestContext) cleanup() {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create scope for cleanup: %v", err)
+	}
+	defer scope.Close()
+
+	_, _ = scope.Conn.Exec(ctx, "DELETE FROM engine_ontologies WHERE project_id = $1", tc.projectID)
+}
+
+// createTestContext returns a context with tenant scope.
+func (tc *ontologyTestContext) createTestContext() (context.Context, func()) {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create tenant scope: %v", err)
+	}
+	ctx = database.SetTenantScope(ctx, scope)
+	return ctx, func() { scope.Close() }
+}
+
+// createTestOntology creates an ontology for testing.
+func (tc *ontologyTestContext) createTestOntology(ctx context.Context, version int, isActive bool) *models.TieredOntology {
+	tc.t.Helper()
+	ontology := &models.TieredOntology{
+		ProjectID: tc.projectID,
+		Version:   version,
+		IsActive:  isActive,
+		DomainSummary: &models.DomainSummary{
+			Description: "Test domain summary",
+			Domains:     []string{"sales", "customer"},
+		},
+		EntitySummaries: map[string]*models.EntitySummary{
+			"accounts": {
+				TableName:    "accounts",
+				BusinessName: "Accounts",
+				Description:  "Customer accounts",
+				Domain:       "customer",
+			},
+		},
+		Metadata: map[string]any{"test": true},
+	}
+	err := tc.repo.Create(ctx, ontology)
+	if err != nil {
+		tc.t.Fatalf("failed to create test ontology: %v", err)
+	}
+	return ontology
+}
+
+// ============================================================================
+// Create Tests
+// ============================================================================
+
+func TestOntologyRepository_Create_Success(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	ontology := &models.TieredOntology{
+		ProjectID: tc.projectID,
+		Version:   1,
+		IsActive:  true,
+		DomainSummary: &models.DomainSummary{
+			Description: "A test business domain",
+			Domains:     []string{"sales", "finance"},
+		},
+		EntitySummaries: map[string]*models.EntitySummary{
+			"orders": {
+				TableName:    "orders",
+				BusinessName: "Orders",
+				Description:  "Customer purchase orders",
+				Domain:       "sales",
+			},
+		},
+		ColumnDetails: map[string][]models.ColumnDetail{
+			"orders": {
+				{Name: "id", IsPrimaryKey: true},
+				{Name: "amount", Role: "measure"},
+			},
+		},
+		Metadata: map[string]any{"tables_analyzed": 10},
+	}
+
+	err := tc.repo.Create(ctx, ontology)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if ontology.ID == uuid.Nil {
+		t.Error("expected ID to be set")
+	}
+	if ontology.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be set")
+	}
+
+	// Verify by fetching
+	retrieved, err := tc.repo.GetByVersion(ctx, tc.projectID, 1)
+	if err != nil {
+		t.Fatalf("GetByVersion failed: %v", err)
+	}
+	if retrieved.DomainSummary == nil {
+		t.Error("expected DomainSummary to be set")
+	}
+	if retrieved.DomainSummary.Description != "A test business domain" {
+		t.Errorf("expected description 'A test business domain', got %q", retrieved.DomainSummary.Description)
+	}
+	if len(retrieved.EntitySummaries) != 1 {
+		t.Errorf("expected 1 entity summary, got %d", len(retrieved.EntitySummaries))
+	}
+}
+
+func TestOntologyRepository_Create_WithNilFields(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create with nil optional fields
+	ontology := &models.TieredOntology{
+		ProjectID: tc.projectID,
+		Version:   1,
+		IsActive:  true,
+	}
+
+	err := tc.repo.Create(ctx, ontology)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	retrieved, err := tc.repo.GetByVersion(ctx, tc.projectID, 1)
+	if err != nil {
+		t.Fatalf("GetByVersion failed: %v", err)
+	}
+	if retrieved.DomainSummary != nil {
+		t.Error("expected nil DomainSummary")
+	}
+	if retrieved.EntitySummaries != nil {
+		t.Error("expected nil EntitySummaries")
+	}
+}
+
+// ============================================================================
+// GetActive Tests
+// ============================================================================
+
+func TestOntologyRepository_GetActive_Success(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create inactive and active versions
+	tc.createTestOntology(ctx, 1, false)
+	active := tc.createTestOntology(ctx, 2, true)
+
+	retrieved, err := tc.repo.GetActive(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetActive failed: %v", err)
+	}
+	if retrieved == nil {
+		t.Fatal("expected active ontology, got nil")
+	}
+	if retrieved.Version != active.Version {
+		t.Errorf("expected version %d, got %d", active.Version, retrieved.Version)
+	}
+	if !retrieved.IsActive {
+		t.Error("expected IsActive to be true")
+	}
+}
+
+func TestOntologyRepository_GetActive_NoActive(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create only inactive versions
+	tc.createTestOntology(ctx, 1, false)
+	tc.createTestOntology(ctx, 2, false)
+
+	retrieved, err := tc.repo.GetActive(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetActive failed: %v", err)
+	}
+	if retrieved != nil {
+		t.Errorf("expected nil, got ontology version %d", retrieved.Version)
+	}
+}
+
+func TestOntologyRepository_GetActive_Empty(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	retrieved, err := tc.repo.GetActive(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetActive failed: %v", err)
+	}
+	if retrieved != nil {
+		t.Error("expected nil for empty project")
+	}
+}
+
+// ============================================================================
+// GetByVersion Tests
+// ============================================================================
+
+func TestOntologyRepository_GetByVersion_Success(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestOntology(ctx, 1, false)
+	tc.createTestOntology(ctx, 2, true)
+
+	retrieved, err := tc.repo.GetByVersion(ctx, tc.projectID, 1)
+	if err != nil {
+		t.Fatalf("GetByVersion failed: %v", err)
+	}
+	if retrieved.Version != 1 {
+		t.Errorf("expected version 1, got %d", retrieved.Version)
+	}
+}
+
+func TestOntologyRepository_GetByVersion_NotFound(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestOntology(ctx, 1, true)
+
+	_, err := tc.repo.GetByVersion(ctx, tc.projectID, 99)
+	if err == nil {
+		t.Error("expected error for non-existent version")
+	}
+}
+
+// ============================================================================
+// UpdateDomainSummary Tests
+// ============================================================================
+
+func TestOntologyRepository_UpdateDomainSummary_Success(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestOntology(ctx, 1, true)
+
+	newSummary := &models.DomainSummary{
+		Description:     "Updated domain description",
+		Domains:         []string{"operations", "hr"},
+		SampleQuestions: []string{"What are the active users?"},
+	}
+
+	err := tc.repo.UpdateDomainSummary(ctx, tc.projectID, newSummary)
+	if err != nil {
+		t.Fatalf("UpdateDomainSummary failed: %v", err)
+	}
+
+	retrieved, err := tc.repo.GetActive(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetActive failed: %v", err)
+	}
+	if retrieved.DomainSummary.Description != "Updated domain description" {
+		t.Errorf("expected updated description, got %q", retrieved.DomainSummary.Description)
+	}
+	if len(retrieved.DomainSummary.SampleQuestions) != 1 {
+		t.Errorf("expected 1 sample question, got %d", len(retrieved.DomainSummary.SampleQuestions))
+	}
+}
+
+func TestOntologyRepository_UpdateDomainSummary_NoActive(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestOntology(ctx, 1, false) // Inactive
+
+	err := tc.repo.UpdateDomainSummary(ctx, tc.projectID, &models.DomainSummary{Description: "test"})
+	if err == nil {
+		t.Error("expected error when no active ontology")
+	}
+}
+
+// ============================================================================
+// UpdateEntitySummary Tests
+// ============================================================================
+
+func TestOntologyRepository_UpdateEntitySummary_Success(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestOntology(ctx, 1, true)
+
+	newSummary := &models.EntitySummary{
+		TableName:    "orders",
+		BusinessName: "Customer Orders",
+		Description:  "All customer purchase orders",
+		Domain:       "sales",
+		Synonyms:     []string{"purchases", "transactions"},
+	}
+
+	err := tc.repo.UpdateEntitySummary(ctx, tc.projectID, "orders", newSummary)
+	if err != nil {
+		t.Fatalf("UpdateEntitySummary failed: %v", err)
+	}
+
+	retrieved, err := tc.repo.GetActive(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetActive failed: %v", err)
+	}
+
+	ordersSummary := retrieved.EntitySummaries["orders"]
+	if ordersSummary == nil {
+		t.Fatal("expected orders summary")
+	}
+	if ordersSummary.BusinessName != "Customer Orders" {
+		t.Errorf("expected 'Customer Orders', got %q", ordersSummary.BusinessName)
+	}
+	if len(ordersSummary.Synonyms) != 2 {
+		t.Errorf("expected 2 synonyms, got %d", len(ordersSummary.Synonyms))
+	}
+}
+
+func TestOntologyRepository_UpdateEntitySummary_AddNew(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestOntology(ctx, 1, true)
+
+	// Add a new entity (not in original)
+	newSummary := &models.EntitySummary{
+		TableName:    "products",
+		BusinessName: "Products",
+		Description:  "Product catalog",
+		Domain:       "product",
+	}
+
+	err := tc.repo.UpdateEntitySummary(ctx, tc.projectID, "products", newSummary)
+	if err != nil {
+		t.Fatalf("UpdateEntitySummary failed: %v", err)
+	}
+
+	retrieved, err := tc.repo.GetActive(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetActive failed: %v", err)
+	}
+
+	// Should have both original and new
+	if len(retrieved.EntitySummaries) != 2 {
+		t.Errorf("expected 2 entities, got %d", len(retrieved.EntitySummaries))
+	}
+	if retrieved.EntitySummaries["products"] == nil {
+		t.Error("expected products entity")
+	}
+	if retrieved.EntitySummaries["accounts"] == nil {
+		t.Error("expected original accounts entity to remain")
+	}
+}
+
+// ============================================================================
+// UpdateEntitySummaries (Batch) Tests
+// ============================================================================
+
+func TestOntologyRepository_UpdateEntitySummaries_Batch(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestOntology(ctx, 1, true)
+
+	summaries := map[string]*models.EntitySummary{
+		"users": {
+			TableName:    "users",
+			BusinessName: "Users",
+			Description:  "Application users",
+			Domain:       "customer",
+		},
+		"roles": {
+			TableName:    "roles",
+			BusinessName: "User Roles",
+			Description:  "Role definitions",
+			Domain:       "customer",
+		},
+	}
+
+	err := tc.repo.UpdateEntitySummaries(ctx, tc.projectID, summaries)
+	if err != nil {
+		t.Fatalf("UpdateEntitySummaries failed: %v", err)
+	}
+
+	retrieved, err := tc.repo.GetActive(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetActive failed: %v", err)
+	}
+
+	// Should have original + 2 new
+	if len(retrieved.EntitySummaries) != 3 {
+		t.Errorf("expected 3 entities, got %d", len(retrieved.EntitySummaries))
+	}
+}
+
+// ============================================================================
+// UpdateColumnDetails Tests
+// ============================================================================
+
+func TestOntologyRepository_UpdateColumnDetails_Success(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestOntology(ctx, 1, true)
+
+	columns := []models.ColumnDetail{
+		{Name: "id", IsPrimaryKey: true, Role: "identifier"},
+		{Name: "name", Description: "Account name", Synonyms: []string{"title", "label"}},
+		{Name: "balance", Role: "measure", SemanticType: "currency"},
+	}
+
+	err := tc.repo.UpdateColumnDetails(ctx, tc.projectID, "accounts", columns)
+	if err != nil {
+		t.Fatalf("UpdateColumnDetails failed: %v", err)
+	}
+
+	retrieved, err := tc.repo.GetActive(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetActive failed: %v", err)
+	}
+
+	accountCols := retrieved.ColumnDetails["accounts"]
+	if len(accountCols) != 3 {
+		t.Errorf("expected 3 columns, got %d", len(accountCols))
+	}
+}
+
+// ============================================================================
+// SetActive Tests
+// ============================================================================
+
+func TestOntologyRepository_SetActive_Success(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestOntology(ctx, 1, true)
+	tc.createTestOntology(ctx, 2, false)
+
+	// Switch active to version 2
+	err := tc.repo.SetActive(ctx, tc.projectID, 2)
+	if err != nil {
+		t.Fatalf("SetActive failed: %v", err)
+	}
+
+	// Verify version 2 is now active
+	active, err := tc.repo.GetActive(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetActive failed: %v", err)
+	}
+	if active.Version != 2 {
+		t.Errorf("expected version 2 active, got %d", active.Version)
+	}
+
+	// Verify version 1 is now inactive
+	v1, err := tc.repo.GetByVersion(ctx, tc.projectID, 1)
+	if err != nil {
+		t.Fatalf("GetByVersion failed: %v", err)
+	}
+	if v1.IsActive {
+		t.Error("expected version 1 to be inactive")
+	}
+}
+
+func TestOntologyRepository_SetActive_NotFound(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestOntology(ctx, 1, true)
+
+	err := tc.repo.SetActive(ctx, tc.projectID, 99)
+	if err == nil {
+		t.Error("expected error for non-existent version")
+	}
+}
+
+// ============================================================================
+// DeactivateAll Tests
+// ============================================================================
+
+func TestOntologyRepository_DeactivateAll_Success(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create one active ontology
+	tc.createTestOntology(ctx, 1, true)
+
+	err := tc.repo.DeactivateAll(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("DeactivateAll failed: %v", err)
+	}
+
+	active, err := tc.repo.GetActive(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetActive failed: %v", err)
+	}
+	if active != nil {
+		t.Error("expected no active ontology after DeactivateAll")
+	}
+}
+
+// ============================================================================
+// GetNextVersion Tests
+// ============================================================================
+
+func TestOntologyRepository_GetNextVersion_FirstVersion(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	version, err := tc.repo.GetNextVersion(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetNextVersion failed: %v", err)
+	}
+	if version != 1 {
+		t.Errorf("expected version 1 for new project, got %d", version)
+	}
+}
+
+func TestOntologyRepository_GetNextVersion_Increments(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestOntology(ctx, 1, false)
+	tc.createTestOntology(ctx, 2, true)
+
+	version, err := tc.repo.GetNextVersion(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetNextVersion failed: %v", err)
+	}
+	if version != 3 {
+		t.Errorf("expected version 3, got %d", version)
+	}
+}
+
+// ============================================================================
+// No Tenant Scope Tests (RLS Enforcement)
+// ============================================================================
+
+func TestOntologyRepository_NoTenantScope(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx := context.Background() // No tenant scope
+
+	ontology := &models.TieredOntology{
+		ProjectID: tc.projectID,
+		Version:   1,
+		IsActive:  true,
+	}
+
+	// Create should fail
+	err := tc.repo.Create(ctx, ontology)
+	if err == nil {
+		t.Error("expected error for Create without tenant scope")
+	}
+
+	// GetActive should fail
+	_, err = tc.repo.GetActive(ctx, tc.projectID)
+	if err == nil {
+		t.Error("expected error for GetActive without tenant scope")
+	}
+
+	// GetByVersion should fail
+	_, err = tc.repo.GetByVersion(ctx, tc.projectID, 1)
+	if err == nil {
+		t.Error("expected error for GetByVersion without tenant scope")
+	}
+
+	// UpdateDomainSummary should fail
+	err = tc.repo.UpdateDomainSummary(ctx, tc.projectID, &models.DomainSummary{})
+	if err == nil {
+		t.Error("expected error for UpdateDomainSummary without tenant scope")
+	}
+
+	// UpdateEntitySummary should fail
+	err = tc.repo.UpdateEntitySummary(ctx, tc.projectID, "test", &models.EntitySummary{})
+	if err == nil {
+		t.Error("expected error for UpdateEntitySummary without tenant scope")
+	}
+
+	// UpdateEntitySummaries should fail
+	err = tc.repo.UpdateEntitySummaries(ctx, tc.projectID, map[string]*models.EntitySummary{})
+	if err == nil {
+		t.Error("expected error for UpdateEntitySummaries without tenant scope")
+	}
+
+	// UpdateColumnDetails should fail
+	err = tc.repo.UpdateColumnDetails(ctx, tc.projectID, "test", nil)
+	if err == nil {
+		t.Error("expected error for UpdateColumnDetails without tenant scope")
+	}
+
+	// SetActive should fail
+	err = tc.repo.SetActive(ctx, tc.projectID, 1)
+	if err == nil {
+		t.Error("expected error for SetActive without tenant scope")
+	}
+
+	// DeactivateAll should fail
+	err = tc.repo.DeactivateAll(ctx, tc.projectID)
+	if err == nil {
+		t.Error("expected error for DeactivateAll without tenant scope")
+	}
+
+	// GetNextVersion should fail
+	_, err = tc.repo.GetNextVersion(ctx, tc.projectID)
+	if err == nil {
+		t.Error("expected error for GetNextVersion without tenant scope")
+	}
+}
+
+// ============================================================================
+// WriteCleanOntology Tests
+// ============================================================================
+
+func TestOntologyRepository_WriteCleanOntology_Success(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create ontology with semantic content
+	ontology := &models.TieredOntology{
+		ProjectID: tc.projectID,
+		Version:   1,
+		IsActive:  true,
+		DomainSummary: &models.DomainSummary{
+			Description: "Test domain",
+			Domains:     []string{"sales"},
+		},
+		EntitySummaries: map[string]*models.EntitySummary{
+			"orders": {
+				TableName:    "orders",
+				BusinessName: "Customer Orders",
+				Description:  "All customer purchase orders",
+				Domain:       "sales",
+				Synonyms:     []string{"purchases"},
+			},
+		},
+		ColumnDetails: map[string][]models.ColumnDetail{
+			"orders": {
+				{
+					Name:         "id",
+					Description:  "Order identifier",
+					IsPrimaryKey: true,
+				},
+				{
+					Name:         "status",
+					Description:  "Order status",
+					SemanticType: "order_lifecycle",
+					EnumValues: []models.EnumValue{
+						{Value: "pending", Description: "Awaiting processing"},
+						{Value: "shipped", Description: "Order shipped"},
+					},
+				},
+			},
+		},
+	}
+
+	err := tc.repo.Create(ctx, ontology)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// WriteCleanOntology should succeed when active ontology exists
+	err = tc.repo.WriteCleanOntology(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("WriteCleanOntology failed: %v", err)
+	}
+
+	// Verify ontology is still accessible
+	retrieved, err := tc.repo.GetActive(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetActive failed: %v", err)
+	}
+
+	// Verify semantic content is preserved
+	if retrieved.DomainSummary == nil || retrieved.DomainSummary.Description != "Test domain" {
+		t.Error("expected DomainSummary to be preserved")
+	}
+
+	ordersSummary := retrieved.EntitySummaries["orders"]
+	if ordersSummary == nil {
+		t.Fatal("expected orders entity summary")
+	}
+	if ordersSummary.BusinessName != "Customer Orders" {
+		t.Errorf("expected BusinessName 'Customer Orders', got %q", ordersSummary.BusinessName)
+	}
+
+	ordersCols := retrieved.ColumnDetails["orders"]
+	if len(ordersCols) != 2 {
+		t.Fatalf("expected 2 columns, got %d", len(ordersCols))
+	}
+}
+
+func TestOntologyRepository_WriteCleanOntology_NoActiveOntology(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// No ontology exists
+	err := tc.repo.WriteCleanOntology(ctx, tc.projectID)
+	if err == nil {
+		t.Error("expected error when no active ontology")
+	}
+}
+
+func TestOntologyRepository_WriteCleanOntology_EmptyOntology(t *testing.T) {
+	tc := setupOntologyTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create empty ontology
+	ontology := &models.TieredOntology{
+		ProjectID: tc.projectID,
+		Version:   1,
+		IsActive:  true,
+	}
+
+	err := tc.repo.Create(ctx, ontology)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// WriteCleanOntology should handle nil maps gracefully
+	err = tc.repo.WriteCleanOntology(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("WriteCleanOntology failed for empty ontology: %v", err)
+	}
+
+	retrieved, err := tc.repo.GetActive(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetActive failed: %v", err)
+	}
+
+	// Should still be valid with empty maps
+	if retrieved.EntitySummaries == nil {
+		// Empty map after clean write is acceptable
+	}
+}

--- a/pkg/repositories/ontology_workflow_repository.go
+++ b/pkg/repositories/ontology_workflow_repository.go
@@ -1,0 +1,473 @@
+package repositories
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+)
+
+// OntologyWorkflowRepository provides data access for ontology workflows.
+type OntologyWorkflowRepository interface {
+	Create(ctx context.Context, workflow *models.OntologyWorkflow) error
+	GetByID(ctx context.Context, id uuid.UUID) (*models.OntologyWorkflow, error)
+	GetByOntology(ctx context.Context, ontologyID uuid.UUID) (*models.OntologyWorkflow, error)
+	GetLatestByProject(ctx context.Context, projectID uuid.UUID) (*models.OntologyWorkflow, error)
+	Update(ctx context.Context, workflow *models.OntologyWorkflow) error
+	UpdateState(ctx context.Context, id uuid.UUID, state models.WorkflowState, errorMsg string) error
+	UpdateProgress(ctx context.Context, id uuid.UUID, progress *models.WorkflowProgress) error
+	UpdateTaskQueue(ctx context.Context, id uuid.UUID, tasks []models.WorkflowTask) error
+	Delete(ctx context.Context, id uuid.UUID) error
+	DeleteByProject(ctx context.Context, projectID uuid.UUID) error
+
+	// Ownership methods for multi-server robustness
+	ClaimOwnership(ctx context.Context, workflowID, ownerID uuid.UUID) (bool, error)
+	UpdateHeartbeat(ctx context.Context, workflowID, ownerID uuid.UUID) error
+	ReleaseOwnership(ctx context.Context, workflowID uuid.UUID) error
+}
+
+type ontologyWorkflowRepository struct{}
+
+// NewOntologyWorkflowRepository creates a new OntologyWorkflowRepository.
+func NewOntologyWorkflowRepository() OntologyWorkflowRepository {
+	return &ontologyWorkflowRepository{}
+}
+
+var _ OntologyWorkflowRepository = (*ontologyWorkflowRepository)(nil)
+
+func (r *ontologyWorkflowRepository) Create(ctx context.Context, workflow *models.OntologyWorkflow) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	now := time.Now()
+	workflow.CreatedAt = now
+	workflow.UpdatedAt = now
+	if workflow.ID == uuid.Nil {
+		workflow.ID = uuid.New()
+	}
+
+	progressJSON, err := json.Marshal(workflow.Progress)
+	if err != nil {
+		return fmt.Errorf("failed to marshal progress: %w", err)
+	}
+	if workflow.Progress == nil {
+		progressJSON = []byte("{}")
+	}
+
+	taskQueueJSON, err := json.Marshal(workflow.TaskQueue)
+	if err != nil {
+		return fmt.Errorf("failed to marshal task_queue: %w", err)
+	}
+	if workflow.TaskQueue == nil {
+		taskQueueJSON = []byte("[]")
+	}
+
+	configJSON, err := json.Marshal(workflow.Config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+	if workflow.Config == nil {
+		configJSON = []byte("{}")
+	}
+
+	query := `
+		INSERT INTO engine_ontology_workflows (
+			id, project_id, ontology_id, state, progress, task_queue, config,
+			error_message, started_at, completed_at, created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`
+
+	_, err = scope.Conn.Exec(ctx, query,
+		workflow.ID, workflow.ProjectID, workflow.OntologyID, workflow.State, progressJSON, taskQueueJSON, configJSON,
+		workflow.ErrorMessage, workflow.StartedAt, workflow.CompletedAt, workflow.CreatedAt, workflow.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create workflow: %w", err)
+	}
+
+	return nil
+}
+
+func (r *ontologyWorkflowRepository) GetByID(ctx context.Context, id uuid.UUID) (*models.OntologyWorkflow, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT id, project_id, ontology_id, state, progress, task_queue, config,
+		       error_message, started_at, completed_at, created_at, updated_at,
+		       owner_id, last_heartbeat
+		FROM engine_ontology_workflows
+		WHERE id = $1`
+
+	row := scope.Conn.QueryRow(ctx, query, id)
+	return scanOntologyWorkflowRow(row)
+}
+
+func (r *ontologyWorkflowRepository) GetByOntology(ctx context.Context, ontologyID uuid.UUID) (*models.OntologyWorkflow, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT id, project_id, ontology_id, state, progress, task_queue, config,
+		       error_message, started_at, completed_at, created_at, updated_at,
+		       owner_id, last_heartbeat
+		FROM engine_ontology_workflows
+		WHERE ontology_id = $1`
+
+	row := scope.Conn.QueryRow(ctx, query, ontologyID)
+	workflow, err := scanOntologyWorkflowRow(row)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil // No workflow found
+		}
+		return nil, err
+	}
+	return workflow, nil
+}
+
+func (r *ontologyWorkflowRepository) GetLatestByProject(ctx context.Context, projectID uuid.UUID) (*models.OntologyWorkflow, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT id, project_id, ontology_id, state, progress, task_queue, config,
+		       error_message, started_at, completed_at, created_at, updated_at,
+		       owner_id, last_heartbeat
+		FROM engine_ontology_workflows
+		WHERE project_id = $1
+		ORDER BY created_at DESC
+		LIMIT 1`
+
+	row := scope.Conn.QueryRow(ctx, query, projectID)
+	workflow, err := scanOntologyWorkflowRow(row)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil // No workflow found
+		}
+		return nil, err
+	}
+	return workflow, nil
+}
+
+func (r *ontologyWorkflowRepository) Update(ctx context.Context, workflow *models.OntologyWorkflow) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	workflow.UpdatedAt = time.Now()
+
+	progressJSON, err := json.Marshal(workflow.Progress)
+	if err != nil {
+		return fmt.Errorf("failed to marshal progress: %w", err)
+	}
+	if workflow.Progress == nil {
+		progressJSON = []byte("{}")
+	}
+
+	taskQueueJSON, err := json.Marshal(workflow.TaskQueue)
+	if err != nil {
+		return fmt.Errorf("failed to marshal task_queue: %w", err)
+	}
+	if workflow.TaskQueue == nil {
+		taskQueueJSON = []byte("[]")
+	}
+
+	configJSON, err := json.Marshal(workflow.Config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+	if workflow.Config == nil {
+		configJSON = []byte("{}")
+	}
+
+	query := `
+		UPDATE engine_ontology_workflows
+		SET state = $2,
+		    progress = $3,
+		    task_queue = $4,
+		    config = $5,
+		    error_message = $6,
+		    started_at = $7,
+		    completed_at = $8,
+		    updated_at = $9
+		WHERE id = $1`
+
+	result, err := scope.Conn.Exec(ctx, query,
+		workflow.ID, workflow.State, progressJSON, taskQueueJSON, configJSON,
+		workflow.ErrorMessage, workflow.StartedAt, workflow.CompletedAt, workflow.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update workflow: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("workflow not found")
+	}
+
+	return nil
+}
+
+func (r *ontologyWorkflowRepository) UpdateState(ctx context.Context, id uuid.UUID, state models.WorkflowState, errorMsg string) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	var completedAt *time.Time
+	if state.IsTerminal() {
+		now := time.Now()
+		completedAt = &now
+	}
+
+	query := `
+		UPDATE engine_ontology_workflows
+		SET state = $2,
+		    error_message = $3,
+		    completed_at = COALESCE($4, completed_at),
+		    updated_at = NOW()
+		WHERE id = $1`
+
+	result, err := scope.Conn.Exec(ctx, query, id, state, errorMsg, completedAt)
+	if err != nil {
+		return fmt.Errorf("failed to update workflow state: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("workflow not found")
+	}
+
+	return nil
+}
+
+func (r *ontologyWorkflowRepository) UpdateProgress(ctx context.Context, id uuid.UUID, progress *models.WorkflowProgress) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	progressJSON, err := json.Marshal(progress)
+	if err != nil {
+		return fmt.Errorf("failed to marshal progress: %w", err)
+	}
+
+	query := `
+		UPDATE engine_ontology_workflows
+		SET progress = $2,
+		    updated_at = NOW()
+		WHERE id = $1`
+
+	result, err := scope.Conn.Exec(ctx, query, id, progressJSON)
+	if err != nil {
+		return fmt.Errorf("failed to update workflow progress: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("workflow not found")
+	}
+
+	return nil
+}
+
+func (r *ontologyWorkflowRepository) UpdateTaskQueue(ctx context.Context, id uuid.UUID, tasks []models.WorkflowTask) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	taskQueueJSON, err := json.Marshal(tasks)
+	if err != nil {
+		return fmt.Errorf("failed to marshal task_queue: %w", err)
+	}
+
+	query := `
+		UPDATE engine_ontology_workflows
+		SET task_queue = $2,
+		    updated_at = NOW()
+		WHERE id = $1`
+
+	result, err := scope.Conn.Exec(ctx, query, id, taskQueueJSON)
+	if err != nil {
+		return fmt.Errorf("failed to update workflow task queue: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("workflow not found")
+	}
+
+	return nil
+}
+
+func (r *ontologyWorkflowRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `DELETE FROM engine_ontology_workflows WHERE id = $1`
+
+	result, err := scope.Conn.Exec(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete workflow: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("workflow not found")
+	}
+
+	return nil
+}
+
+func (r *ontologyWorkflowRepository) DeleteByProject(ctx context.Context, projectID uuid.UUID) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `DELETE FROM engine_ontology_workflows WHERE project_id = $1`
+
+	_, err := scope.Conn.Exec(ctx, query, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to delete workflows: %w", err)
+	}
+
+	return nil
+}
+
+// ============================================================================
+// Helper Functions - Scan
+// ============================================================================
+
+func scanOntologyWorkflowRow(row pgx.Row) (*models.OntologyWorkflow, error) {
+	var w models.OntologyWorkflow
+	var progressJSON, taskQueueJSON, configJSON []byte
+
+	err := row.Scan(
+		&w.ID, &w.ProjectID, &w.OntologyID, &w.State, &progressJSON, &taskQueueJSON, &configJSON,
+		&w.ErrorMessage, &w.StartedAt, &w.CompletedAt, &w.CreatedAt, &w.UpdatedAt,
+		&w.OwnerID, &w.LastHeartbeat,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, err
+		}
+		return nil, fmt.Errorf("failed to scan workflow: %w", err)
+	}
+
+	if len(progressJSON) > 0 && string(progressJSON) != "{}" {
+		w.Progress = &models.WorkflowProgress{}
+		if err := json.Unmarshal(progressJSON, w.Progress); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal progress: %w", err)
+		}
+	}
+
+	if len(taskQueueJSON) > 0 && string(taskQueueJSON) != "[]" {
+		if err := json.Unmarshal(taskQueueJSON, &w.TaskQueue); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal task_queue: %w", err)
+		}
+	}
+
+	if len(configJSON) > 0 && string(configJSON) != "{}" {
+		w.Config = &models.WorkflowConfig{}
+		if err := json.Unmarshal(configJSON, w.Config); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+		}
+	}
+
+	return &w, nil
+}
+
+// ============================================================================
+// Ownership Methods
+// ============================================================================
+
+// ClaimOwnership atomically claims a workflow if it's unowned or already owned by this server.
+// Returns true if ownership was claimed, false if owned by another server.
+func (r *ontologyWorkflowRepository) ClaimOwnership(ctx context.Context, workflowID, ownerID uuid.UUID) (bool, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return false, fmt.Errorf("no tenant scope in context")
+	}
+
+	// Atomic update: only claim if unowned or already owned by us
+	query := `
+		UPDATE engine_ontology_workflows
+		SET owner_id = $2,
+		    last_heartbeat = NOW(),
+		    updated_at = NOW()
+		WHERE id = $1 AND (owner_id IS NULL OR owner_id = $2)
+		RETURNING id`
+
+	var returnedID uuid.UUID
+	err := scope.Conn.QueryRow(ctx, query, workflowID, ownerID).Scan(&returnedID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			// No rows returned means another server owns it
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to claim ownership: %w", err)
+	}
+
+	return true, nil
+}
+
+// UpdateHeartbeat updates the last_heartbeat timestamp for an owned workflow.
+// Only updates if the workflow is owned by the specified owner.
+func (r *ontologyWorkflowRepository) UpdateHeartbeat(ctx context.Context, workflowID, ownerID uuid.UUID) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		UPDATE engine_ontology_workflows
+		SET last_heartbeat = NOW(),
+		    updated_at = NOW()
+		WHERE id = $1 AND owner_id = $2`
+
+	result, err := scope.Conn.Exec(ctx, query, workflowID, ownerID)
+	if err != nil {
+		return fmt.Errorf("failed to update heartbeat: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("workflow not found or not owned by this server")
+	}
+
+	return nil
+}
+
+// ReleaseOwnership clears the owner_id for a workflow, allowing other servers to claim it.
+func (r *ontologyWorkflowRepository) ReleaseOwnership(ctx context.Context, workflowID uuid.UUID) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		UPDATE engine_ontology_workflows
+		SET owner_id = NULL,
+		    last_heartbeat = NULL,
+		    updated_at = NOW()
+		WHERE id = $1`
+
+	_, err := scope.Conn.Exec(ctx, query, workflowID)
+	if err != nil {
+		return fmt.Errorf("failed to release ownership: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/repositories/ontology_workflow_repository_test.go
+++ b/pkg/repositories/ontology_workflow_repository_test.go
@@ -1,0 +1,377 @@
+//go:build integration
+
+package repositories
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/testhelpers"
+)
+
+// workflowTestContext holds test dependencies for workflow repository tests.
+type workflowTestContext struct {
+	t          *testing.T
+	engineDB   *testhelpers.EngineDB
+	repo       OntologyWorkflowRepository
+	projectID  uuid.UUID
+	ontologyID uuid.UUID
+}
+
+// setupWorkflowTest initializes the test context with shared testcontainer.
+// Each test gets a unique project ID to avoid unique constraint conflicts.
+func setupWorkflowTest(t *testing.T) *workflowTestContext {
+	engineDB := testhelpers.GetEngineDB(t)
+	tc := &workflowTestContext{
+		t:          t,
+		engineDB:   engineDB,
+		repo:       NewOntologyWorkflowRepository(),
+		projectID:  uuid.New(), // Unique per test to avoid constraint conflicts
+		ontologyID: uuid.New(),
+	}
+	tc.ensureTestProject()
+	tc.ensureTestOntology()
+	return tc
+}
+
+// ensureTestProject creates the test project if it doesn't exist.
+func (tc *workflowTestContext) ensureTestProject() {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create scope for project setup: %v", err)
+	}
+	defer scope.Close()
+
+	_, err = scope.Conn.Exec(ctx, `
+		INSERT INTO engine_projects (id, name, status)
+		VALUES ($1, $2, 'active')
+		ON CONFLICT (id) DO NOTHING
+	`, tc.projectID, "Workflow Test Project")
+	if err != nil {
+		tc.t.Fatalf("failed to ensure test project: %v", err)
+	}
+}
+
+// ensureTestOntology creates the test ontology if it doesn't exist.
+func (tc *workflowTestContext) ensureTestOntology() {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create scope for ontology setup: %v", err)
+	}
+	defer scope.Close()
+
+	_, err = scope.Conn.Exec(ctx, `
+		INSERT INTO engine_ontologies (id, project_id, version, is_active)
+		VALUES ($1, $2, 1, true)
+		ON CONFLICT (id) DO NOTHING
+	`, tc.ontologyID, tc.projectID)
+	if err != nil {
+		tc.t.Fatalf("failed to ensure test ontology: %v", err)
+	}
+}
+
+// cleanup removes test workflows.
+func (tc *workflowTestContext) cleanup() {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create scope for cleanup: %v", err)
+	}
+	defer scope.Close()
+
+	_, _ = scope.Conn.Exec(ctx, "DELETE FROM engine_ontology_workflows WHERE project_id = $1", tc.projectID)
+}
+
+// createTestContext returns a context with tenant scope.
+func (tc *workflowTestContext) createTestContext() (context.Context, func()) {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create tenant scope: %v", err)
+	}
+	ctx = database.SetTenantScope(ctx, scope)
+	return ctx, func() { scope.Close() }
+}
+
+// createTestWorkflow creates a workflow for testing.
+func (tc *workflowTestContext) createTestWorkflow(ctx context.Context) *models.OntologyWorkflow {
+	tc.t.Helper()
+	now := time.Now()
+	workflow := &models.OntologyWorkflow{
+		ID:         uuid.New(),
+		ProjectID:  tc.projectID,
+		OntologyID: tc.ontologyID,
+		State:      models.WorkflowStatePending,
+		Progress: &models.WorkflowProgress{
+			CurrentPhase: models.WorkflowPhaseInitializing,
+			Current:      0,
+			Total:        10,
+		},
+		Config:    models.DefaultWorkflowConfig(),
+		StartedAt: &now,
+	}
+	err := tc.repo.Create(ctx, workflow)
+	if err != nil {
+		tc.t.Fatalf("failed to create test workflow: %v", err)
+	}
+	return workflow
+}
+
+// ============================================================================
+// Ownership Tests
+// ============================================================================
+
+func TestWorkflowRepository_ClaimOwnership_Unowned(t *testing.T) {
+	tc := setupWorkflowTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create a workflow without owner
+	workflow := tc.createTestWorkflow(ctx)
+	serverID := uuid.New()
+
+	// Claim ownership
+	claimed, err := tc.repo.ClaimOwnership(ctx, workflow.ID, serverID)
+	if err != nil {
+		t.Fatalf("ClaimOwnership failed: %v", err)
+	}
+	if !claimed {
+		t.Fatal("expected to claim unowned workflow")
+	}
+
+	// Verify ownership was set
+	updated, err := tc.repo.GetByID(ctx, workflow.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if updated.OwnerID == nil || *updated.OwnerID != serverID {
+		t.Errorf("expected owner_id to be %s, got %v", serverID, updated.OwnerID)
+	}
+	if updated.LastHeartbeat == nil {
+		t.Error("expected last_heartbeat to be set")
+	}
+}
+
+func TestWorkflowRepository_ClaimOwnership_AlreadyOwnedBySelf(t *testing.T) {
+	tc := setupWorkflowTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create a workflow and claim it
+	workflow := tc.createTestWorkflow(ctx)
+	serverID := uuid.New()
+
+	claimed, err := tc.repo.ClaimOwnership(ctx, workflow.ID, serverID)
+	if err != nil {
+		t.Fatalf("First ClaimOwnership failed: %v", err)
+	}
+	if !claimed {
+		t.Fatal("expected to claim unowned workflow")
+	}
+
+	// Claim again by same server (should succeed - idempotent)
+	claimed2, err := tc.repo.ClaimOwnership(ctx, workflow.ID, serverID)
+	if err != nil {
+		t.Fatalf("Second ClaimOwnership failed: %v", err)
+	}
+	if !claimed2 {
+		t.Fatal("expected to re-claim own workflow")
+	}
+}
+
+func TestWorkflowRepository_ClaimOwnership_OwnedByOther(t *testing.T) {
+	tc := setupWorkflowTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create a workflow and claim it by server 1
+	workflow := tc.createTestWorkflow(ctx)
+	server1ID := uuid.New()
+	server2ID := uuid.New()
+
+	claimed, err := tc.repo.ClaimOwnership(ctx, workflow.ID, server1ID)
+	if err != nil {
+		t.Fatalf("First ClaimOwnership failed: %v", err)
+	}
+	if !claimed {
+		t.Fatal("expected to claim unowned workflow")
+	}
+
+	// Try to claim by server 2 (should fail)
+	claimed2, err := tc.repo.ClaimOwnership(ctx, workflow.ID, server2ID)
+	if err != nil {
+		t.Fatalf("Second ClaimOwnership should not return error: %v", err)
+	}
+	if claimed2 {
+		t.Fatal("expected NOT to claim workflow owned by another server")
+	}
+
+	// Verify owner is still server 1
+	updated, err := tc.repo.GetByID(ctx, workflow.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if updated.OwnerID == nil || *updated.OwnerID != server1ID {
+		t.Errorf("expected owner to still be %s, got %v", server1ID, updated.OwnerID)
+	}
+}
+
+func TestWorkflowRepository_UpdateHeartbeat(t *testing.T) {
+	tc := setupWorkflowTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create a workflow and claim it
+	workflow := tc.createTestWorkflow(ctx)
+	serverID := uuid.New()
+
+	claimed, err := tc.repo.ClaimOwnership(ctx, workflow.ID, serverID)
+	if err != nil || !claimed {
+		t.Fatalf("ClaimOwnership failed: %v, claimed: %v", err, claimed)
+	}
+
+	// Get initial heartbeat
+	initial, _ := tc.repo.GetByID(ctx, workflow.ID)
+	initialHeartbeat := initial.LastHeartbeat
+
+	// Wait a bit then update heartbeat
+	time.Sleep(10 * time.Millisecond)
+
+	err = tc.repo.UpdateHeartbeat(ctx, workflow.ID, serverID)
+	if err != nil {
+		t.Fatalf("UpdateHeartbeat failed: %v", err)
+	}
+
+	// Verify heartbeat was updated
+	updated, err := tc.repo.GetByID(ctx, workflow.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if updated.LastHeartbeat == nil {
+		t.Fatal("expected last_heartbeat to be set")
+	}
+	if !updated.LastHeartbeat.After(*initialHeartbeat) {
+		t.Errorf("expected heartbeat to be updated, initial: %v, updated: %v",
+			initialHeartbeat, updated.LastHeartbeat)
+	}
+}
+
+func TestWorkflowRepository_UpdateHeartbeat_WrongOwner(t *testing.T) {
+	tc := setupWorkflowTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create a workflow and claim it by server 1
+	workflow := tc.createTestWorkflow(ctx)
+	server1ID := uuid.New()
+	server2ID := uuid.New()
+
+	claimed, err := tc.repo.ClaimOwnership(ctx, workflow.ID, server1ID)
+	if err != nil || !claimed {
+		t.Fatalf("ClaimOwnership failed: %v, claimed: %v", err, claimed)
+	}
+
+	// Try to update heartbeat as server 2 (should fail)
+	err = tc.repo.UpdateHeartbeat(ctx, workflow.ID, server2ID)
+	if err == nil {
+		t.Fatal("expected UpdateHeartbeat to fail for wrong owner")
+	}
+}
+
+func TestWorkflowRepository_ReleaseOwnership(t *testing.T) {
+	tc := setupWorkflowTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create a workflow and claim it
+	workflow := tc.createTestWorkflow(ctx)
+	serverID := uuid.New()
+
+	claimed, err := tc.repo.ClaimOwnership(ctx, workflow.ID, serverID)
+	if err != nil || !claimed {
+		t.Fatalf("ClaimOwnership failed: %v, claimed: %v", err, claimed)
+	}
+
+	// Release ownership
+	err = tc.repo.ReleaseOwnership(ctx, workflow.ID)
+	if err != nil {
+		t.Fatalf("ReleaseOwnership failed: %v", err)
+	}
+
+	// Verify ownership was cleared
+	updated, err := tc.repo.GetByID(ctx, workflow.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if updated.OwnerID != nil {
+		t.Errorf("expected owner_id to be nil, got %v", updated.OwnerID)
+	}
+	if updated.LastHeartbeat != nil {
+		t.Errorf("expected last_heartbeat to be nil, got %v", updated.LastHeartbeat)
+	}
+}
+
+func TestWorkflowRepository_ReleaseOwnership_AllowsReclaim(t *testing.T) {
+	tc := setupWorkflowTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create a workflow and claim it by server 1
+	workflow := tc.createTestWorkflow(ctx)
+	server1ID := uuid.New()
+	server2ID := uuid.New()
+
+	claimed, err := tc.repo.ClaimOwnership(ctx, workflow.ID, server1ID)
+	if err != nil || !claimed {
+		t.Fatalf("First ClaimOwnership failed: %v, claimed: %v", err, claimed)
+	}
+
+	// Release ownership
+	err = tc.repo.ReleaseOwnership(ctx, workflow.ID)
+	if err != nil {
+		t.Fatalf("ReleaseOwnership failed: %v", err)
+	}
+
+	// Server 2 should now be able to claim
+	claimed2, err := tc.repo.ClaimOwnership(ctx, workflow.ID, server2ID)
+	if err != nil {
+		t.Fatalf("Second ClaimOwnership failed: %v", err)
+	}
+	if !claimed2 {
+		t.Fatal("expected server 2 to claim released workflow")
+	}
+
+	// Verify owner is now server 2
+	updated, err := tc.repo.GetByID(ctx, workflow.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if updated.OwnerID == nil || *updated.OwnerID != server2ID {
+		t.Errorf("expected owner to be %s, got %v", server2ID, updated.OwnerID)
+	}
+}

--- a/pkg/repositories/workflow_state_repository.go
+++ b/pkg/repositories/workflow_state_repository.go
@@ -1,0 +1,867 @@
+package repositories
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+)
+
+// QuestionCounts holds required and optional pending question counts.
+type QuestionCounts struct {
+	Required int `json:"required"`
+	Optional int `json:"optional"`
+}
+
+// WorkflowStateRepository provides data access for workflow entity states.
+type WorkflowStateRepository interface {
+	// CRUD operations
+	Create(ctx context.Context, state *models.WorkflowEntityState) error
+	CreateBatch(ctx context.Context, states []*models.WorkflowEntityState) error
+	GetByID(ctx context.Context, id uuid.UUID) (*models.WorkflowEntityState, error)
+	Update(ctx context.Context, state *models.WorkflowEntityState) error
+	Delete(ctx context.Context, id uuid.UUID) error
+
+	// Query methods
+	ListByWorkflow(ctx context.Context, workflowID uuid.UUID) ([]*models.WorkflowEntityState, error)
+	ListByStatus(ctx context.Context, workflowID uuid.UUID, status models.WorkflowEntityStatus) ([]*models.WorkflowEntityState, error)
+	GetByEntity(ctx context.Context, workflowID uuid.UUID, entityType models.WorkflowEntityType, entityKey string) (*models.WorkflowEntityState, error)
+
+	// Batch operations
+	DeleteByWorkflow(ctx context.Context, workflowID uuid.UUID) error
+
+	// State updates
+	UpdateStatus(ctx context.Context, id uuid.UUID, status models.WorkflowEntityStatus, lastError *string) error
+	UpdateStateData(ctx context.Context, id uuid.UUID, stateData *models.WorkflowStateData) error
+	IncrementRetryCount(ctx context.Context, id uuid.UUID) error
+
+	// Question operations (for state_data.questions)
+	AddQuestionsToEntity(ctx context.Context, id uuid.UUID, questions []models.WorkflowQuestion) error
+	UpdateQuestionInEntity(ctx context.Context, id uuid.UUID, questionID string, status string, answer string) error
+	RecordAnswerInEntity(ctx context.Context, id uuid.UUID, answer models.WorkflowAnswer) error
+	GetNextPendingQuestion(ctx context.Context, workflowID uuid.UUID) (*models.WorkflowQuestion, uuid.UUID, error)
+	GetPendingQuestions(ctx context.Context, projectID uuid.UUID, limit int) ([]models.WorkflowQuestion, error)
+	GetPendingQuestionsCount(ctx context.Context, workflowID uuid.UUID) (required int, optional int, err error)
+	GetPendingQuestionsCountByProject(ctx context.Context, projectID uuid.UUID) (int, error)
+	FindQuestionByID(ctx context.Context, questionID string) (*models.WorkflowQuestion, *models.WorkflowEntityState, *models.OntologyWorkflow, error)
+}
+
+type workflowStateRepository struct{}
+
+// NewWorkflowStateRepository creates a new WorkflowStateRepository.
+func NewWorkflowStateRepository() WorkflowStateRepository {
+	return &workflowStateRepository{}
+}
+
+var _ WorkflowStateRepository = (*workflowStateRepository)(nil)
+
+// ============================================================================
+// Create Operations
+// ============================================================================
+
+func (r *workflowStateRepository) Create(ctx context.Context, state *models.WorkflowEntityState) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	now := time.Now()
+	state.CreatedAt = now
+	state.UpdatedAt = now
+	if state.ID == uuid.Nil {
+		state.ID = uuid.New()
+	}
+	if state.Status == "" {
+		state.Status = models.WorkflowEntityStatusPending
+	}
+
+	stateDataJSON, err := marshalStateData(state.StateData)
+	if err != nil {
+		return err
+	}
+
+	query := `
+		INSERT INTO engine_workflow_state (
+			id, project_id, ontology_id, workflow_id,
+			entity_type, entity_key, status, state_data,
+			data_fingerprint, last_error, retry_count,
+			created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`
+
+	_, err = scope.Conn.Exec(ctx, query,
+		state.ID, state.ProjectID, state.OntologyID, state.WorkflowID,
+		state.EntityType, state.EntityKey, state.Status, stateDataJSON,
+		state.DataFingerprint, state.LastError, state.RetryCount,
+		state.CreatedAt, state.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create workflow state: %w", err)
+	}
+
+	return nil
+}
+
+func (r *workflowStateRepository) CreateBatch(ctx context.Context, states []*models.WorkflowEntityState) error {
+	if len(states) == 0 {
+		return nil
+	}
+
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	now := time.Now()
+
+	// Use COPY for efficient batch insert
+	columns := []string{
+		"id", "project_id", "ontology_id", "workflow_id",
+		"entity_type", "entity_key", "status", "state_data",
+		"data_fingerprint", "last_error", "retry_count",
+		"created_at", "updated_at",
+	}
+
+	rows := make([][]any, len(states))
+	for i, state := range states {
+		if state.ID == uuid.Nil {
+			state.ID = uuid.New()
+		}
+		state.CreatedAt = now
+		state.UpdatedAt = now
+		if state.Status == "" {
+			state.Status = models.WorkflowEntityStatusPending
+		}
+
+		stateDataJSON, err := marshalStateData(state.StateData)
+		if err != nil {
+			return err
+		}
+
+		rows[i] = []any{
+			state.ID, state.ProjectID, state.OntologyID, state.WorkflowID,
+			state.EntityType, state.EntityKey, state.Status, stateDataJSON,
+			state.DataFingerprint, state.LastError, state.RetryCount,
+			state.CreatedAt, state.UpdatedAt,
+		}
+	}
+
+	_, err := scope.Conn.CopyFrom(
+		ctx,
+		pgx.Identifier{"engine_workflow_state"},
+		columns,
+		pgx.CopyFromRows(rows),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to batch create workflow states: %w", err)
+	}
+
+	return nil
+}
+
+// ============================================================================
+// Read Operations
+// ============================================================================
+
+func (r *workflowStateRepository) GetByID(ctx context.Context, id uuid.UUID) (*models.WorkflowEntityState, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT id, project_id, ontology_id, workflow_id,
+		       entity_type, entity_key, status, state_data,
+		       data_fingerprint, last_error, retry_count,
+		       created_at, updated_at
+		FROM engine_workflow_state
+		WHERE id = $1`
+
+	row := scope.Conn.QueryRow(ctx, query, id)
+	state, err := scanWorkflowStateRow(row)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return state, nil
+}
+
+func (r *workflowStateRepository) GetByEntity(ctx context.Context, workflowID uuid.UUID, entityType models.WorkflowEntityType, entityKey string) (*models.WorkflowEntityState, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT id, project_id, ontology_id, workflow_id,
+		       entity_type, entity_key, status, state_data,
+		       data_fingerprint, last_error, retry_count,
+		       created_at, updated_at
+		FROM engine_workflow_state
+		WHERE workflow_id = $1 AND entity_type = $2 AND entity_key = $3`
+
+	row := scope.Conn.QueryRow(ctx, query, workflowID, entityType, entityKey)
+	state, err := scanWorkflowStateRow(row)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return state, nil
+}
+
+func (r *workflowStateRepository) ListByWorkflow(ctx context.Context, workflowID uuid.UUID) ([]*models.WorkflowEntityState, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT id, project_id, ontology_id, workflow_id,
+		       entity_type, entity_key, status, state_data,
+		       data_fingerprint, last_error, retry_count,
+		       created_at, updated_at
+		FROM engine_workflow_state
+		WHERE workflow_id = $1
+		ORDER BY entity_type, entity_key`
+
+	rows, err := scope.Conn.Query(ctx, query, workflowID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list workflow states: %w", err)
+	}
+	defer rows.Close()
+
+	return scanWorkflowStateRows(rows)
+}
+
+func (r *workflowStateRepository) ListByStatus(ctx context.Context, workflowID uuid.UUID, status models.WorkflowEntityStatus) ([]*models.WorkflowEntityState, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		SELECT id, project_id, ontology_id, workflow_id,
+		       entity_type, entity_key, status, state_data,
+		       data_fingerprint, last_error, retry_count,
+		       created_at, updated_at
+		FROM engine_workflow_state
+		WHERE workflow_id = $1 AND status = $2
+		ORDER BY entity_type, entity_key`
+
+	rows, err := scope.Conn.Query(ctx, query, workflowID, status)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list workflow states by status: %w", err)
+	}
+	defer rows.Close()
+
+	return scanWorkflowStateRows(rows)
+}
+
+// ============================================================================
+// Update Operations
+// ============================================================================
+
+func (r *workflowStateRepository) Update(ctx context.Context, state *models.WorkflowEntityState) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	state.UpdatedAt = time.Now()
+
+	stateDataJSON, err := marshalStateData(state.StateData)
+	if err != nil {
+		return err
+	}
+
+	query := `
+		UPDATE engine_workflow_state
+		SET entity_type = $2,
+		    entity_key = $3,
+		    status = $4,
+		    state_data = $5,
+		    data_fingerprint = $6,
+		    last_error = $7,
+		    retry_count = $8,
+		    updated_at = $9
+		WHERE id = $1`
+
+	result, err := scope.Conn.Exec(ctx, query,
+		state.ID, state.EntityType, state.EntityKey, state.Status, stateDataJSON,
+		state.DataFingerprint, state.LastError, state.RetryCount, state.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update workflow state: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("workflow state not found")
+	}
+
+	return nil
+}
+
+func (r *workflowStateRepository) UpdateStatus(ctx context.Context, id uuid.UUID, status models.WorkflowEntityStatus, lastError *string) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		UPDATE engine_workflow_state
+		SET status = $2,
+		    last_error = $3,
+		    updated_at = NOW()
+		WHERE id = $1`
+
+	result, err := scope.Conn.Exec(ctx, query, id, status, lastError)
+	if err != nil {
+		return fmt.Errorf("failed to update workflow state status: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("workflow state not found")
+	}
+
+	return nil
+}
+
+func (r *workflowStateRepository) UpdateStateData(ctx context.Context, id uuid.UUID, stateData *models.WorkflowStateData) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	stateDataJSON, err := marshalStateData(stateData)
+	if err != nil {
+		return err
+	}
+
+	query := `
+		UPDATE engine_workflow_state
+		SET state_data = $2,
+		    updated_at = NOW()
+		WHERE id = $1`
+
+	result, err := scope.Conn.Exec(ctx, query, id, stateDataJSON)
+	if err != nil {
+		return fmt.Errorf("failed to update workflow state data: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("workflow state not found")
+	}
+
+	return nil
+}
+
+func (r *workflowStateRepository) IncrementRetryCount(ctx context.Context, id uuid.UUID) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `
+		UPDATE engine_workflow_state
+		SET retry_count = retry_count + 1,
+		    updated_at = NOW()
+		WHERE id = $1`
+
+	result, err := scope.Conn.Exec(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("failed to increment retry count: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("workflow state not found")
+	}
+
+	return nil
+}
+
+// ============================================================================
+// Delete Operations
+// ============================================================================
+
+func (r *workflowStateRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `DELETE FROM engine_workflow_state WHERE id = $1`
+
+	result, err := scope.Conn.Exec(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete workflow state: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("workflow state not found")
+	}
+
+	return nil
+}
+
+func (r *workflowStateRepository) DeleteByWorkflow(ctx context.Context, workflowID uuid.UUID) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	query := `DELETE FROM engine_workflow_state WHERE workflow_id = $1`
+
+	_, err := scope.Conn.Exec(ctx, query, workflowID)
+	if err != nil {
+		return fmt.Errorf("failed to delete workflow states: %w", err)
+	}
+
+	return nil
+}
+
+// ============================================================================
+// Question Operations
+// ============================================================================
+
+func (r *workflowStateRepository) AddQuestionsToEntity(ctx context.Context, id uuid.UUID, questions []models.WorkflowQuestion) error {
+	if len(questions) == 0 {
+		return nil
+	}
+
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	// Get current state
+	state, err := r.GetByID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to get workflow state: %w", err)
+	}
+	if state == nil {
+		return fmt.Errorf("workflow state not found: %s", id)
+	}
+
+	// Initialize state_data if nil
+	if state.StateData == nil {
+		state.StateData = &models.WorkflowStateData{}
+	}
+
+	// Append questions
+	state.StateData.Questions = append(state.StateData.Questions, questions...)
+
+	stateDataJSON, err := marshalStateData(state.StateData)
+	if err != nil {
+		return err
+	}
+
+	query := `
+		UPDATE engine_workflow_state
+		SET state_data = $2,
+		    updated_at = NOW()
+		WHERE id = $1`
+
+	result, err := scope.Conn.Exec(ctx, query, id, stateDataJSON)
+	if err != nil {
+		return fmt.Errorf("failed to add questions to entity: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("workflow state not found")
+	}
+
+	return nil
+}
+
+func (r *workflowStateRepository) UpdateQuestionInEntity(ctx context.Context, id uuid.UUID, questionID string, status string, answer string) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	// Get current state
+	state, err := r.GetByID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to get workflow state: %w", err)
+	}
+	if state == nil {
+		return fmt.Errorf("workflow state not found: %s", id)
+	}
+
+	if state.StateData == nil || len(state.StateData.Questions) == 0 {
+		return fmt.Errorf("no questions in entity state: %s", id)
+	}
+
+	// Find and update the question
+	found := false
+	for i := range state.StateData.Questions {
+		if state.StateData.Questions[i].ID == questionID {
+			state.StateData.Questions[i].Status = status
+			if answer != "" {
+				state.StateData.Questions[i].Answer = answer
+				now := time.Now()
+				state.StateData.Questions[i].AnsweredAt = &now
+			}
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("question %s not found in entity state: %s", questionID, id)
+	}
+
+	stateDataJSON, err := marshalStateData(state.StateData)
+	if err != nil {
+		return err
+	}
+
+	query := `
+		UPDATE engine_workflow_state
+		SET state_data = $2,
+		    updated_at = NOW()
+		WHERE id = $1`
+
+	result, err := scope.Conn.Exec(ctx, query, id, stateDataJSON)
+	if err != nil {
+		return fmt.Errorf("failed to update question in entity: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("workflow state not found")
+	}
+
+	return nil
+}
+
+func (r *workflowStateRepository) RecordAnswerInEntity(ctx context.Context, id uuid.UUID, answer models.WorkflowAnswer) error {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+
+	// Get current state
+	state, err := r.GetByID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to get workflow state: %w", err)
+	}
+	if state == nil {
+		return fmt.Errorf("workflow state not found: %s", id)
+	}
+
+	// Initialize state_data if nil
+	if state.StateData == nil {
+		state.StateData = &models.WorkflowStateData{}
+	}
+
+	// Append answer
+	state.StateData.Answers = append(state.StateData.Answers, answer)
+
+	stateDataJSON, err := marshalStateData(state.StateData)
+	if err != nil {
+		return err
+	}
+
+	query := `
+		UPDATE engine_workflow_state
+		SET state_data = $2,
+		    updated_at = NOW()
+		WHERE id = $1`
+
+	result, err := scope.Conn.Exec(ctx, query, id, stateDataJSON)
+	if err != nil {
+		return fmt.Errorf("failed to record answer in entity: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("workflow state not found")
+	}
+
+	return nil
+}
+
+func (r *workflowStateRepository) GetNextPendingQuestion(ctx context.Context, workflowID uuid.UUID) (*models.WorkflowQuestion, uuid.UUID, error) {
+	// Get all states for the workflow
+	states, err := r.ListByWorkflow(ctx, workflowID)
+	if err != nil {
+		return nil, uuid.Nil, fmt.Errorf("failed to list workflow states: %w", err)
+	}
+
+	// Find the highest priority pending question across all entities
+	// Priority 1 = highest, so we look for the lowest number
+	var bestQuestion *models.WorkflowQuestion
+	var bestEntityID uuid.UUID
+	bestPriority := 999
+
+	for _, state := range states {
+		if state.StateData == nil || len(state.StateData.Questions) == 0 {
+			continue
+		}
+
+		for i := range state.StateData.Questions {
+			q := &state.StateData.Questions[i]
+			if q.Status == string(models.QuestionStatusPending) {
+				// Prefer required questions over optional
+				effectivePriority := q.Priority
+				if !q.IsRequired {
+					effectivePriority += 100 // Push optional questions lower
+				}
+
+				if effectivePriority < bestPriority {
+					bestPriority = effectivePriority
+					bestQuestion = q
+					bestEntityID = state.ID
+				}
+			}
+		}
+	}
+
+	if bestQuestion == nil {
+		return nil, uuid.Nil, nil
+	}
+
+	return bestQuestion, bestEntityID, nil
+}
+
+func (r *workflowStateRepository) GetPendingQuestionsCount(ctx context.Context, workflowID uuid.UUID) (required int, optional int, err error) {
+	// Get all states for the workflow
+	states, err := r.ListByWorkflow(ctx, workflowID)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to list workflow states: %w", err)
+	}
+
+	for _, state := range states {
+		if state.StateData == nil || len(state.StateData.Questions) == 0 {
+			continue
+		}
+
+		for _, q := range state.StateData.Questions {
+			if q.Status == string(models.QuestionStatusPending) {
+				if q.IsRequired {
+					required++
+				} else {
+					optional++
+				}
+			}
+		}
+	}
+
+	return required, optional, nil
+}
+
+func (r *workflowStateRepository) GetPendingQuestions(ctx context.Context, projectID uuid.UUID, limit int) ([]models.WorkflowQuestion, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	// Query all workflow states for this project with pending questions.
+	// We extract questions from JSONB and filter for pending status.
+	query := `
+		SELECT q.value
+		FROM engine_workflow_state s
+		JOIN engine_ontology_workflows w ON s.workflow_id = w.id
+		CROSS JOIN LATERAL jsonb_array_elements(COALESCE(s.state_data->'questions', '[]'::jsonb)) AS q
+		WHERE w.project_id = $1
+		  AND q.value->>'status' = 'pending'
+		ORDER BY
+			CASE WHEN (q.value->>'is_required')::boolean THEN 0 ELSE 1 END,
+			COALESCE((q.value->>'priority')::int, 0) DESC
+		LIMIT $2`
+
+	rows, err := scope.Conn.Query(ctx, query, projectID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query pending questions: %w", err)
+	}
+	defer rows.Close()
+
+	var questions []models.WorkflowQuestion
+	for rows.Next() {
+		var questionJSON []byte
+		if err := rows.Scan(&questionJSON); err != nil {
+			return nil, fmt.Errorf("failed to scan question: %w", err)
+		}
+
+		var q models.WorkflowQuestion
+		if err := json.Unmarshal(questionJSON, &q); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal question: %w", err)
+		}
+		questions = append(questions, q)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating questions: %w", err)
+	}
+
+	return questions, nil
+}
+
+func (r *workflowStateRepository) GetPendingQuestionsCountByProject(ctx context.Context, projectID uuid.UUID) (int, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return 0, fmt.Errorf("no tenant scope in context")
+	}
+
+	// Count pending questions across all workflows for this project.
+	query := `
+		SELECT COUNT(*)
+		FROM engine_workflow_state s
+		JOIN engine_ontology_workflows w ON s.workflow_id = w.id
+		CROSS JOIN LATERAL jsonb_array_elements(COALESCE(s.state_data->'questions', '[]'::jsonb)) AS q
+		WHERE w.project_id = $1
+		  AND q.value->>'status' = 'pending'`
+
+	var count int
+	if err := scope.Conn.QueryRow(ctx, query, projectID).Scan(&count); err != nil {
+		return 0, fmt.Errorf("failed to count pending questions: %w", err)
+	}
+
+	return count, nil
+}
+
+func (r *workflowStateRepository) FindQuestionByID(ctx context.Context, questionID string) (*models.WorkflowQuestion, *models.WorkflowEntityState, *models.OntologyWorkflow, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	// Search for the question in all entity states using JSONB query.
+	// This is efficient because we're using @> containment operator on an indexed JSONB path.
+	query := `
+		SELECT s.id, s.project_id, s.ontology_id, s.workflow_id,
+		       s.entity_type, s.entity_key, s.status, s.state_data,
+		       s.data_fingerprint, s.last_error, s.retry_count,
+		       s.created_at, s.updated_at,
+		       w.id, w.project_id, w.ontology_id, w.state, w.error_message,
+		       w.owner_id, w.last_heartbeat, w.created_at, w.updated_at
+		FROM engine_workflow_state s
+		JOIN engine_ontology_workflows w ON s.workflow_id = w.id
+		WHERE EXISTS (
+			SELECT 1 FROM jsonb_array_elements(COALESCE(s.state_data->'questions', '[]'::jsonb)) q
+			WHERE q->>'id' = $1
+		)`
+
+	row := scope.Conn.QueryRow(ctx, query, questionID)
+
+	var ws models.WorkflowEntityState
+	var wf models.OntologyWorkflow
+	var stateDataJSON []byte
+
+	err := row.Scan(
+		&ws.ID, &ws.ProjectID, &ws.OntologyID, &ws.WorkflowID,
+		&ws.EntityType, &ws.EntityKey, &ws.Status, &stateDataJSON,
+		&ws.DataFingerprint, &ws.LastError, &ws.RetryCount,
+		&ws.CreatedAt, &ws.UpdatedAt,
+		&wf.ID, &wf.ProjectID, &wf.OntologyID, &wf.State, &wf.ErrorMessage,
+		&wf.OwnerID, &wf.LastHeartbeat, &wf.CreatedAt, &wf.UpdatedAt,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil, nil, fmt.Errorf("question not found: %s", questionID)
+		}
+		return nil, nil, nil, fmt.Errorf("failed to find question: %w", err)
+	}
+
+	// Parse state data
+	if len(stateDataJSON) > 0 && string(stateDataJSON) != "{}" {
+		ws.StateData = &models.WorkflowStateData{}
+		if err := json.Unmarshal(stateDataJSON, ws.StateData); err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to unmarshal state_data: %w", err)
+		}
+	}
+
+	// Find the specific question
+	if ws.StateData != nil {
+		for i := range ws.StateData.Questions {
+			if ws.StateData.Questions[i].ID == questionID {
+				return &ws.StateData.Questions[i], &ws, &wf, nil
+			}
+		}
+	}
+
+	return nil, nil, nil, fmt.Errorf("question not found in parsed state: %s", questionID)
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+func marshalStateData(stateData *models.WorkflowStateData) ([]byte, error) {
+	if stateData == nil {
+		return []byte("{}"), nil
+	}
+	data, err := json.Marshal(stateData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal state_data: %w", err)
+	}
+	return data, nil
+}
+
+func scanWorkflowStateRow(row pgx.Row) (*models.WorkflowEntityState, error) {
+	var ws models.WorkflowEntityState
+	var stateDataJSON []byte
+
+	err := row.Scan(
+		&ws.ID, &ws.ProjectID, &ws.OntologyID, &ws.WorkflowID,
+		&ws.EntityType, &ws.EntityKey, &ws.Status, &stateDataJSON,
+		&ws.DataFingerprint, &ws.LastError, &ws.RetryCount,
+		&ws.CreatedAt, &ws.UpdatedAt,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, err
+		}
+		return nil, fmt.Errorf("failed to scan workflow state: %w", err)
+	}
+
+	if len(stateDataJSON) > 0 && string(stateDataJSON) != "{}" {
+		ws.StateData = &models.WorkflowStateData{}
+		if err := json.Unmarshal(stateDataJSON, ws.StateData); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal state_data: %w", err)
+		}
+	}
+
+	return &ws, nil
+}
+
+func scanWorkflowStateRows(rows pgx.Rows) ([]*models.WorkflowEntityState, error) {
+	var states []*models.WorkflowEntityState
+	for rows.Next() {
+		var ws models.WorkflowEntityState
+		var stateDataJSON []byte
+
+		err := rows.Scan(
+			&ws.ID, &ws.ProjectID, &ws.OntologyID, &ws.WorkflowID,
+			&ws.EntityType, &ws.EntityKey, &ws.Status, &stateDataJSON,
+			&ws.DataFingerprint, &ws.LastError, &ws.RetryCount,
+			&ws.CreatedAt, &ws.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan workflow state row: %w", err)
+		}
+
+		if len(stateDataJSON) > 0 && string(stateDataJSON) != "{}" {
+			ws.StateData = &models.WorkflowStateData{}
+			if err := json.Unmarshal(stateDataJSON, ws.StateData); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal state_data: %w", err)
+			}
+		}
+
+		states = append(states, &ws)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating workflow state rows: %w", err)
+	}
+
+	return states, nil
+}

--- a/pkg/repositories/workflow_state_repository_test.go
+++ b/pkg/repositories/workflow_state_repository_test.go
@@ -1,0 +1,1369 @@
+//go:build integration
+
+package repositories
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/testhelpers"
+)
+
+// workflowStateTestContext holds test dependencies for workflow state repository tests.
+type workflowStateTestContext struct {
+	t          *testing.T
+	engineDB   *testhelpers.EngineDB
+	repo       WorkflowStateRepository
+	projectID  uuid.UUID
+	ontologyID uuid.UUID
+	workflowID uuid.UUID
+}
+
+// setupWorkflowStateTest initializes the test context with shared testcontainer.
+func setupWorkflowStateTest(t *testing.T) *workflowStateTestContext {
+	engineDB := testhelpers.GetEngineDB(t)
+	tc := &workflowStateTestContext{
+		t:          t,
+		engineDB:   engineDB,
+		repo:       NewWorkflowStateRepository(),
+		projectID:  uuid.MustParse("00000000-0000-0000-0000-000000000081"),
+		ontologyID: uuid.MustParse("00000000-0000-0000-0000-000000000082"),
+		workflowID: uuid.MustParse("00000000-0000-0000-0000-000000000083"),
+	}
+	tc.ensureTestFixtures()
+	return tc
+}
+
+// ensureTestFixtures creates the test project, ontology, and workflow if they don't exist.
+func (tc *workflowStateTestContext) ensureTestFixtures() {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create scope for fixture setup: %v", err)
+	}
+	defer scope.Close()
+
+	now := time.Now()
+
+	// Create project
+	_, err = scope.Conn.Exec(ctx, `
+		INSERT INTO engine_projects (id, name, status)
+		VALUES ($1, $2, 'active')
+		ON CONFLICT (id) DO NOTHING
+	`, tc.projectID, "Workflow State Test Project")
+	if err != nil {
+		tc.t.Fatalf("failed to ensure test project: %v", err)
+	}
+
+	// Create ontology
+	_, err = scope.Conn.Exec(ctx, `
+		INSERT INTO engine_ontologies (id, project_id, is_active, created_at, updated_at)
+		VALUES ($1, $2, true, $3, $3)
+		ON CONFLICT (id) DO NOTHING
+	`, tc.ontologyID, tc.projectID, now)
+	if err != nil {
+		tc.t.Fatalf("failed to ensure test ontology: %v", err)
+	}
+
+	// Create workflow
+	_, err = scope.Conn.Exec(ctx, `
+		INSERT INTO engine_ontology_workflows (id, project_id, ontology_id, state, created_at, updated_at)
+		VALUES ($1, $2, $3, 'running', $4, $4)
+		ON CONFLICT (id) DO NOTHING
+	`, tc.workflowID, tc.projectID, tc.ontologyID, now)
+	if err != nil {
+		tc.t.Fatalf("failed to ensure test workflow: %v", err)
+	}
+}
+
+// cleanup removes test workflow states.
+func (tc *workflowStateTestContext) cleanup() {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create scope for cleanup: %v", err)
+	}
+	defer scope.Close()
+
+	_, _ = scope.Conn.Exec(ctx, "DELETE FROM engine_workflow_state WHERE project_id = $1", tc.projectID)
+}
+
+// createTestContext returns a context with tenant scope.
+func (tc *workflowStateTestContext) createTestContext() (context.Context, func()) {
+	tc.t.Helper()
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("failed to create tenant scope: %v", err)
+	}
+	ctx = database.SetTenantScope(ctx, scope)
+	return ctx, func() { scope.Close() }
+}
+
+// createTestState creates a workflow state for testing.
+func (tc *workflowStateTestContext) createTestState(
+	ctx context.Context,
+	entityType models.WorkflowEntityType,
+	entityKey string,
+	status models.WorkflowEntityStatus,
+) *models.WorkflowEntityState {
+	tc.t.Helper()
+	state := &models.WorkflowEntityState{
+		ProjectID:  tc.projectID,
+		OntologyID: tc.ontologyID,
+		WorkflowID: tc.workflowID,
+		EntityType: entityType,
+		EntityKey:  entityKey,
+		Status:     status,
+	}
+	err := tc.repo.Create(ctx, state)
+	if err != nil {
+		tc.t.Fatalf("failed to create test state: %v", err)
+	}
+	return state
+}
+
+// ============================================================================
+// Create Tests
+// ============================================================================
+
+func TestWorkflowStateRepository_Create_Global(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	state := &models.WorkflowEntityState{
+		ProjectID:  tc.projectID,
+		OntologyID: tc.ontologyID,
+		WorkflowID: tc.workflowID,
+		EntityType: models.WorkflowEntityTypeGlobal,
+		EntityKey:  "",
+		Status:     models.WorkflowEntityStatusPending,
+	}
+
+	err := tc.repo.Create(ctx, state)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if state.ID == uuid.Nil {
+		t.Error("expected ID to be set")
+	}
+	if state.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be set")
+	}
+
+	// Verify by fetching
+	retrieved, err := tc.repo.GetByID(ctx, state.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if retrieved.EntityType != models.WorkflowEntityTypeGlobal {
+		t.Errorf("expected entity_type 'global', got %q", retrieved.EntityType)
+	}
+	if retrieved.EntityKey != "" {
+		t.Errorf("expected empty entity_key, got %q", retrieved.EntityKey)
+	}
+}
+
+func TestWorkflowStateRepository_Create_Table(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	state := &models.WorkflowEntityState{
+		ProjectID:  tc.projectID,
+		OntologyID: tc.ontologyID,
+		WorkflowID: tc.workflowID,
+		EntityType: models.WorkflowEntityTypeTable,
+		EntityKey:  "orders",
+		Status:     models.WorkflowEntityStatusPending,
+	}
+
+	err := tc.repo.Create(ctx, state)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	retrieved, err := tc.repo.GetByID(ctx, state.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if retrieved.EntityType != models.WorkflowEntityTypeTable {
+		t.Errorf("expected entity_type 'table', got %q", retrieved.EntityType)
+	}
+	if retrieved.EntityKey != "orders" {
+		t.Errorf("expected entity_key 'orders', got %q", retrieved.EntityKey)
+	}
+}
+
+func TestWorkflowStateRepository_Create_Column(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	state := &models.WorkflowEntityState{
+		ProjectID:  tc.projectID,
+		OntologyID: tc.ontologyID,
+		WorkflowID: tc.workflowID,
+		EntityType: models.WorkflowEntityTypeColumn,
+		EntityKey:  "orders.status",
+		Status:     models.WorkflowEntityStatusScanned,
+		StateData: &models.WorkflowStateData{
+			Gathered: map[string]any{
+				"distinct_count": 5,
+				"sample_values":  []string{"pending", "shipped", "delivered"},
+			},
+		},
+	}
+
+	err := tc.repo.Create(ctx, state)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	retrieved, err := tc.repo.GetByID(ctx, state.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if retrieved.EntityType != models.WorkflowEntityTypeColumn {
+		t.Errorf("expected entity_type 'column', got %q", retrieved.EntityType)
+	}
+	if retrieved.EntityKey != "orders.status" {
+		t.Errorf("expected entity_key 'orders.status', got %q", retrieved.EntityKey)
+	}
+	if retrieved.StateData == nil {
+		t.Error("expected StateData to be set")
+	}
+	if retrieved.StateData.Gathered == nil {
+		t.Error("expected StateData.Gathered to be set")
+	}
+	if retrieved.StateData.Gathered["distinct_count"] != float64(5) {
+		t.Errorf("expected distinct_count 5, got %v", retrieved.StateData.Gathered["distinct_count"])
+	}
+}
+
+func TestWorkflowStateRepository_Create_WithError(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	errorMsg := "connection timeout"
+	state := &models.WorkflowEntityState{
+		ProjectID:  tc.projectID,
+		OntologyID: tc.ontologyID,
+		WorkflowID: tc.workflowID,
+		EntityType: models.WorkflowEntityTypeTable,
+		EntityKey:  "users",
+		Status:     models.WorkflowEntityStatusFailed,
+		LastError:  &errorMsg,
+		RetryCount: 3,
+	}
+
+	err := tc.repo.Create(ctx, state)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	retrieved, err := tc.repo.GetByID(ctx, state.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if retrieved.LastError == nil || *retrieved.LastError != errorMsg {
+		t.Errorf("expected last_error %q, got %v", errorMsg, retrieved.LastError)
+	}
+	if retrieved.RetryCount != 3 {
+		t.Errorf("expected retry_count 3, got %d", retrieved.RetryCount)
+	}
+}
+
+// ============================================================================
+// CreateBatch Tests
+// ============================================================================
+
+func TestWorkflowStateRepository_CreateBatch_Success(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	states := []*models.WorkflowEntityState{
+		{
+			ProjectID:  tc.projectID,
+			OntologyID: tc.ontologyID,
+			WorkflowID: tc.workflowID,
+			EntityType: models.WorkflowEntityTypeGlobal,
+			EntityKey:  "",
+		},
+		{
+			ProjectID:  tc.projectID,
+			OntologyID: tc.ontologyID,
+			WorkflowID: tc.workflowID,
+			EntityType: models.WorkflowEntityTypeTable,
+			EntityKey:  "orders",
+		},
+		{
+			ProjectID:  tc.projectID,
+			OntologyID: tc.ontologyID,
+			WorkflowID: tc.workflowID,
+			EntityType: models.WorkflowEntityTypeColumn,
+			EntityKey:  "orders.id",
+		},
+		{
+			ProjectID:  tc.projectID,
+			OntologyID: tc.ontologyID,
+			WorkflowID: tc.workflowID,
+			EntityType: models.WorkflowEntityTypeColumn,
+			EntityKey:  "orders.status",
+		},
+	}
+
+	err := tc.repo.CreateBatch(ctx, states)
+	if err != nil {
+		t.Fatalf("CreateBatch failed: %v", err)
+	}
+
+	// All should have IDs set
+	for i, s := range states {
+		if s.ID == uuid.Nil {
+			t.Errorf("state %d: expected ID to be set", i)
+		}
+	}
+
+	// Verify count
+	all, err := tc.repo.ListByWorkflow(ctx, tc.workflowID)
+	if err != nil {
+		t.Fatalf("ListByWorkflow failed: %v", err)
+	}
+	if len(all) != 4 {
+		t.Errorf("expected 4 states, got %d", len(all))
+	}
+}
+
+func TestWorkflowStateRepository_CreateBatch_Empty(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	err := tc.repo.CreateBatch(ctx, []*models.WorkflowEntityState{})
+	if err != nil {
+		t.Fatalf("CreateBatch with empty slice should not error: %v", err)
+	}
+}
+
+// ============================================================================
+// GetByID Tests
+// ============================================================================
+
+func TestWorkflowStateRepository_GetByID_NotFound(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	state, err := tc.repo.GetByID(ctx, uuid.New())
+	if err != nil {
+		t.Fatalf("GetByID should not error for non-existent: %v", err)
+	}
+	if state != nil {
+		t.Error("expected nil for non-existent state")
+	}
+}
+
+// ============================================================================
+// GetByEntity Tests
+// ============================================================================
+
+func TestWorkflowStateRepository_GetByEntity_Success(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	created := tc.createTestState(ctx, models.WorkflowEntityTypeColumn, "orders.status", models.WorkflowEntityStatusScanned)
+
+	retrieved, err := tc.repo.GetByEntity(ctx, tc.workflowID, models.WorkflowEntityTypeColumn, "orders.status")
+	if err != nil {
+		t.Fatalf("GetByEntity failed: %v", err)
+	}
+	if retrieved == nil {
+		t.Fatal("expected state, got nil")
+	}
+	if retrieved.ID != created.ID {
+		t.Errorf("expected ID %v, got %v", created.ID, retrieved.ID)
+	}
+}
+
+func TestWorkflowStateRepository_GetByEntity_NotFound(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	state, err := tc.repo.GetByEntity(ctx, tc.workflowID, models.WorkflowEntityTypeColumn, "nonexistent.column")
+	if err != nil {
+		t.Fatalf("GetByEntity should not error for non-existent: %v", err)
+	}
+	if state != nil {
+		t.Error("expected nil for non-existent entity")
+	}
+}
+
+// ============================================================================
+// ListByWorkflow Tests
+// ============================================================================
+
+func TestWorkflowStateRepository_ListByWorkflow_Success(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestState(ctx, models.WorkflowEntityTypeGlobal, "", models.WorkflowEntityStatusComplete)
+	tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusScanned)
+	tc.createTestState(ctx, models.WorkflowEntityTypeColumn, "orders.id", models.WorkflowEntityStatusPending)
+
+	states, err := tc.repo.ListByWorkflow(ctx, tc.workflowID)
+	if err != nil {
+		t.Fatalf("ListByWorkflow failed: %v", err)
+	}
+	if len(states) != 3 {
+		t.Errorf("expected 3 states, got %d", len(states))
+	}
+
+	// Should be ordered by entity_type, entity_key
+	if states[0].EntityType != models.WorkflowEntityTypeColumn {
+		t.Errorf("expected first to be column (alphabetically), got %q", states[0].EntityType)
+	}
+}
+
+func TestWorkflowStateRepository_ListByWorkflow_Empty(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	states, err := tc.repo.ListByWorkflow(ctx, tc.workflowID)
+	if err != nil {
+		t.Fatalf("ListByWorkflow failed: %v", err)
+	}
+	if len(states) != 0 {
+		t.Errorf("expected 0 states, got %d", len(states))
+	}
+}
+
+// ============================================================================
+// ListByStatus Tests
+// ============================================================================
+
+func TestWorkflowStateRepository_ListByStatus_Success(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestState(ctx, models.WorkflowEntityTypeGlobal, "", models.WorkflowEntityStatusComplete)
+	tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusPending)
+	tc.createTestState(ctx, models.WorkflowEntityTypeTable, "users", models.WorkflowEntityStatusPending)
+	tc.createTestState(ctx, models.WorkflowEntityTypeColumn, "orders.id", models.WorkflowEntityStatusScanned)
+
+	pending, err := tc.repo.ListByStatus(ctx, tc.workflowID, models.WorkflowEntityStatusPending)
+	if err != nil {
+		t.Fatalf("ListByStatus failed: %v", err)
+	}
+	if len(pending) != 2 {
+		t.Errorf("expected 2 pending states, got %d", len(pending))
+	}
+
+	complete, err := tc.repo.ListByStatus(ctx, tc.workflowID, models.WorkflowEntityStatusComplete)
+	if err != nil {
+		t.Fatalf("ListByStatus failed: %v", err)
+	}
+	if len(complete) != 1 {
+		t.Errorf("expected 1 complete state, got %d", len(complete))
+	}
+}
+
+// ============================================================================
+// UpdateStatus Tests
+// ============================================================================
+
+func TestWorkflowStateRepository_UpdateStatus_Success(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	state := tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusPending)
+
+	err := tc.repo.UpdateStatus(ctx, state.ID, models.WorkflowEntityStatusScanning, nil)
+	if err != nil {
+		t.Fatalf("UpdateStatus failed: %v", err)
+	}
+
+	retrieved, err := tc.repo.GetByID(ctx, state.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if retrieved.Status != models.WorkflowEntityStatusScanning {
+		t.Errorf("expected status 'scanning', got %q", retrieved.Status)
+	}
+}
+
+func TestWorkflowStateRepository_UpdateStatus_WithError(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	state := tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusAnalyzing)
+
+	errorMsg := "LLM rate limit exceeded"
+	err := tc.repo.UpdateStatus(ctx, state.ID, models.WorkflowEntityStatusFailed, &errorMsg)
+	if err != nil {
+		t.Fatalf("UpdateStatus failed: %v", err)
+	}
+
+	retrieved, err := tc.repo.GetByID(ctx, state.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if retrieved.Status != models.WorkflowEntityStatusFailed {
+		t.Errorf("expected status 'failed', got %q", retrieved.Status)
+	}
+	if retrieved.LastError == nil || *retrieved.LastError != errorMsg {
+		t.Errorf("expected last_error %q, got %v", errorMsg, retrieved.LastError)
+	}
+}
+
+func TestWorkflowStateRepository_UpdateStatus_NotFound(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	err := tc.repo.UpdateStatus(ctx, uuid.New(), models.WorkflowEntityStatusComplete, nil)
+	if err == nil {
+		t.Error("expected error for non-existent state")
+	}
+}
+
+// ============================================================================
+// UpdateStateData Tests
+// ============================================================================
+
+func TestWorkflowStateRepository_UpdateStateData_Success(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	state := tc.createTestState(ctx, models.WorkflowEntityTypeColumn, "orders.status", models.WorkflowEntityStatusScanned)
+
+	newStateData := &models.WorkflowStateData{
+		Gathered: map[string]any{
+			"distinct_count": 5,
+			"sample_values":  []string{"pending", "shipped", "delivered", "cancelled", "refunded"},
+		},
+		LLMAnalysis: map[string]any{
+			"thinking":      "This appears to be an order lifecycle status column",
+			"semantic_type": "order_lifecycle",
+		},
+	}
+
+	err := tc.repo.UpdateStateData(ctx, state.ID, newStateData)
+	if err != nil {
+		t.Fatalf("UpdateStateData failed: %v", err)
+	}
+
+	retrieved, err := tc.repo.GetByID(ctx, state.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if retrieved.StateData == nil {
+		t.Fatal("expected StateData to be set")
+	}
+	if retrieved.StateData.LLMAnalysis == nil {
+		t.Fatal("expected LLMAnalysis to be set")
+	}
+	if retrieved.StateData.LLMAnalysis["semantic_type"] != "order_lifecycle" {
+		t.Errorf("expected semantic_type 'order_lifecycle', got %v", retrieved.StateData.LLMAnalysis["semantic_type"])
+	}
+}
+
+func TestWorkflowStateRepository_UpdateStateData_NotFound(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	err := tc.repo.UpdateStateData(ctx, uuid.New(), &models.WorkflowStateData{})
+	if err == nil {
+		t.Error("expected error for non-existent state")
+	}
+}
+
+// ============================================================================
+// IncrementRetryCount Tests
+// ============================================================================
+
+func TestWorkflowStateRepository_IncrementRetryCount_Success(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	state := tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusFailed)
+
+	err := tc.repo.IncrementRetryCount(ctx, state.ID)
+	if err != nil {
+		t.Fatalf("IncrementRetryCount failed: %v", err)
+	}
+
+	retrieved, err := tc.repo.GetByID(ctx, state.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if retrieved.RetryCount != 1 {
+		t.Errorf("expected retry_count 1, got %d", retrieved.RetryCount)
+	}
+
+	// Increment again
+	err = tc.repo.IncrementRetryCount(ctx, state.ID)
+	if err != nil {
+		t.Fatalf("IncrementRetryCount failed: %v", err)
+	}
+
+	retrieved, err = tc.repo.GetByID(ctx, state.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if retrieved.RetryCount != 2 {
+		t.Errorf("expected retry_count 2, got %d", retrieved.RetryCount)
+	}
+}
+
+// ============================================================================
+// Delete Tests
+// ============================================================================
+
+func TestWorkflowStateRepository_Delete_Success(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	state := tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusComplete)
+
+	err := tc.repo.Delete(ctx, state.ID)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	retrieved, err := tc.repo.GetByID(ctx, state.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if retrieved != nil {
+		t.Error("expected nil after delete")
+	}
+}
+
+func TestWorkflowStateRepository_Delete_NotFound(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	err := tc.repo.Delete(ctx, uuid.New())
+	if err == nil {
+		t.Error("expected error for non-existent state")
+	}
+}
+
+// ============================================================================
+// DeleteByWorkflow Tests
+// ============================================================================
+
+func TestWorkflowStateRepository_DeleteByWorkflow_Success(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	tc.createTestState(ctx, models.WorkflowEntityTypeGlobal, "", models.WorkflowEntityStatusComplete)
+	tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusComplete)
+	tc.createTestState(ctx, models.WorkflowEntityTypeColumn, "orders.id", models.WorkflowEntityStatusComplete)
+
+	// Verify 3 exist
+	states, err := tc.repo.ListByWorkflow(ctx, tc.workflowID)
+	if err != nil {
+		t.Fatalf("ListByWorkflow failed: %v", err)
+	}
+	if len(states) != 3 {
+		t.Fatalf("expected 3 states before delete, got %d", len(states))
+	}
+
+	err = tc.repo.DeleteByWorkflow(ctx, tc.workflowID)
+	if err != nil {
+		t.Fatalf("DeleteByWorkflow failed: %v", err)
+	}
+
+	// Verify all deleted
+	states, err = tc.repo.ListByWorkflow(ctx, tc.workflowID)
+	if err != nil {
+		t.Fatalf("ListByWorkflow failed: %v", err)
+	}
+	if len(states) != 0 {
+		t.Errorf("expected 0 states after delete, got %d", len(states))
+	}
+}
+
+// ============================================================================
+// Unique Constraint Tests
+// ============================================================================
+
+func TestWorkflowStateRepository_UniqueConstraint(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create first state
+	tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusPending)
+
+	// Try to create duplicate
+	duplicate := &models.WorkflowEntityState{
+		ProjectID:  tc.projectID,
+		OntologyID: tc.ontologyID,
+		WorkflowID: tc.workflowID,
+		EntityType: models.WorkflowEntityTypeTable,
+		EntityKey:  "orders",
+		Status:     models.WorkflowEntityStatusScanned,
+	}
+
+	err := tc.repo.Create(ctx, duplicate)
+	if err == nil {
+		t.Error("expected error for duplicate entity key")
+	}
+}
+
+// ============================================================================
+// No Tenant Scope Tests (RLS Enforcement)
+// ============================================================================
+
+func TestWorkflowStateRepository_NoTenantScope(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx := context.Background() // No tenant scope
+
+	state := &models.WorkflowEntityState{
+		ProjectID:  tc.projectID,
+		OntologyID: tc.ontologyID,
+		WorkflowID: tc.workflowID,
+		EntityType: models.WorkflowEntityTypeGlobal,
+		EntityKey:  "",
+		Status:     models.WorkflowEntityStatusPending,
+	}
+
+	// Create should fail
+	err := tc.repo.Create(ctx, state)
+	if err == nil {
+		t.Error("expected error for Create without tenant scope")
+	}
+
+	// CreateBatch should fail
+	err = tc.repo.CreateBatch(ctx, []*models.WorkflowEntityState{state})
+	if err == nil {
+		t.Error("expected error for CreateBatch without tenant scope")
+	}
+
+	// GetByID should fail
+	_, err = tc.repo.GetByID(ctx, uuid.New())
+	if err == nil {
+		t.Error("expected error for GetByID without tenant scope")
+	}
+
+	// GetByEntity should fail
+	_, err = tc.repo.GetByEntity(ctx, tc.workflowID, models.WorkflowEntityTypeGlobal, "")
+	if err == nil {
+		t.Error("expected error for GetByEntity without tenant scope")
+	}
+
+	// ListByWorkflow should fail
+	_, err = tc.repo.ListByWorkflow(ctx, tc.workflowID)
+	if err == nil {
+		t.Error("expected error for ListByWorkflow without tenant scope")
+	}
+
+	// ListByStatus should fail
+	_, err = tc.repo.ListByStatus(ctx, tc.workflowID, models.WorkflowEntityStatusPending)
+	if err == nil {
+		t.Error("expected error for ListByStatus without tenant scope")
+	}
+
+	// UpdateStatus should fail
+	err = tc.repo.UpdateStatus(ctx, uuid.New(), models.WorkflowEntityStatusComplete, nil)
+	if err == nil {
+		t.Error("expected error for UpdateStatus without tenant scope")
+	}
+
+	// UpdateStateData should fail
+	err = tc.repo.UpdateStateData(ctx, uuid.New(), &models.WorkflowStateData{})
+	if err == nil {
+		t.Error("expected error for UpdateStateData without tenant scope")
+	}
+
+	// IncrementRetryCount should fail
+	err = tc.repo.IncrementRetryCount(ctx, uuid.New())
+	if err == nil {
+		t.Error("expected error for IncrementRetryCount without tenant scope")
+	}
+
+	// Delete should fail
+	err = tc.repo.Delete(ctx, uuid.New())
+	if err == nil {
+		t.Error("expected error for Delete without tenant scope")
+	}
+
+	// DeleteByWorkflow should fail
+	err = tc.repo.DeleteByWorkflow(ctx, tc.workflowID)
+	if err == nil {
+		t.Error("expected error for DeleteByWorkflow without tenant scope")
+	}
+}
+
+// ============================================================================
+// Model Helper Method Tests
+// ============================================================================
+
+func TestWorkflowState_IsTerminal(t *testing.T) {
+	tests := []struct {
+		status   models.WorkflowEntityStatus
+		expected bool
+	}{
+		{models.WorkflowEntityStatusPending, false},
+		{models.WorkflowEntityStatusScanning, false},
+		{models.WorkflowEntityStatusScanned, false},
+		{models.WorkflowEntityStatusAnalyzing, false},
+		{models.WorkflowEntityStatusNeedsInput, false},
+		{models.WorkflowEntityStatusComplete, true},
+		{models.WorkflowEntityStatusFailed, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			if got := tt.status.IsTerminal(); got != tt.expected {
+				t.Errorf("IsTerminal() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWorkflowEntityState_TableName(t *testing.T) {
+	tests := []struct {
+		entityType models.WorkflowEntityType
+		entityKey  string
+		expected   string
+	}{
+		{models.WorkflowEntityTypeGlobal, "", ""},
+		{models.WorkflowEntityTypeTable, "orders", "orders"},
+		{models.WorkflowEntityTypeColumn, "orders.status", "orders"},
+		{models.WorkflowEntityTypeColumn, "users.email", "users"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.entityType)+":"+tt.entityKey, func(t *testing.T) {
+			ws := &models.WorkflowEntityState{EntityType: tt.entityType, EntityKey: tt.entityKey}
+			if got := ws.TableName(); got != tt.expected {
+				t.Errorf("TableName() = %q, expected %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWorkflowEntityState_ColumnName(t *testing.T) {
+	tests := []struct {
+		entityType models.WorkflowEntityType
+		entityKey  string
+		expected   string
+	}{
+		{models.WorkflowEntityTypeGlobal, "", ""},
+		{models.WorkflowEntityTypeTable, "orders", ""},
+		{models.WorkflowEntityTypeColumn, "orders.status", "status"},
+		{models.WorkflowEntityTypeColumn, "users.email", "email"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.entityType)+":"+tt.entityKey, func(t *testing.T) {
+			ws := &models.WorkflowEntityState{EntityType: tt.entityType, EntityKey: tt.entityKey}
+			if got := ws.ColumnName(); got != tt.expected {
+				t.Errorf("ColumnName() = %q, expected %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEntityKeyHelpers(t *testing.T) {
+	if got := models.GlobalEntityKey(); got != "" {
+		t.Errorf("GlobalEntityKey() = %q, expected empty", got)
+	}
+
+	if got := models.TableEntityKey("orders"); got != "orders" {
+		t.Errorf("TableEntityKey() = %q, expected 'orders'", got)
+	}
+
+	if got := models.ColumnEntityKey("orders", "status"); got != "orders.status" {
+		t.Errorf("ColumnEntityKey() = %q, expected 'orders.status'", got)
+	}
+
+	table, col := models.ParseColumnEntityKey("orders.status")
+	if table != "orders" || col != "status" {
+		t.Errorf("ParseColumnEntityKey() = (%q, %q), expected ('orders', 'status')", table, col)
+	}
+
+	table, col = models.ParseColumnEntityKey("invalid")
+	if table != "" || col != "" {
+		t.Errorf("ParseColumnEntityKey() for invalid = (%q, %q), expected empty", table, col)
+	}
+}
+
+// ============================================================================
+// Question Operations Tests
+// ============================================================================
+
+func TestWorkflowStateRepository_AddQuestionsToEntity_Success(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create a table entity state
+	state := tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusNeedsInput)
+
+	// Add questions
+	questions := []models.WorkflowQuestion{
+		{
+			ID:         uuid.New().String(),
+			Text:       "What does 'pending' status mean?",
+			Priority:   1,
+			IsRequired: true,
+			Category:   "business_rules",
+			Status:     "pending",
+		},
+		{
+			ID:         uuid.New().String(),
+			Text:       "Are there any other statuses?",
+			Priority:   3,
+			IsRequired: false,
+			Category:   "enumeration",
+			Status:     "pending",
+		},
+	}
+
+	err := tc.repo.AddQuestionsToEntity(ctx, state.ID, questions)
+	if err != nil {
+		t.Fatalf("AddQuestionsToEntity failed: %v", err)
+	}
+
+	// Verify questions were added
+	retrieved, err := tc.repo.GetByID(ctx, state.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if retrieved.StateData == nil {
+		t.Fatal("expected StateData to be set")
+	}
+	if len(retrieved.StateData.Questions) != 2 {
+		t.Errorf("expected 2 questions, got %d", len(retrieved.StateData.Questions))
+	}
+	if retrieved.StateData.Questions[0].Text != "What does 'pending' status mean?" {
+		t.Errorf("unexpected question text: %s", retrieved.StateData.Questions[0].Text)
+	}
+}
+
+func TestWorkflowStateRepository_AddQuestionsToEntity_Append(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	state := tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusNeedsInput)
+
+	// Add first question
+	q1 := []models.WorkflowQuestion{{
+		ID:         uuid.New().String(),
+		Text:       "First question",
+		Priority:   1,
+		IsRequired: true,
+		Status:     "pending",
+	}}
+	err := tc.repo.AddQuestionsToEntity(ctx, state.ID, q1)
+	if err != nil {
+		t.Fatalf("AddQuestionsToEntity failed: %v", err)
+	}
+
+	// Add second question - should append
+	q2 := []models.WorkflowQuestion{{
+		ID:         uuid.New().String(),
+		Text:       "Second question",
+		Priority:   2,
+		IsRequired: false,
+		Status:     "pending",
+	}}
+	err = tc.repo.AddQuestionsToEntity(ctx, state.ID, q2)
+	if err != nil {
+		t.Fatalf("AddQuestionsToEntity failed: %v", err)
+	}
+
+	// Verify both questions exist
+	retrieved, err := tc.repo.GetByID(ctx, state.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if len(retrieved.StateData.Questions) != 2 {
+		t.Errorf("expected 2 questions after append, got %d", len(retrieved.StateData.Questions))
+	}
+}
+
+func TestWorkflowStateRepository_AddQuestionsToEntity_Empty(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	state := tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusNeedsInput)
+
+	// Adding empty slice should not error
+	err := tc.repo.AddQuestionsToEntity(ctx, state.ID, []models.WorkflowQuestion{})
+	if err != nil {
+		t.Fatalf("AddQuestionsToEntity with empty slice should not error: %v", err)
+	}
+}
+
+func TestWorkflowStateRepository_UpdateQuestionInEntity_Success(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	state := tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusNeedsInput)
+
+	questionID := uuid.New().String()
+	questions := []models.WorkflowQuestion{{
+		ID:         questionID,
+		Text:       "What does 'pending' status mean?",
+		Priority:   1,
+		IsRequired: true,
+		Status:     "pending",
+	}}
+	err := tc.repo.AddQuestionsToEntity(ctx, state.ID, questions)
+	if err != nil {
+		t.Fatalf("AddQuestionsToEntity failed: %v", err)
+	}
+
+	// Update question status and answer
+	err = tc.repo.UpdateQuestionInEntity(ctx, state.ID, questionID, "answered", "Pending means order received but not processed")
+	if err != nil {
+		t.Fatalf("UpdateQuestionInEntity failed: %v", err)
+	}
+
+	// Verify update
+	retrieved, err := tc.repo.GetByID(ctx, state.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	q := retrieved.StateData.Questions[0]
+	if q.Status != "answered" {
+		t.Errorf("expected status 'answered', got %q", q.Status)
+	}
+	if q.Answer != "Pending means order received but not processed" {
+		t.Errorf("unexpected answer: %s", q.Answer)
+	}
+	if q.AnsweredAt == nil {
+		t.Error("expected AnsweredAt to be set")
+	}
+}
+
+func TestWorkflowStateRepository_UpdateQuestionInEntity_NotFound(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	state := tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusNeedsInput)
+
+	// Add a question
+	questions := []models.WorkflowQuestion{{
+		ID:         uuid.New().String(),
+		Text:       "A question",
+		Priority:   1,
+		IsRequired: true,
+		Status:     "pending",
+	}}
+	err := tc.repo.AddQuestionsToEntity(ctx, state.ID, questions)
+	if err != nil {
+		t.Fatalf("AddQuestionsToEntity failed: %v", err)
+	}
+
+	// Try to update non-existent question
+	err = tc.repo.UpdateQuestionInEntity(ctx, state.ID, uuid.New().String(), "answered", "Some answer")
+	if err == nil {
+		t.Error("expected error for non-existent question")
+	}
+}
+
+func TestWorkflowStateRepository_RecordAnswerInEntity_Success(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	state := tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusNeedsInput)
+
+	answer := models.WorkflowAnswer{
+		QuestionID:     uuid.New().String(),
+		Answer:         "Pending means the order was received but not yet processed",
+		AnsweredBy:     uuid.New().String(),
+		AnsweredAt:     time.Now(),
+		EntityUpdates:  []string{"Updated orders entity description"},
+		KnowledgeFacts: []string{uuid.New().String()},
+	}
+
+	err := tc.repo.RecordAnswerInEntity(ctx, state.ID, answer)
+	if err != nil {
+		t.Fatalf("RecordAnswerInEntity failed: %v", err)
+	}
+
+	// Verify answer was recorded
+	retrieved, err := tc.repo.GetByID(ctx, state.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if retrieved.StateData == nil {
+		t.Fatal("expected StateData to be set")
+	}
+	if len(retrieved.StateData.Answers) != 1 {
+		t.Errorf("expected 1 answer, got %d", len(retrieved.StateData.Answers))
+	}
+	if retrieved.StateData.Answers[0].Answer != answer.Answer {
+		t.Errorf("unexpected answer text: %s", retrieved.StateData.Answers[0].Answer)
+	}
+}
+
+func TestWorkflowStateRepository_GetNextPendingQuestion_Success(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create two entities with questions
+	state1 := tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusNeedsInput)
+	state2 := tc.createTestState(ctx, models.WorkflowEntityTypeTable, "users", models.WorkflowEntityStatusNeedsInput)
+
+	// Add questions with different priorities
+	q1ID := uuid.New().String()
+	q1 := []models.WorkflowQuestion{{
+		ID:         q1ID,
+		Text:       "Low priority question",
+		Priority:   5,
+		IsRequired: false,
+		Status:     "pending",
+	}}
+	err := tc.repo.AddQuestionsToEntity(ctx, state1.ID, q1)
+	if err != nil {
+		t.Fatalf("AddQuestionsToEntity failed: %v", err)
+	}
+
+	q2ID := uuid.New().String()
+	q2 := []models.WorkflowQuestion{{
+		ID:         q2ID,
+		Text:       "High priority required question",
+		Priority:   1,
+		IsRequired: true,
+		Status:     "pending",
+	}}
+	err = tc.repo.AddQuestionsToEntity(ctx, state2.ID, q2)
+	if err != nil {
+		t.Fatalf("AddQuestionsToEntity failed: %v", err)
+	}
+
+	// Get next pending - should return highest priority (priority 1) required question
+	question, entityID, err := tc.repo.GetNextPendingQuestion(ctx, tc.workflowID)
+	if err != nil {
+		t.Fatalf("GetNextPendingQuestion failed: %v", err)
+	}
+	if question == nil {
+		t.Fatal("expected a question, got nil")
+	}
+	if question.ID != q2ID {
+		t.Errorf("expected question %s, got %s", q2ID, question.ID)
+	}
+	if entityID != state2.ID {
+		t.Errorf("expected entity %s, got %s", state2.ID, entityID)
+	}
+}
+
+func TestWorkflowStateRepository_GetNextPendingQuestion_NoQuestions(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create entity without questions
+	tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusComplete)
+
+	question, entityID, err := tc.repo.GetNextPendingQuestion(ctx, tc.workflowID)
+	if err != nil {
+		t.Fatalf("GetNextPendingQuestion failed: %v", err)
+	}
+	if question != nil {
+		t.Error("expected nil question when no pending questions exist")
+	}
+	if entityID != uuid.Nil {
+		t.Error("expected nil entityID when no pending questions exist")
+	}
+}
+
+func TestWorkflowStateRepository_GetNextPendingQuestion_SkipsAnswered(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	state := tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusNeedsInput)
+
+	answeredID := uuid.New().String()
+	pendingID := uuid.New().String()
+	questions := []models.WorkflowQuestion{
+		{
+			ID:         answeredID,
+			Text:       "Already answered",
+			Priority:   1,
+			IsRequired: true,
+			Status:     "answered",
+		},
+		{
+			ID:         pendingID,
+			Text:       "Still pending",
+			Priority:   2,
+			IsRequired: true,
+			Status:     "pending",
+		},
+	}
+	err := tc.repo.AddQuestionsToEntity(ctx, state.ID, questions)
+	if err != nil {
+		t.Fatalf("AddQuestionsToEntity failed: %v", err)
+	}
+
+	question, _, err := tc.repo.GetNextPendingQuestion(ctx, tc.workflowID)
+	if err != nil {
+		t.Fatalf("GetNextPendingQuestion failed: %v", err)
+	}
+	if question == nil {
+		t.Fatal("expected a question")
+	}
+	if question.ID != pendingID {
+		t.Errorf("expected pending question %s, got %s", pendingID, question.ID)
+	}
+}
+
+func TestWorkflowStateRepository_GetPendingQuestionsCount_Success(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	state := tc.createTestState(ctx, models.WorkflowEntityTypeTable, "orders", models.WorkflowEntityStatusNeedsInput)
+
+	questions := []models.WorkflowQuestion{
+		{
+			ID:         uuid.New().String(),
+			Text:       "Required pending 1",
+			Priority:   1,
+			IsRequired: true,
+			Status:     "pending",
+		},
+		{
+			ID:         uuid.New().String(),
+			Text:       "Required pending 2",
+			Priority:   2,
+			IsRequired: true,
+			Status:     "pending",
+		},
+		{
+			ID:         uuid.New().String(),
+			Text:       "Optional pending",
+			Priority:   3,
+			IsRequired: false,
+			Status:     "pending",
+		},
+		{
+			ID:         uuid.New().String(),
+			Text:       "Already answered",
+			Priority:   1,
+			IsRequired: true,
+			Status:     "answered",
+		},
+	}
+	err := tc.repo.AddQuestionsToEntity(ctx, state.ID, questions)
+	if err != nil {
+		t.Fatalf("AddQuestionsToEntity failed: %v", err)
+	}
+
+	required, optional, err := tc.repo.GetPendingQuestionsCount(ctx, tc.workflowID)
+	if err != nil {
+		t.Fatalf("GetPendingQuestionsCount failed: %v", err)
+	}
+	if required != 2 {
+		t.Errorf("expected 2 required pending, got %d", required)
+	}
+	if optional != 1 {
+		t.Errorf("expected 1 optional pending, got %d", optional)
+	}
+}

--- a/pkg/services/datasource_test.go
+++ b/pkg/services/datasource_test.go
@@ -125,7 +125,8 @@ func (m *mockAdapterFactory) ListTypes() []datasource.DatasourceAdapterInfo {
 func newTestService(repo *mockDatasourceRepository) (DatasourceService, *crypto.CredentialEncryptor) {
 	encryptor, _ := crypto.NewCredentialEncryptor(testEncryptionKey)
 	factory := &mockAdapterFactory{}
-	return NewDatasourceService(repo, encryptor, factory, zap.NewNop()), encryptor
+	// Pass nil for projectService in tests - auto-set default datasource is tested separately
+	return NewDatasourceService(repo, encryptor, factory, nil, zap.NewNop()), encryptor
 }
 
 func TestDatasourceService_Create_Success(t *testing.T) {
@@ -455,7 +456,7 @@ func TestDatasourceService_TestConnection_Success(t *testing.T) {
 	factory := &mockAdapterFactory{
 		tester: &mockConnectionTester{},
 	}
-	service := NewDatasourceService(repo, encryptor, factory, zap.NewNop())
+	service := NewDatasourceService(repo, encryptor, factory, nil, zap.NewNop())
 
 	config := map[string]any{
 		"host":     "localhost",
@@ -475,7 +476,7 @@ func TestDatasourceService_TestConnection_FactoryError(t *testing.T) {
 	factory := &mockAdapterFactory{
 		factoryErr: errors.New("unsupported datasource type"),
 	}
-	service := NewDatasourceService(repo, encryptor, factory, zap.NewNop())
+	service := NewDatasourceService(repo, encryptor, factory, nil, zap.NewNop())
 
 	err := service.TestConnection(context.Background(), "unknown", nil)
 	if err == nil {
@@ -491,7 +492,7 @@ func TestDatasourceService_TestConnection_ConnectionError(t *testing.T) {
 			testErr: errors.New("connection refused"),
 		},
 	}
-	service := NewDatasourceService(repo, encryptor, factory, zap.NewNop())
+	service := NewDatasourceService(repo, encryptor, factory, nil, zap.NewNop())
 
 	config := map[string]any{
 		"host":     "localhost",

--- a/pkg/services/knowledge.go
+++ b/pkg/services/knowledge.go
@@ -1,0 +1,103 @@
+package services
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
+)
+
+// KnowledgeService provides operations for project knowledge management.
+type KnowledgeService interface {
+	// Store creates or updates a knowledge fact.
+	Store(ctx context.Context, projectID uuid.UUID, factType, key, value, contextInfo string) (*models.KnowledgeFact, error)
+
+	// GetAll retrieves all knowledge facts for a project.
+	GetAll(ctx context.Context, projectID uuid.UUID) ([]*models.KnowledgeFact, error)
+
+	// GetByType retrieves knowledge facts of a specific type.
+	GetByType(ctx context.Context, projectID uuid.UUID, factType string) ([]*models.KnowledgeFact, error)
+
+	// Delete removes a knowledge fact.
+	Delete(ctx context.Context, id uuid.UUID) error
+}
+
+type knowledgeService struct {
+	repo   repositories.KnowledgeRepository
+	logger *zap.Logger
+}
+
+// NewKnowledgeService creates a new knowledge service.
+func NewKnowledgeService(
+	repo repositories.KnowledgeRepository,
+	logger *zap.Logger,
+) KnowledgeService {
+	return &knowledgeService{
+		repo:   repo,
+		logger: logger.Named("knowledge"),
+	}
+}
+
+var _ KnowledgeService = (*knowledgeService)(nil)
+
+func (s *knowledgeService) Store(ctx context.Context, projectID uuid.UUID, factType, key, value, contextInfo string) (*models.KnowledgeFact, error) {
+	fact := &models.KnowledgeFact{
+		ProjectID: projectID,
+		FactType:  factType,
+		Key:       key,
+		Value:     value,
+		Context:   contextInfo,
+	}
+
+	if err := s.repo.Upsert(ctx, fact); err != nil {
+		s.logger.Error("Failed to store knowledge fact",
+			zap.String("project_id", projectID.String()),
+			zap.String("fact_type", factType),
+			zap.String("key", key),
+			zap.Error(err))
+		return nil, err
+	}
+
+	s.logger.Info("Knowledge fact stored",
+		zap.String("project_id", projectID.String()),
+		zap.String("fact_type", factType),
+		zap.String("key", key))
+
+	return fact, nil
+}
+
+func (s *knowledgeService) GetAll(ctx context.Context, projectID uuid.UUID) ([]*models.KnowledgeFact, error) {
+	facts, err := s.repo.GetByProject(ctx, projectID)
+	if err != nil {
+		s.logger.Error("Failed to get knowledge facts",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+	return facts, nil
+}
+
+func (s *knowledgeService) GetByType(ctx context.Context, projectID uuid.UUID, factType string) ([]*models.KnowledgeFact, error) {
+	facts, err := s.repo.GetByType(ctx, projectID, factType)
+	if err != nil {
+		s.logger.Error("Failed to get knowledge facts by type",
+			zap.String("project_id", projectID.String()),
+			zap.String("fact_type", factType),
+			zap.Error(err))
+		return nil, err
+	}
+	return facts, nil
+}
+
+func (s *knowledgeService) Delete(ctx context.Context, id uuid.UUID) error {
+	if err := s.repo.Delete(ctx, id); err != nil {
+		s.logger.Error("Failed to delete knowledge fact",
+			zap.String("id", id.String()),
+			zap.Error(err))
+		return err
+	}
+	return nil
+}

--- a/pkg/services/ontology_builder.go
+++ b/pkg/services/ontology_builder.go
@@ -1,0 +1,2023 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/llm"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
+)
+
+// MaxTablesPerBatch limits tables per LLM call for entity summary generation.
+const MaxTablesPerBatch = 20
+
+// OntologyBuilderService provides LLM-based ontology construction.
+type OntologyBuilderService interface {
+	// BuildTieredOntology orchestrates the complete tiered ontology construction.
+	BuildTieredOntology(ctx context.Context, projectID uuid.UUID, workflowID uuid.UUID) error
+
+	// BuildEntitySummaries generates Tier 1 entity summaries for tables.
+	BuildEntitySummaries(ctx context.Context, projectID uuid.UUID, tables []*models.SchemaTable) (map[string]*models.EntitySummary, error)
+
+	// BuildDomainSummary generates the Tier 0 domain summary from entity summaries.
+	BuildDomainSummary(ctx context.Context, projectID uuid.UUID, entities map[string]*models.EntitySummary) (*models.DomainSummary, error)
+
+	// AnalyzeEntity analyzes a single entity and may generate clarifying questions.
+	// Returns questions generated for this entity (may be empty).
+	// Questions with IsRequired=true indicate the entity cannot be completed without user input.
+	AnalyzeEntity(ctx context.Context, projectID uuid.UUID, workflowID uuid.UUID, tableName string) ([]*models.OntologyQuestion, error)
+
+	// GenerateQuestions generates clarifying questions based on schema analysis.
+	// Deprecated: Use AnalyzeEntity for per-entity question generation.
+	GenerateQuestions(ctx context.Context, projectID uuid.UUID, workflowID uuid.UUID) ([]*models.OntologyQuestion, error)
+
+	// ProcessAnswer processes a user's answer and returns any ontology updates.
+	ProcessAnswer(ctx context.Context, projectID uuid.UUID, question *models.OntologyQuestion, answer string) (*AnswerProcessingResult, error)
+
+	// ProcessProjectDescription analyzes user description + schema to produce
+	// refined domain context, initial knowledge facts, and clarifying questions.
+	// This runs as the first step of extraction (before Tier 1/0).
+	ProcessProjectDescription(ctx context.Context, projectID uuid.UUID, workflowID uuid.UUID, description string) (*DescriptionProcessingResult, error)
+}
+
+// AnswerProcessingResult contains the result of processing a question answer.
+type AnswerProcessingResult struct {
+	FollowUp       *string
+	EntityUpdates  []EntityUpdate
+	ColumnUpdates  []ColumnUpdate
+	KnowledgeFacts []*models.KnowledgeFact
+	ActionsSummary string
+	Thinking       string // LLM reasoning extracted from <think> tags
+}
+
+// EntityUpdate describes an update to apply to an entity.
+type EntityUpdate struct {
+	TableName    string
+	BusinessName *string
+	Description  *string
+	Synonyms     []string
+	Domain       *string
+}
+
+// ColumnUpdate describes an update to apply to a column.
+type ColumnUpdate struct {
+	TableName    string
+	ColumnName   string
+	Description  *string
+	SemanticType *string
+	Synonyms     []string
+	Role         *string
+}
+
+// DescriptionProcessingResult contains the output of processing user's project description.
+type DescriptionProcessingResult struct {
+	DomainContext       *models.DomainContext         `json:"domain_context"`
+	KnowledgeFacts      []*models.KnowledgeFact       `json:"knowledge_facts"`
+	ClarifyingQuestions []*models.OntologyQuestion    `json:"clarifying_questions"`
+	EntityHints         map[string]*models.EntityHint `json:"entity_hints"`
+}
+
+type ontologyBuilderService struct {
+	ontologyRepo      repositories.OntologyRepository
+	schemaRepo        repositories.SchemaRepository
+	workflowRepo      repositories.OntologyWorkflowRepository
+	knowledgeRepo     repositories.KnowledgeRepository
+	workflowStateRepo repositories.WorkflowStateRepository
+	llmFactory        llm.LLMClientFactory
+	logger            *zap.Logger
+}
+
+// NewOntologyBuilderService creates a new ontology builder service.
+func NewOntologyBuilderService(
+	ontologyRepo repositories.OntologyRepository,
+	schemaRepo repositories.SchemaRepository,
+	workflowRepo repositories.OntologyWorkflowRepository,
+	knowledgeRepo repositories.KnowledgeRepository,
+	workflowStateRepo repositories.WorkflowStateRepository,
+	llmFactory llm.LLMClientFactory,
+	logger *zap.Logger,
+) OntologyBuilderService {
+	return &ontologyBuilderService{
+		ontologyRepo:      ontologyRepo,
+		schemaRepo:        schemaRepo,
+		workflowRepo:      workflowRepo,
+		knowledgeRepo:     knowledgeRepo,
+		workflowStateRepo: workflowStateRepo,
+		llmFactory:        llmFactory,
+		logger:            logger.Named("ontology-builder"),
+	}
+}
+
+var _ OntologyBuilderService = (*ontologyBuilderService)(nil)
+
+// ============================================================================
+// BuildTieredOntology - Main Orchestration
+// ============================================================================
+
+func (s *ontologyBuilderService) BuildTieredOntology(ctx context.Context, projectID uuid.UUID, workflowID uuid.UUID) error {
+	startTime := time.Now()
+
+	// Add workflow context for conversation recording
+	ctx = llm.WithWorkflowID(ctx, workflowID)
+
+	s.logger.Info("Starting tiered ontology build",
+		zap.String("project_id", projectID.String()),
+		zap.String("workflow_id", workflowID.String()))
+
+	// Get the active ontology
+	ontology, err := s.ontologyRepo.GetActive(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to get active ontology: %w", err)
+	}
+	if ontology == nil {
+		return fmt.Errorf("no active ontology found")
+	}
+
+	// Get workflow to find datasource and description
+	workflow, err := s.workflowRepo.GetByID(ctx, workflowID)
+	if err != nil {
+		return fmt.Errorf("failed to get workflow: %w", err)
+	}
+	if workflow.Config == nil {
+		return fmt.Errorf("workflow has no config")
+	}
+
+	// Load domain context from ontology metadata (set by InitializeOntologyTask)
+	var domainContext *models.DomainContext
+	if ontology.Metadata != nil {
+		if dc, ok := ontology.Metadata["domain_context"]; ok {
+			if dcMap, ok := dc.(map[string]any); ok {
+				domainContext = &models.DomainContext{
+					KeyTerminology: make(map[string]string),
+				}
+				if summary, ok := dcMap["summary"].(string); ok {
+					domainContext.Summary = summary
+				}
+				if domains, ok := dcMap["primary_domains"].([]any); ok {
+					for _, d := range domains {
+						if ds, ok := d.(string); ok {
+							domainContext.PrimaryDomains = append(domainContext.PrimaryDomains, ds)
+						}
+					}
+				}
+				if terms, ok := dcMap["key_terminology"].(map[string]any); ok {
+					for k, v := range terms {
+						if vs, ok := v.(string); ok {
+							domainContext.KeyTerminology[k] = vs
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Load schema tables
+	tables, err := s.schemaRepo.ListTablesByDatasource(ctx, projectID, workflow.Config.DatasourceID)
+	if err != nil {
+		return fmt.Errorf("failed to list tables: %w", err)
+	}
+	tableCount := len(tables)
+
+	s.logger.Info("Loaded schema tables",
+		zap.Int("table_count", tableCount))
+
+	// Update workflow progress with table count
+	if err := s.workflowRepo.UpdateProgress(ctx, workflowID, &models.WorkflowProgress{
+		CurrentPhase: models.WorkflowPhaseTier1Building,
+		Message:      fmt.Sprintf("Building entity summaries for %d tables...", tableCount),
+		Current:      0,
+		Total:        tableCount,
+	}); err != nil {
+		s.logger.Error("Failed to update progress", zap.Error(err))
+	}
+
+	// Build Tier 1: Entity summaries (with domain context)
+	entitySummaries, err := s.buildEntitySummariesWithContext(ctx, projectID, tables, domainContext)
+	if err != nil {
+		return fmt.Errorf("failed to build entity summaries: %w", err)
+	}
+
+	// Save entity summaries
+	if err := s.ontologyRepo.UpdateEntitySummaries(ctx, projectID, entitySummaries); err != nil {
+		return fmt.Errorf("failed to save entity summaries: %w", err)
+	}
+
+	// Update progress - entity summaries complete
+	if err := s.workflowRepo.UpdateProgress(ctx, workflowID, &models.WorkflowProgress{
+		CurrentPhase: models.WorkflowPhaseTier0Building,
+		Message:      "Building domain summary...",
+		Current:      tableCount,
+		Total:        tableCount,
+	}); err != nil {
+		s.logger.Error("Failed to update progress", zap.Error(err))
+	}
+
+	// Build Tier 0: Domain summary (with domain context)
+	domainSummary, err := s.buildDomainSummaryWithContext(ctx, projectID, entitySummaries, domainContext)
+	if err != nil {
+		return fmt.Errorf("failed to build domain summary: %w", err)
+	}
+
+	// Save domain summary
+	if err := s.ontologyRepo.UpdateDomainSummary(ctx, projectID, domainSummary); err != nil {
+		return fmt.Errorf("failed to save domain summary: %w", err)
+	}
+
+	// Update progress - ontology is now ready
+	if err := s.workflowRepo.UpdateProgress(ctx, workflowID, &models.WorkflowProgress{
+		CurrentPhase:  models.WorkflowPhaseCompleting,
+		Message:       "Ontology ready, generating questions...",
+		Current:       tableCount,
+		Total:         tableCount,
+		OntologyReady: true,
+	}); err != nil {
+		s.logger.Error("Failed to update progress", zap.Error(err))
+	}
+
+	s.logger.Info("Tiered ontology build completed",
+		zap.String("project_id", projectID.String()),
+		zap.String("workflow_id", workflowID.String()),
+		zap.Int("entities", len(entitySummaries)),
+		zap.Int("domains", len(domainSummary.Domains)),
+		zap.Duration("elapsed", time.Since(startTime)))
+
+	// Mark global entity as complete so orchestrator can finalize workflow
+	globalState, err := s.workflowStateRepo.GetByEntity(ctx, workflowID, models.WorkflowEntityTypeGlobal, "")
+	if err != nil {
+		return fmt.Errorf("get global entity state: %w", err)
+	}
+	if globalState != nil {
+		if err := s.workflowStateRepo.UpdateStatus(ctx, globalState.ID, models.WorkflowEntityStatusComplete, nil); err != nil {
+			return fmt.Errorf("update global entity status: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ============================================================================
+// BuildEntitySummaries - Tier 1
+// ============================================================================
+
+func (s *ontologyBuilderService) BuildEntitySummaries(ctx context.Context, projectID uuid.UUID, tables []*models.SchemaTable) (map[string]*models.EntitySummary, error) {
+	// Delegate to context-aware version with nil context
+	return s.buildEntitySummariesWithContext(ctx, projectID, tables, nil)
+}
+
+func (s *ontologyBuilderService) buildEntitySummariesWithContext(ctx context.Context, projectID uuid.UUID, tables []*models.SchemaTable, domainContext *models.DomainContext) (map[string]*models.EntitySummary, error) {
+	if len(tables) == 0 {
+		return map[string]*models.EntitySummary{}, nil
+	}
+
+	startTime := time.Now()
+	s.logger.Info("Building entity summaries",
+		zap.String("project_id", projectID.String()),
+		zap.Int("table_count", len(tables)),
+		zap.Bool("has_domain_context", domainContext != nil))
+
+	// Get LLM client
+	llmClient, err := s.llmFactory.CreateForProject(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create LLM client: %w", err)
+	}
+
+	// Load relationships for context
+	relationships, err := s.loadRelationships(ctx, projectID, tables)
+	if err != nil {
+		s.logger.Error("Failed to load relationships", zap.Error(err))
+	}
+	relationshipMap := s.buildRelationshipMap(relationships, tables)
+
+	// Process in batches
+	allSummaries := make(map[string]*models.EntitySummary)
+
+	for i := 0; i < len(tables); i += MaxTablesPerBatch {
+		end := i + MaxTablesPerBatch
+		if end > len(tables) {
+			end = len(tables)
+		}
+
+		batchTables := tables[i:end]
+		batchNum := (i / MaxTablesPerBatch) + 1
+		totalBatches := (len(tables) + MaxTablesPerBatch - 1) / MaxTablesPerBatch
+
+		s.logger.Info("Processing entity batch",
+			zap.Int("batch", batchNum),
+			zap.Int("total_batches", totalBatches),
+			zap.Int("tables_in_batch", len(batchTables)))
+
+		batchSummaries, err := s.buildEntityBatchWithContext(ctx, llmClient, batchTables, relationshipMap, domainContext)
+		if err != nil {
+			return nil, fmt.Errorf("batch %d failed: %w", batchNum, err)
+		}
+
+		for tableName, summary := range batchSummaries {
+			allSummaries[tableName] = summary
+		}
+	}
+
+	s.logger.Info("Entity summaries built",
+		zap.Int("entity_count", len(allSummaries)),
+		zap.Duration("elapsed", time.Since(startTime)))
+
+	return allSummaries, nil
+}
+
+func (s *ontologyBuilderService) buildEntityBatch(
+	ctx context.Context,
+	llmClient llm.LLMClient,
+	tables []*models.SchemaTable,
+	relationshipMap map[string][]string,
+) (map[string]*models.EntitySummary, error) {
+	return s.buildEntityBatchWithContext(ctx, llmClient, tables, relationshipMap, nil)
+}
+
+func (s *ontologyBuilderService) buildEntityBatchWithContext(
+	ctx context.Context,
+	llmClient llm.LLMClient,
+	tables []*models.SchemaTable,
+	relationshipMap map[string][]string,
+	domainContext *models.DomainContext,
+) (map[string]*models.EntitySummary, error) {
+	prompt := s.buildTier1PromptWithContext(tables, relationshipMap, domainContext)
+	systemMsg := s.tier1SystemMessage()
+
+	result, err := llmClient.GenerateResponse(ctx, prompt, systemMsg, 0.2, false)
+	if err != nil {
+		return nil, fmt.Errorf("LLM call failed: %w", err)
+	}
+
+	// Parse response
+	summaries, err := s.parseTier1Response(result.Content)
+	if err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return summaries, nil
+}
+
+func (s *ontologyBuilderService) tier1SystemMessage() string {
+	return `You are a database ontology expert. Generate concise entity summaries for schema understanding.
+
+For each table, provide:
+1. table_name: The exact table name from input
+2. business_name: Human-friendly name (e.g., "Customer Orders" not "orders")
+3. description: ONE sentence explaining business purpose (max 15 words)
+4. domain: One of: sales, finance, operations, customer, product, analytics, hr, inventory, marketing, unknown
+5. synonyms: 3-5 alternative names users might search for
+6. key_columns: Up to 3 most important columns with their synonyms
+7. column_count: Total number of columns
+8. relationships: Direct relationships (1-hop only)
+
+CRITICAL: Keep each entity summary under 75 tokens. Be concise.
+
+Return a JSON array of entity summaries.`
+}
+
+func (s *ontologyBuilderService) buildTier1Prompt(tables []*models.SchemaTable, relationshipMap map[string][]string) string {
+	return s.buildTier1PromptWithContext(tables, relationshipMap, nil)
+}
+
+func (s *ontologyBuilderService) buildTier1PromptWithContext(tables []*models.SchemaTable, relationshipMap map[string][]string, domainContext *models.DomainContext) string {
+	var prompt strings.Builder
+
+	// Include refined domain context if available (NOT raw user description)
+	if domainContext != nil {
+		prompt.WriteString("## Domain Context\n\n")
+		if domainContext.Summary != "" {
+			prompt.WriteString(domainContext.Summary + "\n\n")
+		}
+
+		if len(domainContext.PrimaryDomains) > 0 {
+			prompt.WriteString("Primary domains: " + strings.Join(domainContext.PrimaryDomains, ", ") + "\n\n")
+		}
+
+		if len(domainContext.KeyTerminology) > 0 {
+			prompt.WriteString("### Key Terminology\n")
+			for term, definition := range domainContext.KeyTerminology {
+				prompt.WriteString(fmt.Sprintf("- **%s**: %s\n", term, definition))
+			}
+			prompt.WriteString("\n")
+		}
+	}
+
+	prompt.WriteString("Generate entity summaries for the following database tables.\n\n")
+	prompt.WriteString("## Tables\n\n")
+
+	for _, table := range tables {
+		prompt.WriteString(fmt.Sprintf("### %s\n", table.TableName))
+		if table.RowCount != nil {
+			prompt.WriteString(fmt.Sprintf("Row count: %d\n", *table.RowCount))
+		}
+
+		// Fetch columns for this table (we have them from SchemaTable)
+		if len(table.Columns) > 0 {
+			prompt.WriteString("Columns:\n")
+			for _, col := range table.Columns {
+				colInfo := fmt.Sprintf("- %s (%s)", col.ColumnName, col.DataType)
+				if col.IsPrimaryKey {
+					colInfo += " [PK]"
+				}
+				prompt.WriteString(colInfo + "\n")
+			}
+		}
+
+		// Add existing business context if available
+		if table.BusinessName != nil && *table.BusinessName != "" {
+			prompt.WriteString(fmt.Sprintf("Current business name: %s\n", *table.BusinessName))
+		}
+		if table.Description != nil && *table.Description != "" {
+			prompt.WriteString(fmt.Sprintf("Current description: %s\n", *table.Description))
+		}
+
+		// Add relationships
+		if rels, ok := relationshipMap[table.TableName]; ok && len(rels) > 0 {
+			prompt.WriteString(fmt.Sprintf("Related to: %s\n", strings.Join(rels, ", ")))
+		}
+
+		prompt.WriteString("\n")
+	}
+
+	prompt.WriteString("## Output Format\n\n")
+	prompt.WriteString("Return a JSON array:\n")
+	prompt.WriteString("```json\n")
+	prompt.WriteString(`[
+  {
+    "table_name": "orders",
+    "business_name": "Customer Orders",
+    "description": "Records of customer purchase transactions",
+    "domain": "sales",
+    "synonyms": ["purchases", "transactions", "sales"],
+    "key_columns": [
+      {"name": "total_amount", "synonyms": ["revenue", "price"]},
+      {"name": "order_date", "synonyms": ["purchase_date"]}
+    ],
+    "column_count": 12,
+    "relationships": ["customers", "products"]
+  }
+]
+`)
+	prompt.WriteString("```\n")
+
+	return prompt.String()
+}
+
+func (s *ontologyBuilderService) parseTier1Response(response string) (map[string]*models.EntitySummary, error) {
+	type llmEntitySummary struct {
+		TableName     string             `json:"table_name"`
+		BusinessName  string             `json:"business_name"`
+		Description   string             `json:"description"`
+		Domain        string             `json:"domain"`
+		Synonyms      []string           `json:"synonyms"`
+		KeyColumns    []models.KeyColumn `json:"key_columns"`
+		ColumnCount   int                `json:"column_count"`
+		Relationships []string           `json:"relationships"`
+	}
+
+	summaries, err := llm.ParseJSONResponse[[]llmEntitySummary](response)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]*models.EntitySummary)
+	for _, entity := range summaries {
+		result[entity.TableName] = &models.EntitySummary{
+			TableName:     entity.TableName,
+			BusinessName:  entity.BusinessName,
+			Description:   entity.Description,
+			Domain:        entity.Domain,
+			Synonyms:      entity.Synonyms,
+			KeyColumns:    entity.KeyColumns,
+			ColumnCount:   entity.ColumnCount,
+			Relationships: entity.Relationships,
+		}
+	}
+
+	return result, nil
+}
+
+// ============================================================================
+// BuildDomainSummary - Tier 0
+// ============================================================================
+
+func (s *ontologyBuilderService) BuildDomainSummary(ctx context.Context, projectID uuid.UUID, entities map[string]*models.EntitySummary) (*models.DomainSummary, error) {
+	return s.buildDomainSummaryWithContext(ctx, projectID, entities, nil)
+}
+
+func (s *ontologyBuilderService) buildDomainSummaryWithContext(ctx context.Context, projectID uuid.UUID, entities map[string]*models.EntitySummary, domainContext *models.DomainContext) (*models.DomainSummary, error) {
+	if len(entities) == 0 {
+		return &models.DomainSummary{
+			Description: "Empty database",
+			Domains:     []string{},
+		}, nil
+	}
+
+	startTime := time.Now()
+	s.logger.Info("Building domain summary",
+		zap.String("project_id", projectID.String()),
+		zap.Int("entity_count", len(entities)),
+		zap.Bool("has_domain_context", domainContext != nil))
+
+	// Get LLM client
+	llmClient, err := s.llmFactory.CreateForProject(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create LLM client: %w", err)
+	}
+
+	prompt := s.buildTier0PromptWithContext(entities, domainContext)
+	systemMsg := s.tier0SystemMessage()
+
+	result, err := llmClient.GenerateResponse(ctx, prompt, systemMsg, 0.2, false)
+	if err != nil {
+		return nil, fmt.Errorf("LLM call failed: %w", err)
+	}
+
+	summary, err := s.parseTier0Response(result.Content, entities)
+	if err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	s.logger.Info("Domain summary built",
+		zap.Int("domain_count", len(summary.Domains)),
+		zap.Duration("elapsed", time.Since(startTime)))
+
+	return summary, nil
+}
+
+func (s *ontologyBuilderService) tier0SystemMessage() string {
+	return `You are a business intelligence expert. Generate a high-level domain summary for this database schema.
+
+Provide:
+1. description: 1-2 sentence business summary of the entire database
+2. domains: List of business domains present (e.g., ["sales", "finance", "operations"])
+3. sample_questions: 3-5 example business questions this database can answer
+
+CRITICAL: Keep total output under 500 tokens. Be extremely concise.
+
+Return a JSON object with these 3 fields.`
+}
+
+func (s *ontologyBuilderService) buildTier0Prompt(entities map[string]*models.EntitySummary) string {
+	return s.buildTier0PromptWithContext(entities, nil)
+}
+
+func (s *ontologyBuilderService) buildTier0PromptWithContext(entities map[string]*models.EntitySummary, domainContext *models.DomainContext) string {
+	var prompt strings.Builder
+
+	prompt.WriteString("Generate a domain summary for this database schema.\n\n")
+
+	// Include pre-existing domain context if available
+	if domainContext != nil && domainContext.Summary != "" {
+		prompt.WriteString("## User-Provided Context\n\n")
+		prompt.WriteString(domainContext.Summary + "\n\n")
+		if len(domainContext.KeyTerminology) > 0 {
+			prompt.WriteString("Key terms:\n")
+			for term, def := range domainContext.KeyTerminology {
+				prompt.WriteString(fmt.Sprintf("- %s: %s\n", term, def))
+			}
+			prompt.WriteString("\n")
+		}
+	}
+
+	prompt.WriteString("## Entities by Domain\n\n")
+
+	// Group entities by domain
+	domainEntities := make(map[string][]string)
+	for _, entity := range entities {
+		domain := entity.Domain
+		if domain == "" {
+			domain = "unknown"
+		}
+		domainEntities[domain] = append(domainEntities[domain], entity.TableName)
+	}
+
+	for domain, tables := range domainEntities {
+		prompt.WriteString(fmt.Sprintf("**%s**: %s\n", domain, strings.Join(tables, ", ")))
+	}
+
+	prompt.WriteString("\n## Entity Descriptions\n\n")
+	for _, entity := range entities {
+		prompt.WriteString(fmt.Sprintf("- **%s**: %s\n", entity.BusinessName, entity.Description))
+	}
+
+	prompt.WriteString("\n## Output Format\n\n")
+	prompt.WriteString("```json\n")
+	prompt.WriteString(`{
+  "description": "E-commerce database tracking orders, customers, and inventory",
+  "domains": ["sales", "customer", "inventory"],
+  "sample_questions": [
+    "What was total revenue last quarter?",
+    "Which products are low in stock?",
+    "Who are our top customers?"
+  ]
+}
+`)
+	prompt.WriteString("```\n")
+
+	return prompt.String()
+}
+
+func (s *ontologyBuilderService) parseTier0Response(response string, entities map[string]*models.EntitySummary) (*models.DomainSummary, error) {
+	type llmDomainSummary struct {
+		Description     string   `json:"description"`
+		Domains         []string `json:"domains"`
+		SampleQuestions []string `json:"sample_questions"`
+	}
+
+	llmSummary, err := llm.ParseJSONResponse[llmDomainSummary](response)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build relationship graph from entity relationships
+	var relationshipGraph []models.RelationshipEdge
+	for tableName, entity := range entities {
+		for _, relatedTable := range entity.Relationships {
+			relationshipGraph = append(relationshipGraph, models.RelationshipEdge{
+				From: tableName,
+				To:   relatedTable,
+			})
+		}
+	}
+
+	return &models.DomainSummary{
+		Description:       llmSummary.Description,
+		Domains:           llmSummary.Domains,
+		SampleQuestions:   llmSummary.SampleQuestions,
+		RelationshipGraph: relationshipGraph,
+	}, nil
+}
+
+// ============================================================================
+// AnalyzeEntity
+// ============================================================================
+
+func (s *ontologyBuilderService) AnalyzeEntity(ctx context.Context, projectID uuid.UUID, workflowID uuid.UUID, tableName string) ([]*models.OntologyQuestion, error) {
+	startTime := time.Now()
+
+	// Add workflow context for conversation recording
+	ctx = llm.WithWorkflowID(ctx, workflowID)
+
+	s.logger.Info("Analyzing entity",
+		zap.String("project_id", projectID.String()),
+		zap.String("workflow_id", workflowID.String()),
+		zap.String("table_name", tableName))
+
+	// Get workflow to find datasource
+	workflow, err := s.workflowRepo.GetByID(ctx, workflowID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get workflow: %w", err)
+	}
+	if workflow.Config == nil {
+		return nil, fmt.Errorf("workflow has no config")
+	}
+
+	// Load the table schema (schema-agnostic lookup)
+	table, err := s.schemaRepo.FindTableByName(ctx, projectID, workflow.Config.DatasourceID, tableName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get table %s: %w", tableName, err)
+	}
+
+	// Load columns for the table (GetTableByName doesn't include columns)
+	columnPtrs, err := s.schemaRepo.ListColumnsByTable(ctx, projectID, table.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get columns for table %s: %w", tableName, err)
+	}
+	// Convert []*SchemaColumn to []SchemaColumn
+	table.Columns = make([]models.SchemaColumn, len(columnPtrs))
+	for i, col := range columnPtrs {
+		table.Columns[i] = *col
+	}
+
+	// Load gathered data from workflow state for each column
+	columnGatheredData := make(map[string]map[string]any)
+	if s.workflowStateRepo != nil {
+		for _, col := range table.Columns {
+			colEntityKey := models.ColumnEntityKey(tableName, col.ColumnName)
+			ws, err := s.workflowStateRepo.GetByEntity(ctx, workflowID, models.WorkflowEntityTypeColumn, colEntityKey)
+			if err != nil {
+				s.logger.Warn("Failed to load column workflow state",
+					zap.String("column", col.ColumnName),
+					zap.Error(err))
+				continue
+			}
+			if ws != nil && ws.StateData != nil && ws.StateData.Gathered != nil {
+				columnGatheredData[col.ColumnName] = ws.StateData.Gathered
+			}
+		}
+	}
+
+	// Load the existing ontology to get the entity summary and domain context
+	ontology, err := s.ontologyRepo.GetActive(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ontology: %w", err)
+	}
+
+	var entitySummary *models.EntitySummary
+	var domainContext *models.DomainContext
+	var entityHint *models.EntityHint
+
+	if ontology != nil {
+		if ontology.EntitySummaries != nil {
+			entitySummary = ontology.EntitySummaries[tableName]
+		}
+
+		// Extract domain context from metadata
+		if ontology.Metadata != nil {
+			if dc, ok := ontology.Metadata["domain_context"]; ok {
+				if dcMap, ok := dc.(map[string]any); ok {
+					domainContext = &models.DomainContext{}
+					if s, ok := dcMap["summary"].(string); ok {
+						domainContext.Summary = s
+					}
+					if pd, ok := dcMap["primary_domains"].([]any); ok {
+						for _, d := range pd {
+							if ds, ok := d.(string); ok {
+								domainContext.PrimaryDomains = append(domainContext.PrimaryDomains, ds)
+							}
+						}
+					}
+					if kt, ok := dcMap["key_terminology"].(map[string]any); ok {
+						domainContext.KeyTerminology = make(map[string]string)
+						for k, v := range kt {
+							if vs, ok := v.(string); ok {
+								domainContext.KeyTerminology[k] = vs
+							}
+						}
+					}
+				}
+			}
+
+			// Extract entity hint from metadata
+			if hints, ok := ontology.Metadata["entity_hints"]; ok {
+				if hintsMap, ok := hints.(map[string]any); ok {
+					if hint, ok := hintsMap[tableName]; ok {
+						if hintMap, ok := hint.(map[string]any); ok {
+							entityHint = &models.EntityHint{}
+							if bn, ok := hintMap["business_name"].(string); ok {
+								entityHint.BusinessName = bn
+							}
+							if d, ok := hintMap["domain"].(string); ok {
+								entityHint.Domain = d
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Load relationships for this table
+	relationships, err := s.schemaRepo.GetRelationshipDetails(ctx, projectID, workflow.Config.DatasourceID)
+	if err != nil {
+		s.logger.Warn("Failed to load relationships", zap.Error(err))
+		relationships = nil
+	}
+
+	// Filter relationships to only those involving this table
+	var tableRelationships []*models.RelationshipDetail
+	for _, rel := range relationships {
+		if rel.SourceTableName == tableName || rel.TargetTableName == tableName {
+			tableRelationships = append(tableRelationships, rel)
+		}
+	}
+
+	// Get LLM client
+	llmClient, err := s.llmFactory.CreateForProject(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create LLM client: %w", err)
+	}
+
+	// Build prompt and call LLM
+	prompt := s.buildEntityAnalysisPrompt(table, entitySummary, domainContext, entityHint, tableRelationships, columnGatheredData)
+	systemMsg := s.entityAnalysisSystemMessage()
+
+	result, err := llmClient.GenerateResponse(ctx, prompt, systemMsg, 0.3, false)
+	if err != nil {
+		return nil, fmt.Errorf("LLM call failed: %w", err)
+	}
+
+	// Parse the response
+	questions, entitySummaryFromLLM, err := s.parseEntityAnalysisResponse(result.Content, projectID, workflow.OntologyID, workflowID, tableName)
+	if err != nil {
+		s.logger.Warn("Failed to parse entity analysis response, treating as no questions",
+			zap.String("table_name", tableName),
+			zap.Error(err))
+		return []*models.OntologyQuestion{}, nil
+	}
+
+	// Write initial entity summary immediately if we got one from LLM
+	if entitySummaryFromLLM != nil {
+		entitySummaryFromLLM.ColumnCount = len(table.Columns)
+		if err := s.ontologyRepo.UpdateEntitySummary(ctx, projectID, tableName, entitySummaryFromLLM); err != nil {
+			s.logger.Warn("Failed to write initial entity summary",
+				zap.String("table_name", tableName),
+				zap.Error(err))
+			// Non-fatal - continue with questions
+		} else {
+			s.logger.Debug("Wrote initial entity summary",
+				zap.String("table_name", tableName),
+				zap.String("business_name", entitySummaryFromLLM.BusinessName))
+		}
+	}
+
+	s.logger.Info("Entity analysis complete",
+		zap.String("table_name", tableName),
+		zap.Int("question_count", len(questions)),
+		zap.Bool("has_entity_summary", entitySummaryFromLLM != nil),
+		zap.Duration("elapsed", time.Since(startTime)))
+
+	return questions, nil
+}
+
+func (s *ontologyBuilderService) entityAnalysisSystemMessage() string {
+	return `You are a database analyst helping to understand a business domain by examining a single table in detail.
+Your goal is to identify any clarifying questions that would help fully understand what this table represents and how it's used.
+
+CRITICAL RULES:
+- Focus on THIS SPECIFIC TABLE only
+- Reference EXACT column names from the schema
+- Focus on BUSINESS understanding, not technical details
+- Only ask questions if there is genuine ambiguity or missing context
+- Many tables are self-explanatory - it's OK to return zero questions
+- Status/type/state columns often encode business rules worth asking about`
+}
+
+func (s *ontologyBuilderService) buildEntityAnalysisPrompt(
+	table *models.SchemaTable,
+	entitySummary *models.EntitySummary,
+	domainContext *models.DomainContext,
+	entityHint *models.EntityHint,
+	relationships []*models.RelationshipDetail,
+	columnGatheredData map[string]map[string]any,
+) string {
+	var sb strings.Builder
+
+	// Include domain context if available (from user's project description)
+	if domainContext != nil && domainContext.Summary != "" {
+		sb.WriteString("## DOMAIN CONTEXT\n\n")
+		sb.WriteString(fmt.Sprintf("%s\n", domainContext.Summary))
+		if len(domainContext.KeyTerminology) > 0 {
+			sb.WriteString("\nKey Terminology:\n")
+			for term, definition := range domainContext.KeyTerminology {
+				sb.WriteString(fmt.Sprintf("  - **%s**: %s\n", term, definition))
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	// Include entity hint if available (from user's project description)
+	if entityHint != nil && (entityHint.BusinessName != "" || entityHint.Domain != "") {
+		sb.WriteString("## USER-PROVIDED CONTEXT FOR THIS TABLE\n\n")
+		if entityHint.BusinessName != "" {
+			sb.WriteString(fmt.Sprintf("User calls this: %s\n", entityHint.BusinessName))
+		}
+		if entityHint.Domain != "" {
+			sb.WriteString(fmt.Sprintf("Domain: %s\n", entityHint.Domain))
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("## TABLE SCHEMA\n\n")
+	sb.WriteString(fmt.Sprintf("Table: %s\n", table.TableName))
+	if table.RowCount != nil {
+		sb.WriteString(fmt.Sprintf("Row count: %d\n", *table.RowCount))
+	}
+	sb.WriteString("\nColumns:\n")
+
+	// Token Budget Management
+	// ========================
+	// LLM has a ~40k token limit. We need to fit:
+	//   - Fixed prompt parts (task description, domain context, relationships): ~16k tokens
+	//   - Column data with sample values: remaining ~24k tokens
+	//
+	// Token-to-char ratio: ~4 chars per token (conservative estimate)
+	//   24k tokens × 4 chars/token = 96k chars available for column data
+	//   Using 76k chars to leave safety margin for response tokens
+	//
+	// Budget allocation:
+	//   - Base column info (name, type, flags): ~50 chars per column
+	//   - Remaining budget divided among columns for sample values
+	//   - Tables with many columns get less sample data per column
+	//   - Tables with few columns get rich sample data
+	const totalSampleBudget = 76000
+	numCols := len(table.Columns)
+	if numCols == 0 {
+		numCols = 1 // avoid division by zero
+	}
+	// Subtract base info cost, divide remainder among columns
+	perColumnBudget := (totalSampleBudget - numCols*50) / numCols
+	if perColumnBudget < 0 {
+		perColumnBudget = 0
+	}
+	// Sample limits based on per-column budget:
+	//   - Enum candidates: more samples (short values, ~30 chars each including overhead)
+	//   - Regular columns: fewer samples (longer values, ~50 chars each)
+	//   - Individual sample max length: 1/3 of column budget, capped at 200 chars
+	maxSamplesForEnum := min(20, perColumnBudget/30)
+	maxSamplesRegular := min(10, perColumnBudget/50)
+	maxSampleLen := min(200, perColumnBudget/3)
+	if maxSampleLen < 20 {
+		maxSampleLen = 20 // minimum useful length to show meaningful data
+	}
+
+	for _, col := range table.Columns {
+		flags := []string{}
+		if col.IsPrimaryKey {
+			flags = append(flags, "PK")
+		}
+		if col.IsNullable {
+			flags = append(flags, "nullable")
+		}
+		flagStr := ""
+		if len(flags) > 0 {
+			flagStr = " [" + strings.Join(flags, ", ") + "]"
+		}
+		sb.WriteString(fmt.Sprintf("  - %s: %s%s\n", col.ColumnName, col.DataType, flagStr))
+
+		// Include gathered data if available (sample values, enum candidate info)
+		if gathered, ok := columnGatheredData[col.ColumnName]; ok {
+			isEnumCandidate := false
+			if isEnum, ok := gathered["is_enum_candidate"].(bool); ok {
+				isEnumCandidate = isEnum
+			}
+
+			// Use budget-based limits for sample values
+			if sampleValues, ok := gathered["sample_values"].([]any); ok && len(sampleValues) > 0 && perColumnBudget > 0 {
+				// Enum candidates get more samples (they're usually short values)
+				maxSamples := maxSamplesRegular
+				if isEnumCandidate {
+					maxSamples = maxSamplesForEnum
+				}
+				if maxSamples < 1 {
+					maxSamples = 1
+				}
+
+				samples := make([]string, 0, min(len(sampleValues), maxSamples))
+				for i, v := range sampleValues {
+					if i >= maxSamples {
+						break
+					}
+					if str, ok := v.(string); ok {
+						// Truncate long sample values
+						if len(str) > maxSampleLen {
+							str = str[:maxSampleLen] + "..."
+						}
+						samples = append(samples, fmt.Sprintf("%q", str))
+					}
+				}
+				if len(samples) > 0 {
+					sb.WriteString(fmt.Sprintf("      Sample values: [%s]\n", strings.Join(samples, ", ")))
+				}
+			}
+
+			// Note if column is an enum candidate
+			if isEnumCandidate {
+				distinctCount := 0
+				if dc, ok := gathered["distinct_count"].(int); ok {
+					distinctCount = dc
+				} else if dc, ok := gathered["distinct_count"].(float64); ok {
+					distinctCount = int(dc)
+				}
+				if distinctCount > 0 {
+					sb.WriteString(fmt.Sprintf("      (Enum candidate: %d distinct values)\n", distinctCount))
+				}
+			}
+		}
+	}
+
+	// Include relationships
+	if len(relationships) > 0 {
+		sb.WriteString("\n## RELATIONSHIPS\n\n")
+		for _, rel := range relationships {
+			if rel.SourceTableName == table.TableName {
+				sb.WriteString(fmt.Sprintf("  - %s.%s → %s.%s (%s)\n",
+					rel.SourceTableName, rel.SourceColumnName,
+					rel.TargetTableName, rel.TargetColumnName,
+					rel.RelationshipType))
+			} else {
+				sb.WriteString(fmt.Sprintf("  - %s.%s ← %s.%s (%s)\n",
+					table.TableName, rel.TargetColumnName,
+					rel.SourceTableName, rel.SourceColumnName,
+					rel.RelationshipType))
+			}
+		}
+	}
+
+	if entitySummary != nil {
+		sb.WriteString("\n## CURRENT UNDERSTANDING\n\n")
+		sb.WriteString(fmt.Sprintf("Business Name: %s\n", entitySummary.BusinessName))
+		sb.WriteString(fmt.Sprintf("Description: %s\n", entitySummary.Description))
+		sb.WriteString(fmt.Sprintf("Domain: %s\n", entitySummary.Domain))
+		if len(entitySummary.Synonyms) > 0 {
+			sb.WriteString(fmt.Sprintf("Synonyms: %s\n", strings.Join(entitySummary.Synonyms, ", ")))
+		}
+		if len(entitySummary.KeyColumns) > 0 {
+			sb.WriteString("Key Columns:\n")
+			for _, kc := range entitySummary.KeyColumns {
+				sb.WriteString(fmt.Sprintf("  - %s\n", kc.Name))
+			}
+		}
+	}
+
+	sb.WriteString(fmt.Sprintf(`
+## TASK
+
+Analyze the table "%s" and determine if there are any questions that would significantly improve understanding of this entity.
+
+Focus on:
+1. Status/type/state columns - what do their values mean?
+2. Unclear column purposes - what data do they hold?
+3. Business rules - any constraints or workflows encoded?
+4. Relationships - any unclear foreign key meanings?
+
+IMPORTANT: Only generate questions if there is genuine ambiguity. Many tables are self-explanatory.
+
+## OUTPUT FORMAT
+
+Return ONLY a JSON object:
+
+%sjson
+{
+  "analysis": "Brief summary of what this table represents and any ambiguities found",
+  "entity_summary": {
+    "business_name": "Human-readable name for this entity (e.g., 'Customer Orders' for orders table)",
+    "description": "1-2 sentence description of what this table represents in business terms",
+    "domain": "Business domain classification (e.g., billing, users, inventory, analytics)"
+  },
+  "questions": [
+    {
+      "text": "What are the possible values for the 'status' column and what does each represent?",
+      "priority": 2,
+      "category": "business_rules",
+      "reasoning": "Status column likely encodes workflow states",
+      "is_required": false,
+      "affects_columns": ["status"]
+    }
+  ]
+}
+%s
+
+Priority scale: 1=Critical, 2=High, 3=Medium, 4=Low, 5=Optional
+Categories: business_rules, relationship, terminology, enumeration, temporal, data_quality
+
+If the table is self-explanatory, return:
+%sjson
+{
+  "analysis": "This table clearly represents X and all columns have obvious purposes.",
+  "entity_summary": {
+    "business_name": "...",
+    "description": "...",
+    "domain": "..."
+  },
+  "questions": []
+}
+%s
+`, table.TableName, "```", "```", "```", "```"))
+
+	return sb.String()
+}
+
+func (s *ontologyBuilderService) parseEntityAnalysisResponse(response string, projectID uuid.UUID, ontologyID uuid.UUID, workflowID uuid.UUID, tableName string) ([]*models.OntologyQuestion, *models.EntitySummary, error) {
+	type llmResponse struct {
+		Analysis      string `json:"analysis"`
+		EntitySummary struct {
+			BusinessName string `json:"business_name"`
+			Description  string `json:"description"`
+			Domain       string `json:"domain"`
+		} `json:"entity_summary"`
+		Questions []struct {
+			Text           string   `json:"text"`
+			Priority       int      `json:"priority"`
+			Category       string   `json:"category"`
+			Reasoning      string   `json:"reasoning"`
+			IsRequired     bool     `json:"is_required"`
+			AffectsColumns []string `json:"affects_columns"`
+		} `json:"questions"`
+	}
+
+	parsed, err := llm.ParseJSONResponse[llmResponse](response)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	questions := make([]*models.OntologyQuestion, 0, len(parsed.Questions))
+	for _, raw := range parsed.Questions {
+		if raw.Text == "" {
+			continue
+		}
+
+		priority := raw.Priority
+		if priority < 1 {
+			priority = 1
+		}
+		if priority > 5 {
+			priority = 5
+		}
+
+		category := raw.Category
+		if category == "" {
+			category = "general"
+		}
+
+		q := &models.OntologyQuestion{
+			ID:         uuid.New(),
+			ProjectID:  projectID,
+			OntologyID: ontologyID,
+			WorkflowID: &workflowID,
+			Text:       raw.Text,
+			Priority:   priority,
+			Category:   category,
+			Reasoning:  raw.Reasoning,
+			IsRequired: raw.IsRequired,
+			Status:     models.QuestionStatusPending,
+			Affects: &models.QuestionAffects{
+				Tables:  []string{tableName},
+				Columns: raw.AffectsColumns,
+			},
+		}
+
+		questions = append(questions, q)
+	}
+
+	// Build entity summary if LLM provided one
+	var entitySummary *models.EntitySummary
+	if parsed.EntitySummary.BusinessName != "" || parsed.EntitySummary.Description != "" || parsed.EntitySummary.Domain != "" {
+		entitySummary = &models.EntitySummary{
+			TableName:    tableName,
+			BusinessName: parsed.EntitySummary.BusinessName,
+			Description:  parsed.EntitySummary.Description,
+			Domain:       parsed.EntitySummary.Domain,
+		}
+	}
+
+	return questions, entitySummary, nil
+}
+
+// ============================================================================
+// GenerateQuestions (Deprecated)
+// ============================================================================
+
+func (s *ontologyBuilderService) GenerateQuestions(ctx context.Context, projectID uuid.UUID, workflowID uuid.UUID) ([]*models.OntologyQuestion, error) {
+	startTime := time.Now()
+
+	// Add workflow context for conversation recording
+	ctx = llm.WithWorkflowID(ctx, workflowID)
+
+	s.logger.Info("Generating questions",
+		zap.String("project_id", projectID.String()),
+		zap.String("workflow_id", workflowID.String()))
+
+	// Get workflow to find datasource
+	workflow, err := s.workflowRepo.GetByID(ctx, workflowID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get workflow: %w", err)
+	}
+	if workflow.Config == nil {
+		return nil, fmt.Errorf("workflow has no config")
+	}
+
+	// Load schema tables
+	tables, err := s.schemaRepo.ListTablesByDatasource(ctx, projectID, workflow.Config.DatasourceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tables: %w", err)
+	}
+
+	if len(tables) == 0 {
+		s.logger.Warn("No tables found for question generation")
+		return []*models.OntologyQuestion{}, nil
+	}
+
+	// Load relationships
+	relationships, err := s.loadRelationships(ctx, projectID, tables)
+	if err != nil {
+		s.logger.Error("Failed to load relationships", zap.Error(err))
+	}
+
+	// Build schema context
+	schemaContext := s.buildSchemaContext(tables, relationships)
+
+	// Get LLM client
+	llmClient, err := s.llmFactory.CreateForProject(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create LLM client: %w", err)
+	}
+
+	prompt := s.buildQuestionGenerationPrompt(schemaContext)
+	systemMsg := s.questionGenerationSystemMessage()
+
+	result, err := llmClient.GenerateResponse(ctx, prompt, systemMsg, 0.3, false)
+	if err != nil {
+		return nil, fmt.Errorf("LLM call failed: %w", err)
+	}
+
+	questions, err := s.parseQuestionsResponse(result.Content, projectID, workflow.OntologyID, workflowID)
+	if err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	// Sort by priority and limit
+	questions = s.sortAndLimitQuestions(questions, 10)
+
+	s.logger.Info("Questions generated",
+		zap.Int("question_count", len(questions)),
+		zap.Duration("elapsed", time.Since(startTime)))
+
+	return questions, nil
+}
+
+func (s *ontologyBuilderService) questionGenerationSystemMessage() string {
+	return `You are a database analyst helping to understand a business domain by examining its schema.
+Your goal is to identify the most important questions that would help understand what this data represents and how it's used in the business.
+
+CRITICAL RULES:
+- ONLY ask questions about tables/columns that ACTUALLY EXIST in the schema provided
+- NEVER make up or assume tables/columns that aren't shown
+- Reference SPECIFIC table.column names in your questions using the EXACT names from the schema
+- Focus on BUSINESS understanding, not technical details
+- Prioritize highly-connected tables - they are central to the business
+- Status/type columns encode business logic - ask about their meanings`
+}
+
+func (s *ontologyBuilderService) buildSchemaContext(tables []*models.SchemaTable, relationships []*models.SchemaRelationship) string {
+	var sb strings.Builder
+
+	sb.WriteString("## DATABASE SCHEMA\n\n")
+	sb.WriteString(fmt.Sprintf("Total tables: %d\n", len(tables)))
+	if len(relationships) > 0 {
+		sb.WriteString(fmt.Sprintf("Foreign key relationships: %d\n", len(relationships)))
+	}
+	sb.WriteString("\n")
+
+	// Build table ID to name lookup for relationships
+	tableNameLookup := make(map[string]string)
+	for _, t := range tables {
+		tableNameLookup[t.ID.String()] = t.TableName
+	}
+
+	// Build relationship count for sorting
+	relationshipCount := make(map[string]int)
+	for _, rel := range relationships {
+		relationshipCount[rel.SourceTableID.String()]++
+		relationshipCount[rel.TargetTableID.String()]++
+	}
+
+	// Sort tables by relationship count
+	sortedTables := make([]*models.SchemaTable, len(tables))
+	copy(sortedTables, tables)
+	sort.Slice(sortedTables, func(i, j int) bool {
+		return relationshipCount[sortedTables[i].ID.String()] > relationshipCount[sortedTables[j].ID.String()]
+	})
+
+	for _, table := range sortedTables {
+		relCount := relationshipCount[table.ID.String()]
+		centralityNote := ""
+		if relCount >= 5 {
+			centralityNote = " (HIGHLY CONNECTED)"
+		} else if relCount >= 3 {
+			centralityNote = " (well connected)"
+		}
+
+		sb.WriteString(fmt.Sprintf("### TABLE: %s%s\n", table.TableName, centralityNote))
+		if table.RowCount != nil {
+			sb.WriteString(fmt.Sprintf("Row count: %d\n", *table.RowCount))
+		}
+		sb.WriteString("Columns:\n")
+
+		for _, col := range table.Columns {
+			flags := []string{}
+			if col.IsPrimaryKey {
+				flags = append(flags, "PK")
+			}
+			if col.IsNullable {
+				flags = append(flags, "nullable")
+			}
+
+			flagStr := ""
+			if len(flags) > 0 {
+				flagStr = " [" + strings.Join(flags, ", ") + "]"
+			}
+
+			sb.WriteString(fmt.Sprintf("  - %s: %s%s\n", col.ColumnName, col.DataType, flagStr))
+		}
+		sb.WriteString("\n")
+	}
+
+	if len(relationships) > 0 {
+		sb.WriteString("## RELATIONSHIPS\n\n")
+		for _, rel := range relationships {
+			sourceName := tableNameLookup[rel.SourceTableID.String()]
+			targetName := tableNameLookup[rel.TargetTableID.String()]
+			// Only include relationships where both tables are known
+			if sourceName != "" && targetName != "" {
+				sb.WriteString(fmt.Sprintf("- %s -> %s\n", sourceName, targetName))
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+func (s *ontologyBuilderService) buildQuestionGenerationPrompt(schemaContext string) string {
+	return fmt.Sprintf(`%s
+
+## TASK
+
+Generate 3-10 targeted questions that would SIGNIFICANTLY improve understanding of what this data represents and how it's used.
+
+## CRITICAL REQUIREMENTS
+
+1. **Schema-Grounded**: Every question MUST reference actual table/column names from the schema above.
+
+2. **High Impact**: Focus on questions that would unlock understanding of:
+   - Core business entities and their purposes
+   - Workflow states and transitions
+   - Key relationships between entities
+   - Business rules encoded in the data
+
+3. **Prioritize** (in this order):
+   - Tables marked as "(HIGHLY CONNECTED)" or "(well connected)"
+   - Columns named 'status', 'type', 'state', 'category'
+   - Unclear naming conventions or abbreviations
+
+## OUTPUT FORMAT
+
+Return ONLY a JSON array:
+
+%sjson
+[
+  {
+    "text": "The 'orders' table has a 'status' column. What are the possible order statuses?",
+    "priority": 1,
+    "category": "business_rules",
+    "reasoning": "Understanding order lifecycle is critical for reporting",
+    "affects": {
+      "tables": ["orders"],
+      "columns": ["orders.status"]
+    },
+    "detected_pattern": "status_column"
+  }
+]
+%s
+
+## Priority Scale
+- 1 = Critical (blocks understanding of core business)
+- 2 = High (affects multiple entities/queries)
+- 3 = Medium (clarifies important details)
+- 4 = Low (nice to have)
+- 5 = Optional (minor clarification)
+
+## Categories
+- business_rules: Status columns, state machines, validation rules
+- relationship: How entities relate, cardinality, business meaning
+- terminology: What terms/abbreviations mean in this business
+- enumeration: What specific values represent
+- temporal: Date ranges, time-based patterns
+- data_quality: Null handling, expected values`, schemaContext, "```", "```")
+}
+
+func (s *ontologyBuilderService) parseQuestionsResponse(response string, projectID uuid.UUID, ontologyID uuid.UUID, workflowID uuid.UUID) ([]*models.OntologyQuestion, error) {
+	type llmQuestion struct {
+		Text      string `json:"text"`
+		Priority  int    `json:"priority"`
+		Category  string `json:"category"`
+		Reasoning string `json:"reasoning"`
+		Affects   struct {
+			Tables  []string `json:"tables"`
+			Columns []string `json:"columns"`
+		} `json:"affects"`
+		DetectedPattern string `json:"detected_pattern"`
+	}
+
+	rawQuestions, err := llm.ParseJSONResponse[[]llmQuestion](response)
+	if err != nil {
+		return nil, err
+	}
+
+	questions := make([]*models.OntologyQuestion, 0, len(rawQuestions))
+	for _, raw := range rawQuestions {
+		if raw.Text == "" {
+			continue
+		}
+
+		// Clamp priority
+		priority := raw.Priority
+		if priority < 1 {
+			priority = 1
+		}
+		if priority > 5 {
+			priority = 5
+		}
+
+		category := raw.Category
+		if category == "" {
+			category = "general"
+		}
+
+		q := &models.OntologyQuestion{
+			ID:              uuid.New(),
+			ProjectID:       projectID,
+			OntologyID:      ontologyID,
+			WorkflowID:      &workflowID,
+			Text:            raw.Text,
+			Priority:        priority,
+			Category:        category,
+			Reasoning:       raw.Reasoning,
+			DetectedPattern: raw.DetectedPattern,
+			Status:          models.QuestionStatusPending,
+			Affects: &models.QuestionAffects{
+				Tables:  raw.Affects.Tables,
+				Columns: raw.Affects.Columns,
+			},
+		}
+
+		questions = append(questions, q)
+	}
+
+	return questions, nil
+}
+
+func (s *ontologyBuilderService) sortAndLimitQuestions(questions []*models.OntologyQuestion, maxCount int) []*models.OntologyQuestion {
+	sort.Slice(questions, func(i, j int) bool {
+		return questions[i].Priority < questions[j].Priority
+	})
+
+	if len(questions) > maxCount {
+		return questions[:maxCount]
+	}
+	return questions
+}
+
+// ============================================================================
+// ProcessAnswer
+// ============================================================================
+
+func (s *ontologyBuilderService) ProcessAnswer(ctx context.Context, projectID uuid.UUID, question *models.OntologyQuestion, answer string) (*AnswerProcessingResult, error) {
+	startTime := time.Now()
+	s.logger.Info("Processing answer",
+		zap.String("project_id", projectID.String()),
+		zap.String("question_id", question.ID.String()))
+
+	// Get LLM client
+	llmClient, err := s.llmFactory.CreateForProject(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create LLM client: %w", err)
+	}
+
+	prompt := s.buildAnswerProcessingPrompt(question, answer)
+	systemMsg := s.answerProcessingSystemMessage()
+
+	llmResult, err := llmClient.GenerateResponse(ctx, prompt, systemMsg, 0.2, false)
+	if err != nil {
+		return nil, fmt.Errorf("LLM call failed: %w", err)
+	}
+
+	// Extract thinking from response before parsing JSON
+	thinking := llm.ExtractThinking(llmResult.Content)
+
+	result, err := s.parseAnswerProcessingResponse(llmResult.Content, projectID)
+	if err != nil {
+		// If parsing fails, return a basic result with thinking preserved
+		s.logger.Warn("Failed to parse answer processing response", zap.Error(err))
+		return &AnswerProcessingResult{
+			ActionsSummary: "Answer recorded",
+			Thinking:       thinking,
+		}, nil
+	}
+
+	// Preserve thinking in the result
+	result.Thinking = thinking
+
+	s.logger.Info("Answer processed",
+		zap.Int("entity_updates", len(result.EntityUpdates)),
+		zap.Int("knowledge_facts", len(result.KnowledgeFacts)),
+		zap.Duration("elapsed", time.Since(startTime)))
+
+	return result, nil
+}
+
+func (s *ontologyBuilderService) answerProcessingSystemMessage() string {
+	return `You are analyzing a user's answer to a database understanding question.
+Extract structured updates to apply to the ontology and knowledge base.
+
+Your response should identify:
+1. Entity updates (table-level: business names, descriptions, synonyms, domains)
+2. Column updates (column-level: descriptions, semantic types, synonyms, roles)
+3. Knowledge facts to store (terminology, business rules, relationships)
+4. Whether a follow-up question is needed
+5. A brief summary of actions taken
+
+IMPORTANT: If the question is about specific columns (listed in "Affected Columns"),
+extract column_updates for those columns based on the user's answer.
+
+Return a JSON object with these fields.`
+}
+
+func (s *ontologyBuilderService) buildAnswerProcessingPrompt(question *models.OntologyQuestion, answer string) string {
+	var prompt strings.Builder
+
+	prompt.WriteString("## Question\n\n")
+	prompt.WriteString(question.Text + "\n\n")
+
+	if question.Affects != nil {
+		prompt.WriteString("## Affected Schema Elements\n\n")
+		if len(question.Affects.Tables) > 0 {
+			prompt.WriteString(fmt.Sprintf("Tables: %s\n", strings.Join(question.Affects.Tables, ", ")))
+		}
+		if len(question.Affects.Columns) > 0 {
+			prompt.WriteString(fmt.Sprintf("Columns: %s\n", strings.Join(question.Affects.Columns, ", ")))
+		}
+		prompt.WriteString("\n")
+	}
+
+	prompt.WriteString("## User's Answer\n\n")
+	prompt.WriteString(answer + "\n\n")
+
+	prompt.WriteString("## Output Format\n\n")
+	prompt.WriteString("```json\n")
+	prompt.WriteString(`{
+  "follow_up": null,
+  "entity_updates": [
+    {
+      "table_name": "orders",
+      "business_name": "Customer Orders",
+      "description": "Records of customer purchases",
+      "synonyms": ["purchases", "transactions"],
+      "domain": "sales"
+    }
+  ],
+  "column_updates": [
+    {
+      "table_name": "orders",
+      "column_name": "status",
+      "description": "Current state of the order in the fulfillment process",
+      "semantic_type": "status",
+      "synonyms": ["order state", "fulfillment status"],
+      "role": "state_tracking"
+    }
+  ],
+  "knowledge_facts": [
+    {
+      "fact_type": "terminology",
+      "key": "SKU",
+      "value": "Stock Keeping Unit - unique product identifier"
+    }
+  ],
+  "actions_summary": "Updated orders entity and status column with business context"
+}
+`)
+	prompt.WriteString("```\n")
+
+	return prompt.String()
+}
+
+func (s *ontologyBuilderService) parseAnswerProcessingResponse(response string, projectID uuid.UUID) (*AnswerProcessingResult, error) {
+	type llmResult struct {
+		FollowUp      *string `json:"follow_up"`
+		EntityUpdates []struct {
+			TableName    string   `json:"table_name"`
+			BusinessName *string  `json:"business_name"`
+			Description  *string  `json:"description"`
+			Synonyms     []string `json:"synonyms"`
+			Domain       *string  `json:"domain"`
+		} `json:"entity_updates"`
+		ColumnUpdates []struct {
+			TableName    string   `json:"table_name"`
+			ColumnName   string   `json:"column_name"`
+			Description  *string  `json:"description"`
+			SemanticType *string  `json:"semantic_type"`
+			Synonyms     []string `json:"synonyms"`
+			Role         *string  `json:"role"`
+		} `json:"column_updates"`
+		KnowledgeFacts []struct {
+			FactType string `json:"fact_type"`
+			Key      string `json:"key"`
+			Value    string `json:"value"`
+			Context  string `json:"context"`
+		} `json:"knowledge_facts"`
+		ActionsSummary string `json:"actions_summary"`
+	}
+
+	llmResp, err := llm.ParseJSONResponse[llmResult](response)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &AnswerProcessingResult{
+		FollowUp:       llmResp.FollowUp,
+		ActionsSummary: llmResp.ActionsSummary,
+	}
+
+	for _, eu := range llmResp.EntityUpdates {
+		result.EntityUpdates = append(result.EntityUpdates, EntityUpdate{
+			TableName:    eu.TableName,
+			BusinessName: eu.BusinessName,
+			Description:  eu.Description,
+			Synonyms:     eu.Synonyms,
+			Domain:       eu.Domain,
+		})
+	}
+
+	for _, cu := range llmResp.ColumnUpdates {
+		result.ColumnUpdates = append(result.ColumnUpdates, ColumnUpdate{
+			TableName:    cu.TableName,
+			ColumnName:   cu.ColumnName,
+			Description:  cu.Description,
+			SemanticType: cu.SemanticType,
+			Synonyms:     cu.Synonyms,
+			Role:         cu.Role,
+		})
+	}
+
+	for _, kf := range llmResp.KnowledgeFacts {
+		result.KnowledgeFacts = append(result.KnowledgeFacts, &models.KnowledgeFact{
+			ProjectID: projectID,
+			FactType:  kf.FactType,
+			Key:       kf.Key,
+			Value:     kf.Value,
+			Context:   kf.Context,
+		})
+	}
+
+	return result, nil
+}
+
+// ============================================================================
+// Helper Methods
+// ============================================================================
+
+func (s *ontologyBuilderService) loadRelationships(ctx context.Context, projectID uuid.UUID, tables []*models.SchemaTable) ([]*models.SchemaRelationship, error) {
+	if len(tables) == 0 {
+		return nil, nil
+	}
+
+	// Get datasource ID from first table
+	datasourceID := tables[0].DatasourceID
+
+	return s.schemaRepo.ListRelationshipsByDatasource(ctx, projectID, datasourceID)
+}
+
+func (s *ontologyBuilderService) buildRelationshipMap(relationships []*models.SchemaRelationship, tables []*models.SchemaTable) map[string][]string {
+	relMap := make(map[string][]string)
+
+	if relationships == nil || len(relationships) == 0 {
+		return relMap
+	}
+
+	// Build lookup from table ID to table name
+	tableNameLookup := make(map[string]string)
+	for _, t := range tables {
+		tableNameLookup[t.ID.String()] = t.TableName
+	}
+
+	for _, rel := range relationships {
+		sourceName := tableNameLookup[rel.SourceTableID.String()]
+		targetName := tableNameLookup[rel.TargetTableID.String()]
+
+		// Skip relationships where either table is not in our lookup
+		if sourceName == "" || targetName == "" {
+			continue
+		}
+
+		relMap[sourceName] = append(relMap[sourceName], targetName)
+		relMap[targetName] = append(relMap[targetName], sourceName)
+	}
+
+	// Deduplicate
+	for key, related := range relMap {
+		relMap[key] = uniqueStrings(related)
+	}
+
+	return relMap
+}
+
+func uniqueStrings(input []string) []string {
+	seen := make(map[string]bool)
+	result := make([]string, 0, len(input))
+
+	for _, s := range input {
+		if !seen[s] {
+			seen[s] = true
+			result = append(result, s)
+		}
+	}
+
+	return result
+}
+
+// ============================================================================
+// ProcessProjectDescription - Kickoff Task
+// ============================================================================
+
+func (s *ontologyBuilderService) ProcessProjectDescription(ctx context.Context, projectID uuid.UUID, workflowID uuid.UUID, description string) (*DescriptionProcessingResult, error) {
+	if description == "" {
+		// No description provided - return empty result
+		return &DescriptionProcessingResult{
+			EntityHints: make(map[string]*models.EntityHint),
+		}, nil
+	}
+
+	// Add workflow context for conversation recording
+	ctx = llm.WithWorkflowID(ctx, workflowID)
+
+	startTime := time.Now()
+	s.logger.Info("Processing project description",
+		zap.String("project_id", projectID.String()),
+		zap.String("workflow_id", workflowID.String()),
+		zap.Int("description_len", len(description)))
+
+	// Update workflow progress
+	if err := s.workflowRepo.UpdateProgress(ctx, workflowID, &models.WorkflowProgress{
+		CurrentPhase: models.WorkflowPhaseDescriptionProcessing,
+		Message:      "Analyzing project description...",
+	}); err != nil {
+		s.logger.Error("Failed to update progress", zap.Error(err))
+	}
+
+	// Get workflow to find datasource
+	workflow, err := s.workflowRepo.GetByID(ctx, workflowID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get workflow: %w", err)
+	}
+	if workflow.Config == nil {
+		return nil, fmt.Errorf("workflow has no config")
+	}
+
+	// Load schema tables for context
+	tables, err := s.schemaRepo.ListTablesByDatasource(ctx, projectID, workflow.Config.DatasourceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tables: %w", err)
+	}
+
+	// Build schema summary for LLM
+	schemaSummary := s.buildSchemaSummaryForDescription(tables)
+
+	// Get LLM client
+	llmClient, err := s.llmFactory.CreateForProject(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create LLM client: %w", err)
+	}
+
+	prompt := s.buildDescriptionProcessingPrompt(description, schemaSummary)
+	systemMsg := s.descriptionProcessingSystemMessage()
+
+	llmResult, err := llmClient.GenerateResponse(ctx, prompt, systemMsg, 0.3, false)
+	if err != nil {
+		return nil, fmt.Errorf("LLM call failed: %w", err)
+	}
+
+	// Parse response
+	result, err := s.parseDescriptionProcessingResponse(llmResult.Content, projectID, workflow.OntologyID, workflowID)
+	if err != nil {
+		s.logger.Warn("Failed to parse description processing response",
+			zap.Error(err),
+			zap.String("response", llmResult.Content))
+		// Return empty result rather than failing
+		return &DescriptionProcessingResult{
+			EntityHints: make(map[string]*models.EntityHint),
+		}, nil
+	}
+
+	// Store domain context in ontology metadata for use by subsequent tasks
+	if result.DomainContext != nil {
+		metadata := map[string]any{
+			"domain_context": result.DomainContext,
+		}
+		if len(result.EntityHints) > 0 {
+			metadata["entity_hints"] = result.EntityHints
+		}
+		if err := s.ontologyRepo.UpdateMetadata(ctx, projectID, metadata); err != nil {
+			s.logger.Error("Failed to store domain context in metadata",
+				zap.Error(err))
+			// Continue - this is non-fatal
+		}
+	}
+
+	// Persist knowledge facts extracted from the description
+	for _, fact := range result.KnowledgeFacts {
+		if err := s.knowledgeRepo.Upsert(ctx, fact); err != nil {
+			s.logger.Error("Failed to store knowledge fact from description",
+				zap.String("fact_type", fact.FactType),
+				zap.String("key", fact.Key),
+				zap.Error(err))
+			// Continue - non-fatal, log and proceed
+		}
+	}
+
+	// Note: Clarifying questions from description analysis are now returned in the result
+	// and should be stored in workflow state by the caller (InitializeOntologyTask)
+	if len(result.ClarifyingQuestions) > 0 {
+		s.logger.Info("Description processing generated clarifying questions",
+			zap.Int("count", len(result.ClarifyingQuestions)))
+	}
+
+	s.logger.Info("Project description processed",
+		zap.Int("knowledge_facts", len(result.KnowledgeFacts)),
+		zap.Int("questions", len(result.ClarifyingQuestions)),
+		zap.Int("entity_hints", len(result.EntityHints)),
+		zap.Duration("elapsed", time.Since(startTime)))
+
+	return result, nil
+}
+
+func (s *ontologyBuilderService) descriptionProcessingSystemMessage() string {
+	return `You are a database analyst helping to understand a data source. The user has provided a description of their data. Your job is to:
+
+1. Extract structured knowledge from their description
+2. Identify terminology and business rules they've mentioned
+3. Generate clarifying questions where the description is ambiguous or incomplete
+4. Provide hints for entity naming and domain classification
+
+IMPORTANT:
+- Extract only what the user explicitly stated or clearly implied
+- Do not invent information not present in the description
+- Flag ambiguities as clarifying questions rather than making assumptions
+- Your output will seed the ontology, so be precise and conservative
+- Be concise - each fact/question should be a single focused item
+
+Return a JSON object with: domain_context, knowledge_facts, clarifying_questions, entity_hints`
+}
+
+func (s *ontologyBuilderService) buildSchemaSummaryForDescription(tables []*models.SchemaTable) string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("Total tables: %d\n\n", len(tables)))
+
+	for _, table := range tables {
+		sb.WriteString(fmt.Sprintf("### %s\n", table.TableName))
+		if table.RowCount != nil {
+			sb.WriteString(fmt.Sprintf("Rows: %d\n", *table.RowCount))
+		}
+		sb.WriteString("Columns: ")
+		colNames := make([]string, 0, len(table.Columns))
+		for _, col := range table.Columns {
+			colNames = append(colNames, col.ColumnName)
+		}
+		sb.WriteString(strings.Join(colNames, ", "))
+		sb.WriteString("\n\n")
+	}
+
+	return sb.String()
+}
+
+func (s *ontologyBuilderService) buildDescriptionProcessingPrompt(description, schemaSummary string) string {
+	return fmt.Sprintf(`## User's Description
+%s
+
+## Database Schema
+%s
+
+## Task
+Analyze the user's description against the schema and extract:
+1. A refined domain context summary (concise, LLM-optimized)
+2. Key terminology definitions mentioned
+3. Business rules mentioned or implied
+4. Clarifying questions where the description is ambiguous
+5. Entity hints (business names, domains, synonyms) for specific tables
+
+## Output Format
+Return a JSON object:
+%sjson
+{
+  "domain_context": {
+    "summary": "Brief description of what this database represents",
+    "primary_domains": ["sales", "inventory"],
+    "key_terminology": {
+      "Customer": "Person who has completed a purchase",
+      "SKU": "Stock Keeping Unit"
+    }
+  },
+  "knowledge_facts": [
+    {
+      "fact_type": "terminology",
+      "key": "customer_definition",
+      "value": "Person who has completed at least one purchase"
+    }
+  ],
+  "clarifying_questions": [
+    {
+      "text": "What are the possible values for order status?",
+      "priority": 1,
+      "category": "business_rules",
+      "reasoning": "Understanding order lifecycle is critical"
+    }
+  ],
+  "entity_hints": {
+    "orders": {
+      "business_name": "Customer Orders",
+      "domain": "sales"
+    }
+  }
+}
+%s`, description, schemaSummary, "```", "```")
+}
+
+func (s *ontologyBuilderService) parseDescriptionProcessingResponse(response string, projectID uuid.UUID, ontologyID uuid.UUID, workflowID uuid.UUID) (*DescriptionProcessingResult, error) {
+	type llmResponse struct {
+		DomainContext struct {
+			Summary        string            `json:"summary"`
+			PrimaryDomains []string          `json:"primary_domains"`
+			KeyTerminology map[string]string `json:"key_terminology"`
+		} `json:"domain_context"`
+		KnowledgeFacts []struct {
+			FactType string `json:"fact_type"`
+			Key      string `json:"key"`
+			Value    string `json:"value"`
+			Context  string `json:"context"`
+		} `json:"knowledge_facts"`
+		ClarifyingQuestions []struct {
+			Text      string `json:"text"`
+			Priority  int    `json:"priority"`
+			Category  string `json:"category"`
+			Reasoning string `json:"reasoning"`
+			Affects   struct {
+				Tables  []string `json:"tables"`
+				Columns []string `json:"columns"`
+			} `json:"affects"`
+		} `json:"clarifying_questions"`
+		EntityHints map[string]struct {
+			BusinessName string   `json:"business_name"`
+			Domain       string   `json:"domain"`
+			Synonyms     []string `json:"synonyms"`
+		} `json:"entity_hints"`
+	}
+
+	parsed, err := llm.ParseJSONResponse[llmResponse](response)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &DescriptionProcessingResult{
+		DomainContext: &models.DomainContext{
+			Summary:        parsed.DomainContext.Summary,
+			PrimaryDomains: parsed.DomainContext.PrimaryDomains,
+			KeyTerminology: parsed.DomainContext.KeyTerminology,
+		},
+		KnowledgeFacts:      make([]*models.KnowledgeFact, 0, len(parsed.KnowledgeFacts)),
+		ClarifyingQuestions: make([]*models.OntologyQuestion, 0, len(parsed.ClarifyingQuestions)),
+		EntityHints:         make(map[string]*models.EntityHint),
+	}
+
+	// Convert knowledge facts
+	for _, kf := range parsed.KnowledgeFacts {
+		if kf.Key == "" || kf.Value == "" {
+			continue
+		}
+		result.KnowledgeFacts = append(result.KnowledgeFacts, &models.KnowledgeFact{
+			ProjectID: projectID,
+			FactType:  kf.FactType,
+			Key:       kf.Key,
+			Value:     kf.Value,
+			Context:   "Extracted from user description",
+		})
+	}
+
+	// Convert clarifying questions
+	for _, cq := range parsed.ClarifyingQuestions {
+		if cq.Text == "" {
+			continue
+		}
+		priority := cq.Priority
+		if priority < 1 || priority > 5 {
+			priority = 2
+		}
+		q := &models.OntologyQuestion{
+			ID:              uuid.New(),
+			ProjectID:       projectID,
+			OntologyID:      ontologyID,
+			WorkflowID:      &workflowID,
+			Text:            cq.Text,
+			Priority:        priority,
+			Category:        cq.Category,
+			Reasoning:       cq.Reasoning,
+			DetectedPattern: "user_description",
+			Status:          models.QuestionStatusPending,
+		}
+		if len(cq.Affects.Tables) > 0 || len(cq.Affects.Columns) > 0 {
+			q.Affects = &models.QuestionAffects{
+				Tables:  cq.Affects.Tables,
+				Columns: cq.Affects.Columns,
+			}
+		}
+		result.ClarifyingQuestions = append(result.ClarifyingQuestions, q)
+	}
+
+	// Convert entity hints
+	for tableName, hint := range parsed.EntityHints {
+		result.EntityHints[tableName] = &models.EntityHint{
+			BusinessName: hint.BusinessName,
+			Domain:       hint.Domain,
+			Synonyms:     hint.Synonyms,
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/services/ontology_chat.go
+++ b/pkg/services/ontology_chat.go
@@ -1,0 +1,548 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/adapters/datasource"
+	"github.com/ekaya-inc/ekaya-engine/pkg/llm"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
+)
+
+// OntologyChatService provides operations for ontology chat interface.
+type OntologyChatService interface {
+	// Initialize initializes a chat session and returns an opening message.
+	Initialize(ctx context.Context, projectID uuid.UUID) (*models.ChatInitResponse, error)
+
+	// SendMessage sends a message and streams the response via the event channel.
+	// The channel will receive events until ChatEventDone or ChatEventError.
+	// NOTE: Caller owns the channel and is responsible for closing it. This service
+	// writes events but does not close the channel, allowing the caller (handler)
+	// to manage the channel lifecycle.
+	SendMessage(ctx context.Context, projectID uuid.UUID, message string, eventChan chan<- models.ChatEvent) error
+
+	// GetHistory retrieves chat history for a project.
+	GetHistory(ctx context.Context, projectID uuid.UUID, limit int) ([]*models.ChatMessage, error)
+
+	// ClearHistory clears the chat history for a project.
+	ClearHistory(ctx context.Context, projectID uuid.UUID) error
+
+	// SaveMessage saves a chat message.
+	SaveMessage(ctx context.Context, message *models.ChatMessage) error
+}
+
+type ontologyChatService struct {
+	chatRepo          repositories.OntologyChatRepository
+	ontologyRepo      repositories.OntologyRepository
+	knowledgeRepo     repositories.KnowledgeRepository
+	schemaRepo        repositories.SchemaRepository
+	workflowRepo      repositories.OntologyWorkflowRepository
+	stateRepo         repositories.WorkflowStateRepository
+	llmFactory        llm.LLMClientFactory
+	datasourceService DatasourceService
+	adapterFactory    datasource.DatasourceAdapterFactory
+	logger            *zap.Logger
+}
+
+// NewOntologyChatService creates a new ontology chat service.
+func NewOntologyChatService(
+	chatRepo repositories.OntologyChatRepository,
+	ontologyRepo repositories.OntologyRepository,
+	knowledgeRepo repositories.KnowledgeRepository,
+	schemaRepo repositories.SchemaRepository,
+	workflowRepo repositories.OntologyWorkflowRepository,
+	stateRepo repositories.WorkflowStateRepository,
+	llmFactory llm.LLMClientFactory,
+	datasourceService DatasourceService,
+	adapterFactory datasource.DatasourceAdapterFactory,
+	logger *zap.Logger,
+) OntologyChatService {
+	return &ontologyChatService{
+		chatRepo:          chatRepo,
+		ontologyRepo:      ontologyRepo,
+		knowledgeRepo:     knowledgeRepo,
+		schemaRepo:        schemaRepo,
+		workflowRepo:      workflowRepo,
+		stateRepo:         stateRepo,
+		llmFactory:        llmFactory,
+		datasourceService: datasourceService,
+		adapterFactory:    adapterFactory,
+		logger:            logger.Named("ontology-chat"),
+	}
+}
+
+var _ OntologyChatService = (*ontologyChatService)(nil)
+
+func (s *ontologyChatService) Initialize(ctx context.Context, projectID uuid.UUID) (*models.ChatInitResponse, error) {
+	// Check for existing history
+	historyCount, err := s.chatRepo.GetHistoryCount(ctx, projectID)
+	if err != nil {
+		s.logger.Error("Failed to get chat history count",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+
+	// Get pending questions count from workflow state
+	pendingCount, err := s.stateRepo.GetPendingQuestionsCountByProject(ctx, projectID)
+	if err != nil {
+		s.logger.Error("Failed to get pending question count",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+
+	// Get the ontology to provide context
+	ontology, err := s.ontologyRepo.GetActive(ctx, projectID)
+	if err != nil {
+		s.logger.Error("Failed to get active ontology",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+
+	var openingMessage string
+
+	if historyCount == 0 {
+		// First conversation
+		if ontology == nil || ontology.DomainSummary == nil {
+			openingMessage = "Hello! I'm here to help you build and refine your data ontology. " +
+				"It looks like we haven't extracted any ontology yet. " +
+				"Would you like to start the extraction process?"
+		} else {
+			entityCount := ontology.TableCount()
+			openingMessage = fmt.Sprintf(
+				"Hello! I'm here to help you refine your data ontology. "+
+					"I have analyzed %d tables in your database. ",
+				entityCount,
+			)
+			if pendingCount > 0 {
+				openingMessage += fmt.Sprintf(
+					"There are %d questions I'd like to ask to better understand your data. "+
+						"You can answer them in the Questions panel, or feel free to ask me anything about your schema.",
+					pendingCount,
+				)
+			} else {
+				openingMessage += "Feel free to ask me anything about your schema or tell me about specific business rules."
+			}
+		}
+	} else {
+		// Continuing conversation
+		if pendingCount > 0 {
+			openingMessage = fmt.Sprintf(
+				"Welcome back! There are %d pending questions to help refine the ontology. "+
+					"How can I assist you today?",
+				pendingCount,
+			)
+		} else {
+			openingMessage = "Welcome back! How can I help you refine your data ontology?"
+		}
+	}
+
+	s.logger.Info("Chat initialized",
+		zap.String("project_id", projectID.String()),
+		zap.Int("pending_questions", pendingCount),
+		zap.Bool("has_history", historyCount > 0))
+
+	return &models.ChatInitResponse{
+		OpeningMessage:       openingMessage,
+		PendingQuestionCount: pendingCount,
+		HasExistingHistory:   historyCount > 0,
+	}, nil
+}
+
+func (s *ontologyChatService) SendMessage(ctx context.Context, projectID uuid.UUID, message string, eventChan chan<- models.ChatEvent) error {
+	// Get workflow first to get ontologyID for all messages
+	workflow, err := s.workflowRepo.GetLatestByProject(ctx, projectID)
+	if err != nil {
+		s.logger.Error("Failed to get workflow",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		eventChan <- models.NewErrorEvent("No ontology workflow found. Please run extraction first.")
+		return err
+	}
+
+	if workflow.Config == nil {
+		s.logger.Error("Workflow has no configuration",
+			zap.String("project_id", projectID.String()),
+			zap.String("workflow_id", workflow.ID.String()))
+		eventChan <- models.NewErrorEvent("Workflow has no configuration")
+		return fmt.Errorf("workflow %s has no configuration", workflow.ID)
+	}
+
+	// Save user message with ontologyID from workflow
+	userMessage := &models.ChatMessage{
+		ProjectID:  projectID,
+		OntologyID: workflow.OntologyID,
+		Role:       models.ChatRoleUser,
+		Content:    message,
+	}
+
+	if err := s.chatRepo.SaveMessage(ctx, userMessage); err != nil {
+		s.logger.Error("Failed to save user message",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		eventChan <- models.NewErrorEvent("Failed to save message")
+		return err
+	}
+
+	// Get datasource config (decrypted)
+	ds, err := s.datasourceService.Get(ctx, projectID, workflow.Config.DatasourceID)
+	if err != nil {
+		s.logger.Error("Failed to get datasource",
+			zap.String("project_id", projectID.String()),
+			zap.String("datasource_id", workflow.Config.DatasourceID.String()),
+			zap.Error(err))
+		eventChan <- models.NewErrorEvent("Failed to get datasource configuration")
+		return err
+	}
+
+	// Create query executor
+	queryExecutor, err := s.adapterFactory.NewQueryExecutor(ctx, ds.DatasourceType, ds.Config)
+	if err != nil {
+		s.logger.Error("Failed to create query executor",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		eventChan <- models.NewErrorEvent("Failed to connect to datasource")
+		return err
+	}
+	defer queryExecutor.Close()
+
+	// Create tool executor
+	toolExecutor := llm.NewOntologyToolExecutor(&llm.OntologyToolExecutorConfig{
+		ProjectID:     projectID,
+		DatasourceID:  workflow.Config.DatasourceID,
+		OntologyRepo:  s.ontologyRepo,
+		WorkflowRepo:  s.workflowRepo,
+		StateRepo:     s.stateRepo,
+		KnowledgeRepo: s.knowledgeRepo,
+		SchemaRepo:    s.schemaRepo,
+		QueryExecutor: queryExecutor,
+		Logger:        s.logger,
+	})
+
+	// Create streaming client
+	streamingClient, err := s.llmFactory.CreateStreamingClient(ctx, projectID)
+	if err != nil {
+		s.logger.Error("Failed to create LLM client",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		eventChan <- models.NewErrorEvent("Failed to create LLM client")
+		return err
+	}
+
+	// Get ontology for system prompt context
+	ontology, err := s.ontologyRepo.GetActive(ctx, projectID)
+	if err != nil {
+		s.logger.Error("Failed to get active ontology",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		eventChan <- models.NewErrorEvent("Failed to get ontology")
+		return err
+	}
+
+	// Build messages from chat history
+	history, err := s.chatRepo.GetHistory(ctx, projectID, 20)
+	if err != nil {
+		s.logger.Error("Failed to get chat history",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		eventChan <- models.NewErrorEvent("Failed to get chat history")
+		return err
+	}
+
+	messages := s.convertChatHistoryToLLMMessages(history)
+
+	// Build system prompt with ontology context
+	systemPrompt := s.buildChatSystemPrompt(ontology)
+
+	// Create streaming request
+	req := &llm.StreamingRequest{
+		SystemPrompt: systemPrompt,
+		Messages:     messages,
+		Tools:        llm.GetOntologyChatTools(),
+		Temperature:  0.7,
+	}
+
+	// Stream with tools and forward events
+	internalChan := make(chan llm.StreamEvent, 100)
+	errChan := make(chan error, 1)
+	go func() {
+		defer close(internalChan)
+		errChan <- streamingClient.StreamWithTools(ctx, req, toolExecutor, internalChan)
+	}()
+
+	// Accumulators for building complete messages
+	var textBuilder strings.Builder
+	var pendingToolCalls []models.ToolCall
+
+	// Forward stream events to chat events and save to history
+	for event := range internalChan {
+		chatEvent := s.convertStreamEventToChatEvent(event)
+		eventChan <- chatEvent
+
+		switch event.Type {
+		case llm.StreamEventText:
+			textBuilder.WriteString(event.Content)
+
+		case llm.StreamEventToolCall:
+			// Accumulate tool calls for the assistant message
+			if tc, ok := event.Data.(llm.ToolCall); ok {
+				pendingToolCalls = append(pendingToolCalls, models.ToolCall{
+					ID:   tc.ID,
+					Type: tc.Type,
+					Function: models.ToolCallFunction{
+						Name:      tc.Function.Name,
+						Arguments: tc.Function.Arguments,
+					},
+				})
+			}
+
+		case llm.StreamEventToolResult:
+			// When we see the first tool result, save the assistant message with tool calls
+			if len(pendingToolCalls) > 0 || textBuilder.Len() > 0 {
+				assistantMsg := &models.ChatMessage{
+					ProjectID:  projectID,
+					OntologyID: workflow.OntologyID,
+					Role:       models.ChatRoleAssistant,
+					Content:    textBuilder.String(),
+					ToolCalls:  pendingToolCalls,
+				}
+				if err := s.chatRepo.SaveMessage(ctx, assistantMsg); err != nil {
+					s.logger.Error("Failed to save assistant message with tool calls",
+						zap.String("project_id", projectID.String()),
+						zap.Error(err))
+				}
+				// Reset accumulators for next iteration
+				textBuilder.Reset()
+				pendingToolCalls = nil
+			}
+
+			// Save the tool result as a tool message
+			toolCallID := ""
+			if data, ok := event.Data.(map[string]string); ok {
+				toolCallID = data["tool_call_id"]
+			}
+			toolMsg := &models.ChatMessage{
+				ProjectID:  projectID,
+				OntologyID: workflow.OntologyID,
+				Role:       models.ChatRoleTool,
+				Content:    event.Content,
+				ToolCallID: toolCallID,
+			}
+			if err := s.chatRepo.SaveMessage(ctx, toolMsg); err != nil {
+				s.logger.Error("Failed to save tool result message",
+					zap.String("project_id", projectID.String()),
+					zap.String("tool_call_id", toolCallID),
+					zap.Error(err))
+			}
+
+		case llm.StreamEventDone, llm.StreamEventError:
+			// Save any remaining text as final assistant message
+			if textBuilder.Len() > 0 {
+				assistantMsg := &models.ChatMessage{
+					ProjectID:  projectID,
+					OntologyID: workflow.OntologyID,
+					Role:       models.ChatRoleAssistant,
+					Content:    textBuilder.String(),
+				}
+				if err := s.chatRepo.SaveMessage(ctx, assistantMsg); err != nil {
+					s.logger.Error("Failed to save final assistant message",
+						zap.String("project_id", projectID.String()),
+						zap.Error(err))
+				}
+			}
+			break
+		}
+
+		// Stop on done or error
+		if event.Type == llm.StreamEventDone || event.Type == llm.StreamEventError {
+			break
+		}
+	}
+
+	// Wait for streaming goroutine to complete and return any error
+	return <-errChan
+}
+
+func (s *ontologyChatService) GetHistory(ctx context.Context, projectID uuid.UUID, limit int) ([]*models.ChatMessage, error) {
+	messages, err := s.chatRepo.GetHistory(ctx, projectID, limit)
+	if err != nil {
+		s.logger.Error("Failed to get chat history",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+	return messages, nil
+}
+
+func (s *ontologyChatService) ClearHistory(ctx context.Context, projectID uuid.UUID) error {
+	if err := s.chatRepo.ClearHistory(ctx, projectID); err != nil {
+		s.logger.Error("Failed to clear chat history",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		return err
+	}
+
+	s.logger.Info("Chat history cleared",
+		zap.String("project_id", projectID.String()))
+
+	return nil
+}
+
+func (s *ontologyChatService) SaveMessage(ctx context.Context, message *models.ChatMessage) error {
+	if err := s.chatRepo.SaveMessage(ctx, message); err != nil {
+		s.logger.Error("Failed to save message",
+			zap.String("project_id", message.ProjectID.String()),
+			zap.Error(err))
+		return err
+	}
+	return nil
+}
+
+// ============================================================================
+// Helper Methods
+// ============================================================================
+
+// convertChatHistoryToLLMMessages converts chat message history to LLM message format.
+func (s *ontologyChatService) convertChatHistoryToLLMMessages(history []*models.ChatMessage) []llm.Message {
+	messages := make([]llm.Message, 0, len(history))
+	for _, msg := range history {
+		llmMsg := llm.Message{
+			Content:    msg.Content,
+			ToolCallID: msg.ToolCallID,
+		}
+
+		// Convert role
+		switch msg.Role {
+		case models.ChatRoleUser:
+			llmMsg.Role = llm.RoleUser
+		case models.ChatRoleAssistant:
+			llmMsg.Role = llm.RoleAssistant
+		case models.ChatRoleTool:
+			llmMsg.Role = llm.RoleTool
+		default:
+			llmMsg.Role = llm.RoleUser
+		}
+
+		// Convert tool calls if present
+		if len(msg.ToolCalls) > 0 {
+			llmMsg.ToolCalls = make([]llm.ToolCall, len(msg.ToolCalls))
+			for i, tc := range msg.ToolCalls {
+				llmMsg.ToolCalls[i] = llm.ToolCall{
+					ID:   tc.ID,
+					Type: tc.Type,
+					Function: llm.ToolCallFunc{
+						Name:      tc.Function.Name,
+						Arguments: tc.Function.Arguments,
+					},
+				}
+			}
+		}
+
+		messages = append(messages, llmMsg)
+	}
+	return messages
+}
+
+// buildChatSystemPrompt creates a system prompt with ontology context.
+func (s *ontologyChatService) buildChatSystemPrompt(ontology *models.TieredOntology) string {
+	var sb strings.Builder
+
+	sb.WriteString(`You are an AI assistant helping users understand and refine their data ontology. Your role is to:
+
+1. Answer questions about the database schema, tables, and columns
+2. Help identify and document business rules and domain knowledge
+3. Clarify the meaning and relationships between data entities
+4. Store important facts about the data using the available tools
+
+Available tools:
+- query_column_values: Query sample values from database columns
+- query_schema_metadata: Get metadata about tables and columns
+- update_entity: Update descriptions or synonyms for tables
+- update_column: Update descriptions or semantic types for columns
+- store_knowledge: Store business facts and domain knowledge
+- answer_question: Mark ontology questions as answered
+- get_pending_questions: Retrieve pending questions about the schema
+
+Guidelines:
+- Be helpful and conversational while staying focused on data understanding
+- Use tools when you need to explore the data or update the ontology
+- When storing knowledge, categorize it appropriately (terminology, business_rule, data_relationship, constraint, context)
+- Ask clarifying questions when the user's intent is unclear
+
+`)
+
+	if ontology != nil && ontology.DomainSummary != nil {
+		sb.WriteString("## Current Domain Context\n\n")
+		if ontology.DomainSummary.Description != "" {
+			if len(ontology.DomainSummary.Domains) > 0 {
+				sb.WriteString(fmt.Sprintf("**Domains:** %s\n", strings.Join(ontology.DomainSummary.Domains, ", ")))
+			}
+			sb.WriteString(fmt.Sprintf("**Description:** %s\n\n", ontology.DomainSummary.Description))
+		}
+
+		if len(ontology.EntitySummaries) > 0 {
+			sb.WriteString("## Available Tables\n\n")
+			// RESEARCH: Consider ordering by relevance (row count, relationship degree,
+			// query frequency) rather than alphabetically to signal importance to the LLM.
+			tableNames := make([]string, 0, len(ontology.EntitySummaries))
+			for name := range ontology.EntitySummaries {
+				tableNames = append(tableNames, name)
+			}
+			sort.Strings(tableNames)
+			for _, tableName := range tableNames {
+				entity := ontology.EntitySummaries[tableName]
+				if entity.Description != "" {
+					sb.WriteString(fmt.Sprintf("- **%s**: %s\n", tableName, entity.Description))
+				} else {
+					sb.WriteString(fmt.Sprintf("- **%s**\n", tableName))
+				}
+			}
+			sb.WriteString("\n")
+		}
+	} else {
+		sb.WriteString("Note: No ontology has been extracted yet. You may need to help the user start the extraction process.\n\n")
+	}
+
+	return sb.String()
+}
+
+// convertStreamEventToChatEvent converts an LLM stream event to a chat event.
+func (s *ontologyChatService) convertStreamEventToChatEvent(event llm.StreamEvent) models.ChatEvent {
+	switch event.Type {
+	case llm.StreamEventText:
+		return models.NewTextEvent(event.Content)
+	case llm.StreamEventToolCall:
+		// Convert llm.ToolCall to models.ToolCall
+		if tc, ok := event.Data.(llm.ToolCall); ok {
+			modelTC := models.ToolCall{
+				ID:   tc.ID,
+				Type: tc.Type,
+				Function: models.ToolCallFunction{
+					Name:      tc.Function.Name,
+					Arguments: tc.Function.Arguments,
+				},
+			}
+			return models.NewToolCallEvent(modelTC)
+		}
+		return models.NewTextEvent(event.Content)
+	case llm.StreamEventToolResult:
+		if data, ok := event.Data.(map[string]string); ok {
+			return models.NewToolResultEvent(data["tool_call_id"], event.Content)
+		}
+		return models.NewToolResultEvent("", event.Content)
+	case llm.StreamEventDone:
+		return models.NewDoneEvent()
+	case llm.StreamEventError:
+		return models.NewErrorEvent(event.Content)
+	default:
+		return models.NewTextEvent(event.Content)
+	}
+}

--- a/pkg/services/ontology_question.go
+++ b/pkg/services/ontology_question.go
@@ -1,0 +1,412 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
+)
+
+// OntologyQuestionService provides operations for ontology question management.
+// Questions are stored in the engine_ontology_questions table, decoupled from workflow lifecycle.
+type OntologyQuestionService interface {
+	// GetNextQuestion returns the next pending question for a project.
+	GetNextQuestion(ctx context.Context, projectID uuid.UUID, includeSkipped bool) (*models.OntologyQuestion, error)
+
+	// GetPendingQuestions returns all pending questions for a project.
+	GetPendingQuestions(ctx context.Context, projectID uuid.UUID) ([]*models.OntologyQuestion, error)
+
+	// GetPendingCount returns the count of pending questions.
+	GetPendingCount(ctx context.Context, projectID uuid.UUID) (int, error)
+
+	// GetPendingCounts returns separate counts of required and optional pending questions.
+	GetPendingCounts(ctx context.Context, projectID uuid.UUID) (*repositories.QuestionCounts, error)
+
+	// AnswerQuestion processes an answer and applies any resulting actions.
+	AnswerQuestion(ctx context.Context, questionID uuid.UUID, answer string, userID string) (*models.AnswerResult, error)
+
+	// SkipQuestion marks a question as skipped.
+	SkipQuestion(ctx context.Context, questionID uuid.UUID) error
+
+	// DeleteQuestion soft-deletes a question.
+	DeleteQuestion(ctx context.Context, questionID uuid.UUID) error
+
+	// CreateQuestions creates a batch of questions for a project/workflow.
+	CreateQuestions(ctx context.Context, questions []*models.OntologyQuestion) error
+}
+
+type ontologyQuestionService struct {
+	questionRepo  repositories.OntologyQuestionRepository
+	ontologyRepo  repositories.OntologyRepository
+	knowledgeRepo repositories.KnowledgeRepository
+	builder       OntologyBuilderService
+	logger        *zap.Logger
+}
+
+// NewOntologyQuestionService creates a new ontology question service.
+func NewOntologyQuestionService(
+	questionRepo repositories.OntologyQuestionRepository,
+	ontologyRepo repositories.OntologyRepository,
+	knowledgeRepo repositories.KnowledgeRepository,
+	builder OntologyBuilderService,
+	logger *zap.Logger,
+) OntologyQuestionService {
+	return &ontologyQuestionService{
+		questionRepo:  questionRepo,
+		ontologyRepo:  ontologyRepo,
+		knowledgeRepo: knowledgeRepo,
+		builder:       builder,
+		logger:        logger.Named("ontology-question"),
+	}
+}
+
+var _ OntologyQuestionService = (*ontologyQuestionService)(nil)
+
+func (s *ontologyQuestionService) GetNextQuestion(ctx context.Context, projectID uuid.UUID, includeSkipped bool) (*models.OntologyQuestion, error) {
+	// Questions are stored in the dedicated table, no need to check workflow state
+	question, err := s.questionRepo.GetNextPending(ctx, projectID)
+	if err != nil {
+		s.logger.Error("Failed to get next pending question",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+	return question, nil
+}
+
+func (s *ontologyQuestionService) GetPendingQuestions(ctx context.Context, projectID uuid.UUID) ([]*models.OntologyQuestion, error) {
+	questions, err := s.questionRepo.ListPending(ctx, projectID)
+	if err != nil {
+		s.logger.Error("Failed to list pending questions",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+	return questions, nil
+}
+
+func (s *ontologyQuestionService) GetPendingCount(ctx context.Context, projectID uuid.UUID) (int, error) {
+	counts, err := s.GetPendingCounts(ctx, projectID)
+	if err != nil {
+		return 0, err
+	}
+	if counts == nil {
+		return 0, nil
+	}
+	return counts.Required + counts.Optional, nil
+}
+
+func (s *ontologyQuestionService) GetPendingCounts(ctx context.Context, projectID uuid.UUID) (*repositories.QuestionCounts, error) {
+	counts, err := s.questionRepo.GetPendingCounts(ctx, projectID)
+	if err != nil {
+		s.logger.Error("Failed to get pending question counts",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+	return counts, nil
+}
+
+func (s *ontologyQuestionService) AnswerQuestion(ctx context.Context, questionID uuid.UUID, answer string, userID string) (*models.AnswerResult, error) {
+	// Get the question from the dedicated table
+	question, err := s.questionRepo.GetByID(ctx, questionID)
+	if err != nil {
+		s.logger.Error("Failed to get question",
+			zap.String("question_id", questionID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+
+	if question == nil {
+		return nil, fmt.Errorf("question not found")
+	}
+
+	if question.Status != models.QuestionStatusPending && question.Status != models.QuestionStatusSkipped {
+		return nil, fmt.Errorf("question is not in a pending state")
+	}
+
+	// Process the answer using LLM to extract ontology updates and knowledge facts
+	processingResult, err := s.builder.ProcessAnswer(ctx, question.ProjectID, question, answer)
+	if err != nil {
+		s.logger.Error("Failed to process answer",
+			zap.String("question_id", questionID.String()),
+			zap.Error(err))
+		return nil, fmt.Errorf("process answer: %w", err)
+	}
+
+	// Apply entity updates to the ontology
+	if err := s.applyEntityUpdates(ctx, question.ProjectID, processingResult.EntityUpdates); err != nil {
+		s.logger.Error("Failed to apply entity updates",
+			zap.String("question_id", questionID.String()),
+			zap.Error(err))
+		return nil, fmt.Errorf("apply entity updates: %w", err)
+	}
+
+	// Apply column updates to the ontology
+	if err := s.applyColumnUpdates(ctx, question.ProjectID, processingResult.ColumnUpdates); err != nil {
+		s.logger.Error("Failed to apply column updates",
+			zap.String("question_id", questionID.String()),
+			zap.Error(err))
+		return nil, fmt.Errorf("apply column updates: %w", err)
+	}
+
+	// Store knowledge facts
+	for _, fact := range processingResult.KnowledgeFacts {
+		if err := s.knowledgeRepo.Upsert(ctx, fact); err != nil {
+			s.logger.Error("Failed to store knowledge fact",
+				zap.String("fact_type", fact.FactType),
+				zap.String("key", fact.Key),
+				zap.Error(err))
+			return nil, fmt.Errorf("store knowledge fact %s/%s: %w", fact.FactType, fact.Key, err)
+		}
+	}
+
+	// Create follow-up question if needed
+	if processingResult.FollowUp != nil && *processingResult.FollowUp != "" {
+		followUp := &models.OntologyQuestion{
+			ProjectID:        question.ProjectID,
+			OntologyID:       question.OntologyID,
+			Text:             *processingResult.FollowUp,
+			Priority:         question.Priority,
+			IsRequired:       false, // Follow-ups are optional
+			Category:         "follow_up",
+			Status:           models.QuestionStatusPending,
+			Affects:          question.Affects, // Inherit affects from parent
+			ParentQuestionID: &questionID,
+		}
+		if err := s.questionRepo.Create(ctx, followUp); err != nil {
+			s.logger.Error("Failed to create follow-up question",
+				zap.String("question_id", questionID.String()),
+				zap.Error(err))
+			return nil, fmt.Errorf("create follow-up question: %w", err)
+		}
+	}
+
+	// Mark question as answered
+	var answeredByUUID *uuid.UUID
+	if userID != "" {
+		if uid, err := uuid.Parse(userID); err == nil {
+			answeredByUUID = &uid
+		}
+	}
+	if err := s.questionRepo.SubmitAnswer(ctx, questionID, answer, answeredByUUID); err != nil {
+		s.logger.Error("Failed to submit answer",
+			zap.String("question_id", questionID.String()),
+			zap.Error(err))
+		return nil, fmt.Errorf("submit answer: %w", err)
+	}
+
+	s.logger.Info("Question answered and processed",
+		zap.String("question_id", questionID.String()),
+		zap.String("user_id", userID),
+		zap.Int("entity_updates", len(processingResult.EntityUpdates)),
+		zap.Int("knowledge_facts", len(processingResult.KnowledgeFacts)))
+
+	// Get next question
+	nextQuestion, err := s.GetNextQuestion(ctx, question.ProjectID, false)
+	if err != nil {
+		s.logger.Error("Failed to get next question after answer",
+			zap.String("project_id", question.ProjectID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+
+	return &models.AnswerResult{
+		QuestionID:     questionID,
+		FollowUp:       processingResult.FollowUp,
+		ActionsSummary: processingResult.ActionsSummary,
+		Thinking:       processingResult.Thinking,
+		NextQuestion:   nextQuestion,
+		AllComplete:    nextQuestion == nil,
+	}, nil
+}
+
+// applyEntityUpdates applies entity updates from answer processing to the ontology.
+func (s *ontologyQuestionService) applyEntityUpdates(ctx context.Context, projectID uuid.UUID, updates []EntityUpdate) error {
+	if len(updates) == 0 {
+		return nil
+	}
+
+	// Get the active ontology to merge updates
+	ontology, err := s.ontologyRepo.GetActive(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("get active ontology: %w", err)
+	}
+	if ontology == nil {
+		return fmt.Errorf("no active ontology for project %s", projectID.String())
+	}
+
+	for _, update := range updates {
+		// Get existing summary or create new one
+		existingSummary := ontology.EntitySummaries[update.TableName]
+		if existingSummary == nil {
+			existingSummary = &models.EntitySummary{
+				TableName: update.TableName,
+			}
+		}
+
+		// Merge updates into existing summary
+		if update.BusinessName != nil {
+			existingSummary.BusinessName = *update.BusinessName
+		}
+		if update.Description != nil {
+			existingSummary.Description = *update.Description
+		}
+		if update.Domain != nil {
+			existingSummary.Domain = *update.Domain
+		}
+		if len(update.Synonyms) > 0 {
+			// Deduplicate synonyms
+			existingSynonyms := make(map[string]bool)
+			for _, syn := range existingSummary.Synonyms {
+				existingSynonyms[syn] = true
+			}
+			for _, syn := range update.Synonyms {
+				if !existingSynonyms[syn] {
+					existingSummary.Synonyms = append(existingSummary.Synonyms, syn)
+				}
+			}
+		}
+
+		// Persist the update
+		if err := s.ontologyRepo.UpdateEntitySummary(ctx, projectID, update.TableName, existingSummary); err != nil {
+			return fmt.Errorf("update entity %s: %w", update.TableName, err)
+		}
+	}
+
+	return nil
+}
+
+// applyColumnUpdates applies column updates from answer processing to the ontology.
+func (s *ontologyQuestionService) applyColumnUpdates(ctx context.Context, projectID uuid.UUID, updates []ColumnUpdate) error {
+	if len(updates) == 0 {
+		return nil
+	}
+
+	// Get the active ontology to merge updates
+	ontology, err := s.ontologyRepo.GetActive(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("get active ontology: %w", err)
+	}
+	if ontology == nil {
+		return fmt.Errorf("no active ontology for project %s", projectID.String())
+	}
+
+	// Group updates by table for efficient batch updates
+	updatesByTable := make(map[string][]ColumnUpdate)
+	for _, update := range updates {
+		updatesByTable[update.TableName] = append(updatesByTable[update.TableName], update)
+	}
+
+	for tableName, tableUpdates := range updatesByTable {
+		// Get existing columns or create new slice
+		columns := ontology.ColumnDetails[tableName]
+		if columns == nil {
+			columns = []models.ColumnDetail{}
+		}
+
+		// Apply each column update
+		for _, update := range tableUpdates {
+			found := false
+			for i := range columns {
+				if columns[i].Name == update.ColumnName {
+					// Update existing column
+					if update.Description != nil {
+						columns[i].Description = *update.Description
+					}
+					if update.SemanticType != nil {
+						columns[i].SemanticType = *update.SemanticType
+					}
+					if update.Role != nil {
+						columns[i].Role = *update.Role
+					}
+					if len(update.Synonyms) > 0 {
+						// Deduplicate synonyms
+						existingSynonyms := make(map[string]bool)
+						for _, syn := range columns[i].Synonyms {
+							existingSynonyms[syn] = true
+						}
+						for _, syn := range update.Synonyms {
+							if !existingSynonyms[syn] {
+								columns[i].Synonyms = append(columns[i].Synonyms, syn)
+							}
+						}
+					}
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				// Create new column detail
+				newColumn := models.ColumnDetail{
+					Name: update.ColumnName,
+				}
+				if update.Description != nil {
+					newColumn.Description = *update.Description
+				}
+				if update.SemanticType != nil {
+					newColumn.SemanticType = *update.SemanticType
+				}
+				if update.Role != nil {
+					newColumn.Role = *update.Role
+				}
+				if len(update.Synonyms) > 0 {
+					newColumn.Synonyms = update.Synonyms
+				}
+				columns = append(columns, newColumn)
+			}
+		}
+
+		// Persist the updates for this table
+		if err := s.ontologyRepo.UpdateColumnDetails(ctx, projectID, tableName, columns); err != nil {
+			return fmt.Errorf("update columns for %s: %w", tableName, err)
+		}
+
+		s.logger.Info("Applied column updates",
+			zap.String("project_id", projectID.String()),
+			zap.String("table_name", tableName),
+			zap.Int("column_count", len(tableUpdates)))
+	}
+
+	return nil
+}
+
+func (s *ontologyQuestionService) SkipQuestion(ctx context.Context, questionID uuid.UUID) error {
+	if err := s.questionRepo.UpdateStatus(ctx, questionID, models.QuestionStatusSkipped); err != nil {
+		s.logger.Error("Failed to skip question",
+			zap.String("question_id", questionID.String()),
+			zap.Error(err))
+		return err
+	}
+
+	s.logger.Info("Question skipped",
+		zap.String("question_id", questionID.String()))
+
+	return nil
+}
+
+func (s *ontologyQuestionService) DeleteQuestion(ctx context.Context, questionID uuid.UUID) error {
+	if err := s.questionRepo.UpdateStatus(ctx, questionID, models.QuestionStatusDeleted); err != nil {
+		s.logger.Error("Failed to delete question",
+			zap.String("question_id", questionID.String()),
+			zap.Error(err))
+		return err
+	}
+
+	s.logger.Info("Question deleted",
+		zap.String("question_id", questionID.String()))
+
+	return nil
+}
+
+func (s *ontologyQuestionService) CreateQuestions(ctx context.Context, questions []*models.OntologyQuestion) error {
+	if len(questions) == 0 {
+		return nil
+	}
+	return s.questionRepo.CreateBatch(ctx, questions)
+}

--- a/pkg/services/ontology_tasks.go
+++ b/pkg/services/ontology_tasks.go
@@ -1,0 +1,581 @@
+package services
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/adapters/datasource"
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
+	"github.com/ekaya-inc/ekaya-engine/pkg/services/workqueue"
+)
+
+// TenantContextFunc acquires a tenant-scoped database connection for background work.
+// Returns the scoped context, a cleanup function (MUST be called), and any error.
+// Using a function type instead of interface - easiest to test with inline closures.
+type TenantContextFunc func(ctx context.Context, projectID uuid.UUID) (context.Context, func(), error)
+
+// NewTenantContextFunc creates a TenantContextFunc that uses the given database.
+func NewTenantContextFunc(db *database.DB) TenantContextFunc {
+	return func(ctx context.Context, projectID uuid.UUID) (context.Context, func(), error) {
+		scope, err := db.WithTenant(ctx, projectID)
+		if err != nil {
+			return nil, nil, err
+		}
+		tenantCtx := database.SetTenantScope(ctx, scope)
+		return tenantCtx, func() { scope.Close() }, nil
+	}
+}
+
+// BuildTieredOntologyTask builds Tier 0 (domain summary) and Tier 1 (entity summaries).
+// This is an LLM task - only one can run at a time.
+type BuildTieredOntologyTask struct {
+	workqueue.BaseTask
+	builder      OntologyBuilderService
+	getTenantCtx TenantContextFunc
+	projectID    uuid.UUID
+	workflowID   uuid.UUID
+}
+
+// NewBuildTieredOntologyTask creates a new build task.
+func NewBuildTieredOntologyTask(
+	builder OntologyBuilderService,
+	getTenantCtx TenantContextFunc,
+	projectID uuid.UUID,
+	workflowID uuid.UUID,
+) *BuildTieredOntologyTask {
+	return &BuildTieredOntologyTask{
+		BaseTask:     workqueue.NewBaseTask("Build Tiered Ontology", true),
+		builder:      builder,
+		getTenantCtx: getTenantCtx,
+		projectID:    projectID,
+		workflowID:   workflowID,
+	}
+}
+
+// Execute implements workqueue.Task.
+func (t *BuildTieredOntologyTask) Execute(ctx context.Context, enqueuer workqueue.TaskEnqueuer) error {
+	tenantCtx, cleanup, err := t.getTenantCtx(ctx, t.projectID)
+	if err != nil {
+		return fmt.Errorf("acquire tenant connection: %w", err)
+	}
+	defer cleanup()
+
+	return t.builder.BuildTieredOntology(tenantCtx, t.projectID, t.workflowID)
+}
+
+// InitializeOntologyTask is a quick non-LLM task that sets up the extraction workflow.
+// It loads tables from schema and enqueues child tasks for processing.
+type InitializeOntologyTask struct {
+	workqueue.BaseTask
+	schemaRepo        repositories.SchemaRepository
+	ontologyRepo      repositories.OntologyRepository
+	workflowStateRepo repositories.WorkflowStateRepository
+	dsSvc             DatasourceService
+	adapterFactory    datasource.DatasourceAdapterFactory
+	builder           OntologyBuilderService
+	workflowService   OntologyWorkflowService
+	getTenantCtx      TenantContextFunc
+	projectID         uuid.UUID
+	workflowID        uuid.UUID
+	datasourceID      uuid.UUID
+	description       string
+}
+
+// NewInitializeOntologyTask creates a new initialization task.
+func NewInitializeOntologyTask(
+	schemaRepo repositories.SchemaRepository,
+	ontologyRepo repositories.OntologyRepository,
+	workflowStateRepo repositories.WorkflowStateRepository,
+	dsSvc DatasourceService,
+	adapterFactory datasource.DatasourceAdapterFactory,
+	builder OntologyBuilderService,
+	workflowService OntologyWorkflowService,
+	getTenantCtx TenantContextFunc,
+	projectID uuid.UUID,
+	workflowID uuid.UUID,
+	datasourceID uuid.UUID,
+	description string,
+) *InitializeOntologyTask {
+	return &InitializeOntologyTask{
+		BaseTask:          workqueue.NewBaseTask("Initialize Ontology", false), // Non-LLM task
+		schemaRepo:        schemaRepo,
+		ontologyRepo:      ontologyRepo,
+		workflowStateRepo: workflowStateRepo,
+		dsSvc:             dsSvc,
+		adapterFactory:    adapterFactory,
+		builder:           builder,
+		workflowService:   workflowService,
+		getTenantCtx:      getTenantCtx,
+		projectID:         projectID,
+		workflowID:        workflowID,
+		datasourceID:      datasourceID,
+		description:       description,
+	}
+}
+
+// Execute implements workqueue.Task.
+// This task loads tables from schema, updates workflow progress, and optionally
+// enqueues the project description task. The orchestrator handles scanning/analyzing.
+func (t *InitializeOntologyTask) Execute(ctx context.Context, enqueuer workqueue.TaskEnqueuer) error {
+	tenantCtx, cleanup, err := t.getTenantCtx(ctx, t.projectID)
+	if err != nil {
+		return fmt.Errorf("acquire tenant connection: %w", err)
+	}
+	defer cleanup()
+
+	// Load tables from schema
+	tables, err := t.schemaRepo.ListTablesByDatasource(tenantCtx, t.projectID, t.datasourceID)
+	if err != nil {
+		return fmt.Errorf("load tables: %w", err)
+	}
+	tableCount := len(tables)
+
+	// Load all columns and group by table name
+	allColumns, err := t.schemaRepo.ListColumnsByDatasource(tenantCtx, t.projectID, t.datasourceID)
+	if err != nil {
+		return fmt.Errorf("load columns: %w", err)
+	}
+
+	// Build map of table ID -> column names
+	tableIDToColumns := make(map[string][]string)
+	for _, col := range allColumns {
+		tableIDToColumns[col.SchemaTableID.String()] = append(tableIDToColumns[col.SchemaTableID.String()], col.ColumnName)
+	}
+
+	// Count total columns
+	columnCount := len(allColumns)
+
+	// Scanning phase entities = tables + columns (no global entity)
+	scanningEntities := tableCount + columnCount
+
+	// Update progress for Scanning phase
+	_ = t.workflowService.UpdateProgress(tenantCtx, t.workflowID, &models.WorkflowProgress{
+		CurrentPhase: models.WorkflowPhaseScanning,
+		Message:      fmt.Sprintf("Scanning %d tables, %d columns...", tableCount, columnCount),
+		Current:      0,
+		Total:        scanningEntities,
+	})
+
+	// Enqueue UnderstandProjectDescriptionTask if description provided (LLM task)
+	// This runs before the orchestrator takes over, processing the user's description
+	if t.description != "" {
+		totalEntities := 1 + tableCount + columnCount // For description task progress
+		descTask := NewUnderstandProjectDescriptionTask(
+			t.builder,
+			t.workflowService,
+			t.getTenantCtx,
+			t.projectID,
+			t.workflowID,
+			t.description,
+			totalEntities,
+		)
+		enqueuer.Enqueue(descTask)
+	}
+
+	// NOTE: Task chaining removed in chunk 5.
+	// The orchestrator will detect pending entities and enqueue scan/analyze tasks.
+
+	return nil
+}
+
+// UnderstandProjectDescriptionTask processes the user's project description with LLM.
+// This is an LLM task - only one can run at a time.
+type UnderstandProjectDescriptionTask struct {
+	workqueue.BaseTask
+	builder         OntologyBuilderService
+	workflowService OntologyWorkflowService
+	getTenantCtx    TenantContextFunc
+	projectID       uuid.UUID
+	workflowID      uuid.UUID
+	description     string
+	tableCount      int
+}
+
+// NewUnderstandProjectDescriptionTask creates a new description processing task.
+func NewUnderstandProjectDescriptionTask(
+	builder OntologyBuilderService,
+	workflowService OntologyWorkflowService,
+	getTenantCtx TenantContextFunc,
+	projectID uuid.UUID,
+	workflowID uuid.UUID,
+	description string,
+	tableCount int,
+) *UnderstandProjectDescriptionTask {
+	return &UnderstandProjectDescriptionTask{
+		BaseTask:        workqueue.NewBaseTask("Understand Project Description", true), // LLM task
+		builder:         builder,
+		workflowService: workflowService,
+		getTenantCtx:    getTenantCtx,
+		projectID:       projectID,
+		workflowID:      workflowID,
+		description:     description,
+		tableCount:      tableCount,
+	}
+}
+
+// Execute implements workqueue.Task.
+func (t *UnderstandProjectDescriptionTask) Execute(ctx context.Context, enqueuer workqueue.TaskEnqueuer) error {
+	tenantCtx, cleanup, err := t.getTenantCtx(ctx, t.projectID)
+	if err != nil {
+		return fmt.Errorf("acquire tenant connection: %w", err)
+	}
+	defer cleanup()
+
+	// Update progress
+	_ = t.workflowService.UpdateProgress(tenantCtx, t.workflowID, &models.WorkflowProgress{
+		CurrentPhase: models.WorkflowPhaseDescriptionProcessing,
+		Message:      "Analyzing your project description...",
+		Current:      0,
+		Total:        t.tableCount,
+	})
+
+	// Process description with LLM
+	_, err = t.builder.ProcessProjectDescription(tenantCtx, t.projectID, t.workflowID, t.description)
+	if err != nil {
+		// Non-fatal - continue without description context
+		// ProcessProjectDescription stores results in metadata even on partial failure
+	}
+
+	// Update progress - transition to scanning phase
+	_ = t.workflowService.UpdateProgress(tenantCtx, t.workflowID, &models.WorkflowProgress{
+		CurrentPhase: models.WorkflowPhaseScanning,
+		Message:      "Scanning database tables...",
+		Current:      0,
+		Total:        t.tableCount,
+	})
+
+	return nil
+}
+
+// NOTE: UpdateEntityDataTask was removed in chunk 5.
+// The orchestrator now enqueues UnderstandEntityTask directly when it sees scanned entities.
+
+// UnderstandEntityTask uses LLM to analyze an entity and generate clarifying questions.
+// This is an LLM task - only one can run at a time.
+// Questions are written to the engine_ontology_questions table (decoupled from workflow lifecycle).
+// Entities are always marked complete after analysis, regardless of whether questions exist.
+type UnderstandEntityTask struct {
+	workqueue.BaseTask
+	ontologyRepo      repositories.OntologyRepository
+	questionRepo      repositories.OntologyQuestionRepository
+	workflowStateRepo repositories.WorkflowStateRepository
+	builder           OntologyBuilderService
+	workflowService   OntologyWorkflowService
+	getTenantCtx      TenantContextFunc
+	projectID         uuid.UUID
+	workflowID        uuid.UUID
+	ontologyID        uuid.UUID
+	tableName         string
+	schemaName        string
+	columnNames       []string // Column names for this table
+}
+
+// NewUnderstandEntityTask creates a new entity analysis task.
+func NewUnderstandEntityTask(
+	ontologyRepo repositories.OntologyRepository,
+	questionRepo repositories.OntologyQuestionRepository,
+	workflowStateRepo repositories.WorkflowStateRepository,
+	builder OntologyBuilderService,
+	workflowService OntologyWorkflowService,
+	getTenantCtx TenantContextFunc,
+	projectID uuid.UUID,
+	workflowID uuid.UUID,
+	ontologyID uuid.UUID,
+	tableName string,
+	schemaName string,
+	columnNames []string,
+) *UnderstandEntityTask {
+	displayName := tableName
+	if schemaName != "" && schemaName != "public" {
+		displayName = schemaName + "." + tableName
+	}
+	return &UnderstandEntityTask{
+		BaseTask:          workqueue.NewBaseTask(fmt.Sprintf("Analyze %s", displayName), true), // LLM task
+		ontologyRepo:      ontologyRepo,
+		questionRepo:      questionRepo,
+		workflowStateRepo: workflowStateRepo,
+		builder:           builder,
+		workflowService:   workflowService,
+		getTenantCtx:      getTenantCtx,
+		projectID:         projectID,
+		workflowID:        workflowID,
+		ontologyID:        ontologyID,
+		tableName:         tableName,
+		schemaName:        schemaName,
+		columnNames:       columnNames,
+	}
+}
+
+// Execute implements workqueue.Task.
+// Analyzes the entity with LLM, writes questions to the questions table, and marks entity as complete.
+// Questions are decoupled from workflow - the entity is always marked complete after analysis.
+func (t *UnderstandEntityTask) Execute(ctx context.Context, enqueuer workqueue.TaskEnqueuer) error {
+	tenantCtx, cleanup, err := t.getTenantCtx(ctx, t.projectID)
+	if err != nil {
+		return fmt.Errorf("acquire tenant connection: %w", err)
+	}
+	defer cleanup()
+
+	// Update table workflow state status to analyzing
+	tableWS, err := t.workflowStateRepo.GetByEntity(tenantCtx, t.workflowID, models.WorkflowEntityTypeTable, t.tableName)
+	if err != nil {
+		return fmt.Errorf("get table workflow state: %w", err)
+	}
+	if tableWS == nil {
+		return fmt.Errorf("table workflow state not found: %s", t.tableName)
+	}
+	if err := t.workflowStateRepo.UpdateStatus(tenantCtx, tableWS.ID, models.WorkflowEntityStatusAnalyzing, nil); err != nil {
+		return fmt.Errorf("update table workflow state status to analyzing: %w", err)
+	}
+
+	// Analyze entity with LLM - may generate clarifying questions
+	questions, err := t.builder.AnalyzeEntity(tenantCtx, t.projectID, t.workflowID, t.tableName)
+	if err != nil {
+		return fmt.Errorf("analyze entity: %w", err)
+	}
+
+	// Write questions to the dedicated questions table (decoupled from workflow lifecycle)
+	if len(questions) > 0 {
+		// Populate project and ontology IDs for each question
+		for _, q := range questions {
+			q.ProjectID = t.projectID
+			q.OntologyID = t.ontologyID
+		}
+		if err := t.questionRepo.CreateBatch(tenantCtx, questions); err != nil {
+			return fmt.Errorf("create questions: %w", err)
+		}
+	}
+
+	// Collect question IDs for audit trail
+	questionIDs := make([]string, len(questions))
+	hasRequiredQuestions := false
+	for i, q := range questions {
+		questionIDs[i] = q.ID.String()
+		if q.IsRequired {
+			hasRequiredQuestions = true
+		}
+	}
+
+	// Refresh table workflow state to get latest version
+	tableWS, err = t.workflowStateRepo.GetByEntity(tenantCtx, t.workflowID, models.WorkflowEntityTypeTable, t.tableName)
+	if err != nil {
+		return fmt.Errorf("refresh table workflow state: %w", err)
+	}
+	if tableWS == nil {
+		return fmt.Errorf("table workflow state not found after refresh: %s", t.tableName)
+	}
+
+	// Always mark entity as complete - questions are handled separately
+	tableWS.Status = models.WorkflowEntityStatusComplete
+	if tableWS.StateData == nil {
+		tableWS.StateData = &models.WorkflowStateData{}
+	}
+	tableWS.StateData.LLMAnalysis = map[string]any{
+		"question_ids":           questionIDs,
+		"question_count":         len(questions),
+		"has_required_questions": hasRequiredQuestions,
+		"analyzed_at":            time.Now(),
+	}
+	if err := t.workflowStateRepo.Update(tenantCtx, tableWS); err != nil {
+		return fmt.Errorf("update table workflow state with LLM analysis: %w", err)
+	}
+
+	// Mark all columns as complete (entity is always complete now)
+	for _, colName := range t.columnNames {
+		colEntityKey := models.ColumnEntityKey(t.tableName, colName)
+		colWS, err := t.workflowStateRepo.GetByEntity(tenantCtx, t.workflowID, models.WorkflowEntityTypeColumn, colEntityKey)
+		if err != nil {
+			return fmt.Errorf("get column workflow state for %s: %w", colName, err)
+		}
+		if colWS == nil {
+			return fmt.Errorf("column workflow state not found: %s", colEntityKey)
+		}
+		if err := t.workflowStateRepo.UpdateStatus(tenantCtx, colWS.ID, models.WorkflowEntityStatusComplete, nil); err != nil {
+			return fmt.Errorf("update column workflow state status for %s: %w", colName, err)
+		}
+	}
+
+	return nil
+}
+
+// ScanTableDataTask scans all columns in a table to collect statistics.
+// This is a non-LLM data task that runs during the Scanning phase.
+// It collects row counts, distinct values, null percentages, and enum candidates.
+type ScanTableDataTask struct {
+	workqueue.BaseTask
+	ontologyRepo      repositories.OntologyRepository
+	workflowStateRepo repositories.WorkflowStateRepository
+	dsSvc             DatasourceService
+	adapterFactory    datasource.DatasourceAdapterFactory
+	getTenantCtx      TenantContextFunc
+	projectID         uuid.UUID
+	workflowID        uuid.UUID
+	datasourceID      uuid.UUID
+	tableName         string
+	schemaName        string
+	columnNames       []string
+}
+
+// NewScanTableDataTask creates a new scan task for a table.
+func NewScanTableDataTask(
+	ontologyRepo repositories.OntologyRepository,
+	workflowStateRepo repositories.WorkflowStateRepository,
+	dsSvc DatasourceService,
+	adapterFactory datasource.DatasourceAdapterFactory,
+	getTenantCtx TenantContextFunc,
+	projectID uuid.UUID,
+	workflowID uuid.UUID,
+	datasourceID uuid.UUID,
+	tableName string,
+	schemaName string,
+	columnNames []string,
+) *ScanTableDataTask {
+	displayName := tableName
+	if schemaName != "" && schemaName != "public" {
+		displayName = schemaName + "." + tableName
+	}
+	return &ScanTableDataTask{
+		BaseTask:          workqueue.NewBaseTask(fmt.Sprintf("Scan %s", displayName), false), // Non-LLM task
+		ontologyRepo:      ontologyRepo,
+		workflowStateRepo: workflowStateRepo,
+		dsSvc:             dsSvc,
+		adapterFactory:    adapterFactory,
+		getTenantCtx:      getTenantCtx,
+		projectID:         projectID,
+		workflowID:        workflowID,
+		datasourceID:      datasourceID,
+		tableName:         tableName,
+		schemaName:        schemaName,
+		columnNames:       columnNames,
+	}
+}
+
+// Execute implements workqueue.Task.
+// Scans all columns in the table and updates their scan data in workflow state.
+func (t *ScanTableDataTask) Execute(ctx context.Context, enqueuer workqueue.TaskEnqueuer) error {
+	tenantCtx, cleanup, err := t.getTenantCtx(ctx, t.projectID)
+	if err != nil {
+		return fmt.Errorf("acquire tenant connection: %w", err)
+	}
+	defer cleanup()
+
+	// Update table workflow state status to scanning (pending -> scanning transition)
+	tableWS, err := t.workflowStateRepo.GetByEntity(tenantCtx, t.workflowID, models.WorkflowEntityTypeTable, t.tableName)
+	if err != nil {
+		return fmt.Errorf("get table workflow state: %w", err)
+	}
+	if tableWS == nil {
+		return fmt.Errorf("table workflow state not found: %s", t.tableName)
+	}
+	if err := t.workflowStateRepo.UpdateStatus(tenantCtx, tableWS.ID, models.WorkflowEntityStatusScanning, nil); err != nil {
+		return fmt.Errorf("update table workflow state status to scanning: %w", err)
+	}
+
+	// Get datasource with decrypted config
+	ds, err := t.dsSvc.Get(tenantCtx, t.projectID, t.datasourceID)
+	if err != nil {
+		return fmt.Errorf("get datasource: %w", err)
+	}
+
+	// Create schema discoverer
+	discoverer, err := t.adapterFactory.NewSchemaDiscoverer(ctx, ds.DatasourceType, ds.Config)
+	if err != nil {
+		return fmt.Errorf("create schema discoverer: %w", err)
+	}
+	defer discoverer.Close()
+
+	// Get column statistics
+	stats, err := discoverer.AnalyzeColumnStats(ctx, t.schemaName, t.tableName, t.columnNames)
+	if err != nil {
+		return fmt.Errorf("analyze column stats: %w", err)
+	}
+
+	// Build map for quick lookup
+	statsMap := make(map[string]datasource.ColumnStats)
+	for _, s := range stats {
+		statsMap[s.ColumnName] = s
+	}
+
+	// Scan each column and update workflow state with gathered data
+	for _, colName := range t.columnNames {
+		colStats := statsMap[colName]
+
+		// Get sample values (up to 50)
+		sampleValues, err := discoverer.GetDistinctValues(ctx, t.schemaName, t.tableName, colName, 50)
+		if err != nil {
+			// Log but continue - some columns may not be scannable (e.g., binary types)
+			sampleValues = nil
+		}
+
+		// Calculate null percentage
+		nullPercent := 0.0
+		if colStats.RowCount > 0 {
+			nullPercent = float64(colStats.RowCount-colStats.NonNullCount) / float64(colStats.RowCount) * 100
+		}
+
+		// Determine if column is an enum candidate
+		// Heuristic: distinct_count <= 50 AND distinct_count < row_count * 0.1
+		isEnumCandidate := false
+		if colStats.DistinctCount > 0 && colStats.DistinctCount <= 50 && colStats.RowCount > 0 {
+			if float64(colStats.DistinctCount) < float64(colStats.RowCount)*0.1 {
+				isEnumCandidate = true
+			}
+		}
+
+		// Compute value fingerprint for change detection
+		fingerprint := ""
+		if len(sampleValues) > 0 {
+			sorted := make([]string, len(sampleValues))
+			copy(sorted, sampleValues)
+			sort.Strings(sorted)
+			hash := sha256.Sum256([]byte(fmt.Sprintf("%v", sorted)))
+			fingerprint = fmt.Sprintf("%x", hash[:8]) // Use first 8 bytes
+		}
+
+		scannedAt := time.Now()
+
+		// Update column workflow state with gathered data
+		colEntityKey := models.ColumnEntityKey(t.tableName, colName)
+		ws, err := t.workflowStateRepo.GetByEntity(tenantCtx, t.workflowID, models.WorkflowEntityTypeColumn, colEntityKey)
+		if err != nil {
+			return fmt.Errorf("get column workflow state: %w", err)
+		}
+		if ws == nil {
+			return fmt.Errorf("column workflow state not found: %s", colEntityKey)
+		}
+
+		ws.Status = models.WorkflowEntityStatusScanned
+		ws.StateData = &models.WorkflowStateData{
+			Gathered: map[string]any{
+				"row_count":         colStats.RowCount,
+				"non_null_count":    colStats.NonNullCount,
+				"distinct_count":    colStats.DistinctCount,
+				"null_percent":      nullPercent,
+				"sample_values":     sampleValues,
+				"is_enum_candidate": isEnumCandidate,
+				"value_fingerprint": fingerprint,
+				"scanned_at":        scannedAt,
+			},
+		}
+		if err := t.workflowStateRepo.Update(tenantCtx, ws); err != nil {
+			return fmt.Errorf("update column workflow state: %w", err)
+		}
+	}
+
+	// Update table workflow state status to scanned
+	if err := t.workflowStateRepo.UpdateStatus(tenantCtx, tableWS.ID, models.WorkflowEntityStatusScanned, nil); err != nil {
+		return fmt.Errorf("update table workflow state status to scanned: %w", err)
+	}
+
+	return nil
+}
+
+// NOTE: TransitionToAnalyzingTask was removed in chunk 5.
+// The orchestrator handles phase transitions and task enqueueing directly.

--- a/pkg/services/ontology_workflow.go
+++ b/pkg/services/ontology_workflow.go
@@ -1,0 +1,919 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/adapters/datasource"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
+	"github.com/ekaya-inc/ekaya-engine/pkg/services/workqueue"
+)
+
+// OntologyWorkflowService provides operations for ontology workflow management.
+type OntologyWorkflowService interface {
+	// StartExtraction initiates a new ontology extraction workflow.
+	StartExtraction(ctx context.Context, projectID uuid.UUID, config *models.WorkflowConfig) (*models.OntologyWorkflow, error)
+
+	// GetStatus returns the current workflow status for a project.
+	GetStatus(ctx context.Context, projectID uuid.UUID) (*models.OntologyWorkflow, error)
+
+	// GetByID returns a specific workflow by its ID.
+	GetByID(ctx context.Context, workflowID uuid.UUID) (*models.OntologyWorkflow, error)
+
+	// GetOntology returns the active tiered ontology for a project.
+	GetOntology(ctx context.Context, projectID uuid.UUID) (*models.TieredOntology, error)
+
+	// Cancel cancels a running workflow.
+	Cancel(ctx context.Context, workflowID uuid.UUID) error
+
+	// DeleteOntology deletes all ontology data for a project (workflows, ontologies, questions).
+	DeleteOntology(ctx context.Context, projectID uuid.UUID) error
+
+	// UpdateProgress updates the workflow progress.
+	UpdateProgress(ctx context.Context, workflowID uuid.UUID, progress *models.WorkflowProgress) error
+
+	// MarkComplete marks a workflow as completed.
+	MarkComplete(ctx context.Context, workflowID uuid.UUID) error
+
+	// MarkFailed marks a workflow as failed with an error message.
+	MarkFailed(ctx context.Context, workflowID uuid.UUID, errMsg string) error
+
+	// Shutdown gracefully stops all active workflows owned by this server.
+	// Called during server shutdown to release ownership so new servers can take over.
+	Shutdown(ctx context.Context) error
+
+	// GetSchemaEntityCount returns the total number of entities (1 global + tables + columns)
+	// that would be processed by an ontology extraction workflow.
+	GetSchemaEntityCount(ctx context.Context, projectID uuid.UUID) (int, error)
+}
+
+// taskQueueUpdate holds data for a task queue database update.
+type taskQueueUpdate struct {
+	projectID  uuid.UUID
+	workflowID uuid.UUID
+	tasks      []models.WorkflowTask
+}
+
+// taskQueueWriter manages serialized writes for a single workflow.
+type taskQueueWriter struct {
+	updates chan taskQueueUpdate
+	done    chan struct{}
+}
+
+// heartbeatInfo holds info needed for heartbeat goroutine
+type heartbeatInfo struct {
+	projectID uuid.UUID
+	stop      chan struct{}
+}
+
+type ontologyWorkflowService struct {
+	workflowRepo   repositories.OntologyWorkflowRepository
+	ontologyRepo   repositories.OntologyRepository
+	schemaRepo     repositories.SchemaRepository
+	stateRepo      repositories.WorkflowStateRepository
+	questionRepo   repositories.OntologyQuestionRepository
+	dsSvc          DatasourceService
+	adapterFactory datasource.DatasourceAdapterFactory
+	builder        OntologyBuilderService
+	getTenantCtx   TenantContextFunc
+	logger         *zap.Logger
+
+	// activeQueues maps workflowID -> *workqueue.Queue for cancellation support
+	activeQueues sync.Map
+	// taskQueueWriters maps workflowID -> *taskQueueWriter for serialized DB writes
+	taskQueueWriters sync.Map
+
+	// Ownership fields for multi-server robustness
+	serverInstanceID uuid.UUID // Unique ID for this server instance
+	heartbeatStop    sync.Map  // workflowID -> *heartbeatInfo
+}
+
+// NewOntologyWorkflowService creates a new ontology workflow service.
+func NewOntologyWorkflowService(
+	workflowRepo repositories.OntologyWorkflowRepository,
+	ontologyRepo repositories.OntologyRepository,
+	schemaRepo repositories.SchemaRepository,
+	stateRepo repositories.WorkflowStateRepository,
+	questionRepo repositories.OntologyQuestionRepository,
+	dsSvc DatasourceService,
+	adapterFactory datasource.DatasourceAdapterFactory,
+	builder OntologyBuilderService,
+	getTenantCtx TenantContextFunc,
+	logger *zap.Logger,
+) OntologyWorkflowService {
+	serverID := uuid.New()
+	namedLogger := logger.Named("ontology-workflow")
+	namedLogger.Info("Workflow service initialized", zap.String("server_instance_id", serverID.String()))
+
+	return &ontologyWorkflowService{
+		workflowRepo:     workflowRepo,
+		ontologyRepo:     ontologyRepo,
+		schemaRepo:       schemaRepo,
+		stateRepo:        stateRepo,
+		questionRepo:     questionRepo,
+		dsSvc:            dsSvc,
+		adapterFactory:   adapterFactory,
+		builder:          builder,
+		getTenantCtx:     getTenantCtx,
+		logger:           namedLogger,
+		serverInstanceID: serverID,
+	}
+}
+
+var _ OntologyWorkflowService = (*ontologyWorkflowService)(nil)
+
+func (s *ontologyWorkflowService) StartExtraction(ctx context.Context, projectID uuid.UUID, config *models.WorkflowConfig) (*models.OntologyWorkflow, error) {
+	// Set defaults
+	if config == nil {
+		config = models.DefaultWorkflowConfig()
+	}
+
+	// Step 1: Deactivate any existing active ontology
+	if err := s.ontologyRepo.DeactivateAll(ctx, projectID); err != nil {
+		s.logger.Error("Failed to deactivate existing ontologies",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+
+	// Step 2: Create new ontology version
+	nextVersion, err := s.ontologyRepo.GetNextVersion(ctx, projectID)
+	if err != nil {
+		s.logger.Error("Failed to get next ontology version",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+
+	ontology := &models.TieredOntology{
+		ID:              uuid.New(),
+		ProjectID:       projectID,
+		Version:         nextVersion,
+		IsActive:        true,
+		EntitySummaries: make(map[string]*models.EntitySummary),
+		ColumnDetails:   make(map[string][]models.ColumnDetail),
+		Metadata:        make(map[string]any),
+	}
+
+	if err := s.ontologyRepo.Create(ctx, ontology); err != nil {
+		s.logger.Error("Failed to create ontology",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+
+	// Step 3: Check for existing workflow for this ontology
+	// The unique index on ontology_id prevents duplicates at DB level, but we check here for better error messages
+	existing, err := s.workflowRepo.GetByOntology(ctx, ontology.ID)
+	if err != nil {
+		s.logger.Error("Failed to check existing workflow for ontology",
+			zap.String("ontology_id", ontology.ID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+
+	if existing != nil {
+		return nil, fmt.Errorf("workflow already exists for this ontology")
+	}
+
+	// Step 4: Create new workflow linked to the ontology
+	now := time.Now()
+	workflow := &models.OntologyWorkflow{
+		ID:         uuid.New(),
+		ProjectID:  projectID,
+		OntologyID: ontology.ID,
+		State:      models.WorkflowStatePending,
+		Progress: &models.WorkflowProgress{
+			CurrentPhase: models.WorkflowPhaseInitializing,
+			Current:      0,
+			Total:        0, // Will be set by InitializeOntologyTask
+			Message:      "Starting ontology extraction...",
+		},
+		TaskQueue: []models.WorkflowTask{},
+		Config:    config,
+		StartedAt: &now,
+	}
+
+	if err := s.workflowRepo.Create(ctx, workflow); err != nil {
+		s.logger.Error("Failed to create workflow",
+			zap.String("project_id", projectID.String()),
+			zap.String("ontology_id", ontology.ID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+
+	// Step 5: Initialize workflow state for all entities
+	if err := s.initializeWorkflowEntities(ctx, projectID, workflow.ID, ontology.ID, config.DatasourceID); err != nil {
+		s.logger.Error("Failed to initialize workflow entities",
+			zap.String("workflow_id", workflow.ID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+
+	// Claim ownership and transition to running
+	claimed, err := s.workflowRepo.ClaimOwnership(ctx, workflow.ID, s.serverInstanceID)
+	if err != nil {
+		s.logger.Error("Failed to claim workflow ownership",
+			zap.String("workflow_id", workflow.ID.String()),
+			zap.Error(err))
+		return nil, fmt.Errorf("claim ownership: %w", err)
+	}
+	if !claimed {
+		s.logger.Error("Workflow already owned by another server",
+			zap.String("workflow_id", workflow.ID.String()))
+		return nil, fmt.Errorf("workflow already owned by another server")
+	}
+
+	// Transition to running
+	workflow.State = models.WorkflowStateRunning
+	if err := s.workflowRepo.UpdateState(ctx, workflow.ID, models.WorkflowStateRunning, ""); err != nil {
+		s.logger.Error("Failed to start workflow",
+			zap.String("workflow_id", workflow.ID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+
+	// Start heartbeat goroutine to maintain ownership
+	s.startHeartbeat(workflow.ID, projectID)
+
+	s.logger.Info("Ontology extraction started",
+		zap.String("project_id", projectID.String()),
+		zap.String("workflow_id", workflow.ID.String()),
+		zap.String("ontology_id", ontology.ID.String()),
+		zap.String("server_instance_id", s.serverInstanceID.String()),
+		zap.Int("ontology_version", nextVersion))
+
+	// Create work queue and enqueue the initialization task
+	// InitializeOntologyTask will enqueue all other tasks (data tasks, LLM tasks, etc.)
+	// Queue uses ParallelLLMStrategy: LLM tasks run in parallel (no limit),
+	// data tasks serialize with data tasks.
+	// This allows efficient batching of LLM requests to the model provider.
+	queue := workqueue.NewQueueWithStrategy(s.logger, workqueue.NewParallelLLMStrategy())
+	s.activeQueues.Store(workflow.ID, queue)
+
+	// Start single writer goroutine for task queue updates.
+	// This prevents race conditions where multiple goroutines overwrite each other's updates.
+	writer := s.startTaskQueueWriter(workflow.ID)
+
+	// Set up callback to sync task queue to database for UI visibility
+	queue.SetOnUpdate(func(snapshots []workqueue.TaskSnapshot) {
+		// Convert snapshots to models.WorkflowTask with status mapping
+		tasks := make([]models.WorkflowTask, len(snapshots))
+		for i, snap := range snapshots {
+			// Map workqueue status to model status
+			// workqueue: pending, running, completed, failed, cancelled, paused
+			// model/UI:  queued, processing, complete, failed, paused
+			status := string(snap.Status)
+			switch snap.Status {
+			case workqueue.TaskStatusPending:
+				status = models.TaskStatusQueued
+			case workqueue.TaskStatusRunning:
+				status = models.TaskStatusProcessing
+			case workqueue.TaskStatusCompleted:
+				status = models.TaskStatusComplete
+			case workqueue.TaskStatusFailed, workqueue.TaskStatusCancelled:
+				status = models.TaskStatusFailed
+			case workqueue.TaskStatusPaused:
+				status = models.TaskStatusPaused
+			}
+
+			tasks[i] = models.WorkflowTask{
+				ID:          snap.ID,
+				Name:        snap.Name,
+				Status:      status,
+				RequiresLLM: snap.RequiresLLM,
+				Error:       snap.Error,
+			}
+		}
+		// Send to single writer goroutine (non-blocking due to buffered channel)
+		select {
+		case writer.updates <- taskQueueUpdate{
+			projectID:  projectID,
+			workflowID: workflow.ID,
+			tasks:      tasks,
+		}:
+		default:
+			// Buffer full - this shouldn't happen with buffer size 100
+			s.logger.Warn("Task queue update buffer full, dropping update",
+				zap.String("workflow_id", workflow.ID.String()))
+		}
+	})
+
+	initTask := NewInitializeOntologyTask(
+		s.schemaRepo,
+		s.ontologyRepo,
+		s.stateRepo,
+		s.dsSvc,
+		s.adapterFactory,
+		s.builder,
+		s, // OntologyWorkflowService for progress updates
+		s.getTenantCtx,
+		projectID,
+		workflow.ID,
+		config.DatasourceID,
+		config.ProjectDescription,
+	)
+	queue.Enqueue(initTask)
+
+	// Run workflow in background - HTTP request returns immediately
+	go s.runWorkflow(projectID, workflow.ID, queue)
+
+	return workflow, nil
+}
+
+// runWorkflow waits for init task, then runs the orchestrator.
+// Runs in a background goroutine - acquires its own DB connection.
+func (s *ontologyWorkflowService) runWorkflow(projectID, workflowID uuid.UUID, queue *workqueue.Queue) {
+	// Clean up when done
+	defer s.activeQueues.Delete(workflowID)
+	defer s.stopTaskQueueWriter(workflowID) // Stop the writer and flush final state
+	defer s.stopHeartbeat(workflowID)       // Stop heartbeat goroutine
+	defer func() {
+		// Release ownership so other servers can take over if needed
+		ctx, cleanup, err := s.getTenantCtx(context.Background(), projectID)
+		if err != nil {
+			s.logger.Error("Failed to acquire DB connection for ownership release",
+				zap.String("workflow_id", workflowID.String()),
+				zap.Error(err))
+			return
+		}
+		defer cleanup()
+		if releaseErr := s.workflowRepo.ReleaseOwnership(ctx, workflowID); releaseErr != nil {
+			s.logger.Error("Failed to release workflow ownership",
+				zap.String("workflow_id", workflowID.String()),
+				zap.Error(releaseErr))
+		}
+	}()
+
+	// Wait for init task to complete (description processing if any)
+	err := queue.Wait(context.Background())
+	if err != nil {
+		s.logger.Error("Init task failed",
+			zap.String("workflow_id", workflowID.String()),
+			zap.Error(err))
+		s.markWorkflowFailed(projectID, workflowID, err.Error())
+		return
+	}
+
+	// Create orchestrator to drive the workflow
+	orchestrator := NewOrchestrator(
+		s.stateRepo,
+		s.getTenantCtx,
+		s.logger,
+		queue,
+		s.workflowRepo,
+		s.schemaRepo,
+		s.ontologyRepo,
+		s.questionRepo,
+		s.dsSvc,
+		s.adapterFactory,
+		s.builder,
+		s, // OntologyWorkflowService
+		0, // Use DefaultPollInterval
+	)
+
+	// Run orchestrator loop
+	if err := orchestrator.Run(context.Background(), projectID, workflowID); err != nil {
+		s.logger.Error("Orchestrator failed",
+			zap.String("workflow_id", workflowID.String()),
+			zap.Error(err))
+		s.markWorkflowFailed(projectID, workflowID, err.Error())
+		return
+	}
+
+	// Orchestrator completed - check final state
+	s.finalizeWorkflow(projectID, workflowID)
+}
+
+// markWorkflowFailed updates workflow state to failed.
+func (s *ontologyWorkflowService) markWorkflowFailed(projectID, workflowID uuid.UUID, errMsg string) {
+	ctx, cleanup, dbErr := s.getTenantCtx(context.Background(), projectID)
+	if dbErr != nil {
+		s.logger.Error("Failed to acquire DB connection for workflow failure update",
+			zap.String("workflow_id", workflowID.String()),
+			zap.Error(dbErr))
+		return
+	}
+	defer cleanup()
+
+	if updateErr := s.workflowRepo.UpdateState(ctx, workflowID, models.WorkflowStateFailed, errMsg); updateErr != nil {
+		s.logger.Error("Failed to mark workflow as failed",
+			zap.String("workflow_id", workflowID.String()),
+			zap.Error(updateErr))
+	}
+}
+
+// finalizeWorkflow marks workflow as complete.
+// Questions are now decoupled from workflow lifecycle - workflow completes regardless of pending questions.
+func (s *ontologyWorkflowService) finalizeWorkflow(projectID, workflowID uuid.UUID) {
+	ctx, cleanup, dbErr := s.getTenantCtx(context.Background(), projectID)
+	if dbErr != nil {
+		s.logger.Error("Failed to acquire DB connection for workflow completion",
+			zap.String("workflow_id", workflowID.String()),
+			zap.Error(dbErr))
+		return
+	}
+	defer cleanup()
+
+	// Get current workflow to preserve entity counts from orchestrator
+	workflow, wfErr := s.workflowRepo.GetByID(ctx, workflowID)
+	entityCount := 0
+	if wfErr == nil && workflow != nil && workflow.Progress != nil {
+		entityCount = workflow.Progress.Total
+	}
+	if entityCount == 0 {
+		entityCount = 1 // Fallback to avoid 0/0
+	}
+
+	// Get pending question counts for logging (questions are in separate table now)
+	counts, qErr := s.questionRepo.GetPendingCounts(ctx, projectID)
+	pendingCount := 0
+	if qErr != nil {
+		s.logger.Error("Failed to check pending questions",
+			zap.String("project_id", projectID.String()),
+			zap.Error(qErr))
+	} else if counts != nil {
+		pendingCount = counts.Required + counts.Optional
+	}
+
+	// Always mark workflow as completed - questions are handled independently
+	completionMsg := "Ontology extraction complete"
+	if pendingCount > 0 {
+		completionMsg = fmt.Sprintf("Ontology extraction complete (%d questions pending)", pendingCount)
+	}
+
+	if updateErr := s.workflowRepo.UpdateProgress(ctx, workflowID, &models.WorkflowProgress{
+		CurrentPhase: models.WorkflowPhaseCompleting,
+		Message:      completionMsg,
+		Current:      entityCount,
+		Total:        entityCount,
+	}); updateErr != nil {
+		s.logger.Error("Failed to update final progress",
+			zap.String("workflow_id", workflowID.String()),
+			zap.Error(updateErr))
+	}
+
+	if updateErr := s.workflowRepo.UpdateState(ctx, workflowID, models.WorkflowStateCompleted, ""); updateErr != nil {
+		s.logger.Error("Failed to mark workflow as completed",
+			zap.String("workflow_id", workflowID.String()),
+			zap.Error(updateErr))
+		return
+	}
+
+	s.logger.Info("Workflow completed successfully",
+		zap.String("workflow_id", workflowID.String()),
+		zap.Int("pending_questions", pendingCount),
+		zap.Int("entity_count", entityCount))
+}
+
+func (s *ontologyWorkflowService) GetStatus(ctx context.Context, projectID uuid.UUID) (*models.OntologyWorkflow, error) {
+	workflow, err := s.workflowRepo.GetLatestByProject(ctx, projectID)
+	if err != nil {
+		s.logger.Error("Failed to get workflow status",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+	return workflow, nil
+}
+
+func (s *ontologyWorkflowService) GetByID(ctx context.Context, workflowID uuid.UUID) (*models.OntologyWorkflow, error) {
+	workflow, err := s.workflowRepo.GetByID(ctx, workflowID)
+	if err != nil {
+		s.logger.Error("Failed to get workflow by ID",
+			zap.String("workflow_id", workflowID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+	return workflow, nil
+}
+
+func (s *ontologyWorkflowService) GetOntology(ctx context.Context, projectID uuid.UUID) (*models.TieredOntology, error) {
+	ontology, err := s.ontologyRepo.GetActive(ctx, projectID)
+	if err != nil {
+		s.logger.Error("Failed to get active ontology",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		return nil, err
+	}
+	return ontology, nil
+}
+
+func (s *ontologyWorkflowService) Cancel(ctx context.Context, workflowID uuid.UUID) error {
+	// Cancel active queue if running (signals tasks to stop)
+	if queueVal, ok := s.activeQueues.Load(workflowID); ok {
+		if queue, ok := queueVal.(*workqueue.Queue); ok {
+			queue.Cancel()
+			s.logger.Info("Queue cancelled for workflow",
+				zap.String("workflow_id", workflowID.String()))
+		}
+		s.activeQueues.Delete(workflowID)
+	}
+
+	// Delete workflow record - cascades to questions and LLM conversations
+	if err := s.workflowRepo.Delete(ctx, workflowID); err != nil {
+		s.logger.Error("Failed to delete workflow",
+			zap.String("workflow_id", workflowID.String()),
+			zap.Error(err))
+		return err
+	}
+
+	s.logger.Info("Workflow cancelled and deleted",
+		zap.String("workflow_id", workflowID.String()))
+
+	return nil
+}
+
+func (s *ontologyWorkflowService) DeleteOntology(ctx context.Context, projectID uuid.UUID) error {
+	// Cancel any active workflow first
+	workflow, err := s.workflowRepo.GetLatestByProject(ctx, projectID)
+	if err != nil {
+		// Log but continue - we still want to delete ontologies even if workflow lookup fails
+		s.logger.Error("Failed to get latest workflow for delete",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+	}
+	if workflow != nil && !workflow.State.IsTerminal() {
+		if queueVal, ok := s.activeQueues.Load(workflow.ID); ok {
+			if queue, ok := queueVal.(*workqueue.Queue); ok {
+				queue.Cancel()
+			}
+		}
+		s.activeQueues.Delete(workflow.ID)
+		s.stopTaskQueueWriter(workflow.ID)
+	}
+
+	// Delete all ontologies for project (cascades to workflows, questions, and chat messages via FK)
+	if err := s.ontologyRepo.DeleteByProject(ctx, projectID); err != nil {
+		s.logger.Error("Failed to delete ontologies",
+			zap.String("project_id", projectID.String()),
+			zap.Error(err))
+		return fmt.Errorf("delete ontologies: %w", err)
+	}
+
+	s.logger.Info("Deleted all ontology data for project",
+		zap.String("project_id", projectID.String()))
+
+	return nil
+}
+
+func (s *ontologyWorkflowService) UpdateProgress(ctx context.Context, workflowID uuid.UUID, progress *models.WorkflowProgress) error {
+	if err := s.workflowRepo.UpdateProgress(ctx, workflowID, progress); err != nil {
+		s.logger.Error("Failed to update workflow progress",
+			zap.String("workflow_id", workflowID.String()),
+			zap.Error(err))
+		return err
+	}
+	return nil
+}
+
+func (s *ontologyWorkflowService) MarkComplete(ctx context.Context, workflowID uuid.UUID) error {
+	if err := s.workflowRepo.UpdateState(ctx, workflowID, models.WorkflowStateCompleted, ""); err != nil {
+		s.logger.Error("Failed to complete workflow",
+			zap.String("workflow_id", workflowID.String()),
+			zap.Error(err))
+		return err
+	}
+
+	s.logger.Info("Workflow completed",
+		zap.String("workflow_id", workflowID.String()))
+
+	return nil
+}
+
+func (s *ontologyWorkflowService) MarkFailed(ctx context.Context, workflowID uuid.UUID, errMsg string) error {
+	if err := s.workflowRepo.UpdateState(ctx, workflowID, models.WorkflowStateFailed, errMsg); err != nil {
+		s.logger.Error("Failed to mark workflow as failed",
+			zap.String("workflow_id", workflowID.String()),
+			zap.Error(err))
+		return err
+	}
+
+	s.logger.Error("Workflow failed",
+		zap.String("workflow_id", workflowID.String()),
+		zap.String("error", errMsg))
+
+	return nil
+}
+
+// startTaskQueueWriter creates and starts a single writer goroutine for a workflow.
+// All task queue updates are serialized through this writer to prevent race conditions.
+func (s *ontologyWorkflowService) startTaskQueueWriter(workflowID uuid.UUID) *taskQueueWriter {
+	writer := &taskQueueWriter{
+		updates: make(chan taskQueueUpdate, 100), // Buffer to avoid blocking the workqueue
+		done:    make(chan struct{}),
+	}
+	s.taskQueueWriters.Store(workflowID, writer)
+	go s.runTaskQueueWriter(writer)
+	return writer
+}
+
+// stopTaskQueueWriter closes the channel and waits for the writer to finish.
+func (s *ontologyWorkflowService) stopTaskQueueWriter(workflowID uuid.UUID) {
+	if writerVal, ok := s.taskQueueWriters.LoadAndDelete(workflowID); ok {
+		writer := writerVal.(*taskQueueWriter)
+		close(writer.updates)
+		<-writer.done // Wait for writer to finish
+	}
+}
+
+// runTaskQueueWriter is the single writer goroutine that processes updates.
+// It drains all pending updates and only persists the latest one (debounce).
+func (s *ontologyWorkflowService) runTaskQueueWriter(writer *taskQueueWriter) {
+	defer close(writer.done)
+
+	for {
+		// Wait for at least one update
+		update, ok := <-writer.updates
+		if !ok {
+			return // Channel closed, exit
+		}
+
+		// Drain any additional pending updates, keeping only the latest
+		for {
+			select {
+			case newer, ok := <-writer.updates:
+				if !ok {
+					// Channel closed while draining - persist what we have and exit
+					s.persistTaskQueue(update.projectID, update.workflowID, update.tasks)
+					return
+				}
+				update = newer // Keep the newer update
+			default:
+				// No more pending updates, persist the latest
+				goto persist
+			}
+		}
+
+	persist:
+		s.persistTaskQueue(update.projectID, update.workflowID, update.tasks)
+	}
+}
+
+// persistTaskQueue saves the task queue to the database.
+func (s *ontologyWorkflowService) persistTaskQueue(projectID, workflowID uuid.UUID, tasks []models.WorkflowTask) {
+	// Acquire a fresh DB connection since this runs in a goroutine
+	ctx, cleanup, err := s.getTenantCtx(context.Background(), projectID)
+	if err != nil {
+		s.logger.Error("Failed to acquire DB connection for task queue update",
+			zap.String("workflow_id", workflowID.String()),
+			zap.Error(err))
+		return
+	}
+	defer cleanup()
+
+	if err := s.workflowRepo.UpdateTaskQueue(ctx, workflowID, tasks); err != nil {
+		s.logger.Error("Failed to persist task queue",
+			zap.String("workflow_id", workflowID.String()),
+			zap.Error(err))
+	}
+}
+
+// ============================================================================
+// Workflow Entity State Initialization
+// ============================================================================
+
+// initializeWorkflowEntities creates workflow state rows for all entities.
+// Creates one global entity, one entity per table, and one entity per column.
+// All entities start with status='pending'.
+func (s *ontologyWorkflowService) initializeWorkflowEntities(
+	ctx context.Context,
+	projectID, workflowID, ontologyID, datasourceID uuid.UUID,
+) error {
+	// Get all tables for this datasource
+	tables, err := s.schemaRepo.ListTablesByDatasource(ctx, projectID, datasourceID)
+	if err != nil {
+		return fmt.Errorf("list tables: %w", err)
+	}
+
+	// Get all columns for this datasource
+	columns, err := s.schemaRepo.ListColumnsByDatasource(ctx, projectID, datasourceID)
+	if err != nil {
+		return fmt.Errorf("list columns: %w", err)
+	}
+
+	// Build entity states slice
+	states := make([]*models.WorkflowEntityState, 0, 1+len(tables)+len(columns))
+
+	// 1. Global entity
+	states = append(states, &models.WorkflowEntityState{
+		ProjectID:  projectID,
+		OntologyID: ontologyID,
+		WorkflowID: workflowID,
+		EntityType: models.WorkflowEntityTypeGlobal,
+		EntityKey:  models.GlobalEntityKey(),
+		Status:     models.WorkflowEntityStatusPending,
+		StateData:  &models.WorkflowStateData{},
+	})
+
+	// 2. Table entities
+	tableByID := make(map[uuid.UUID]*models.SchemaTable)
+	for _, table := range tables {
+		tableByID[table.ID] = table
+		states = append(states, &models.WorkflowEntityState{
+			ProjectID:  projectID,
+			OntologyID: ontologyID,
+			WorkflowID: workflowID,
+			EntityType: models.WorkflowEntityTypeTable,
+			EntityKey:  models.TableEntityKey(table.TableName),
+			Status:     models.WorkflowEntityStatusPending,
+			StateData:  &models.WorkflowStateData{},
+		})
+	}
+
+	// 3. Column entities
+	for _, col := range columns {
+		table := tableByID[col.SchemaTableID]
+		if table == nil {
+			continue // Skip orphaned columns
+		}
+		states = append(states, &models.WorkflowEntityState{
+			ProjectID:  projectID,
+			OntologyID: ontologyID,
+			WorkflowID: workflowID,
+			EntityType: models.WorkflowEntityTypeColumn,
+			EntityKey:  models.ColumnEntityKey(table.TableName, col.ColumnName),
+			Status:     models.WorkflowEntityStatusPending,
+			StateData:  &models.WorkflowStateData{},
+		})
+	}
+
+	// Batch create all entities
+	if err := s.stateRepo.CreateBatch(ctx, states); err != nil {
+		return fmt.Errorf("create workflow entities: %w", err)
+	}
+
+	s.logger.Info("Initialized workflow entities",
+		zap.String("workflow_id", workflowID.String()),
+		zap.Int("total_entities", len(states)),
+		zap.Int("tables", len(tables)),
+		zap.Int("columns", len(columns)))
+
+	return nil
+}
+
+// ============================================================================
+// Heartbeat Management
+// ============================================================================
+
+// startHeartbeat launches a background goroutine that periodically updates
+// the workflow's last_heartbeat timestamp to maintain ownership.
+func (s *ontologyWorkflowService) startHeartbeat(workflowID, projectID uuid.UUID) {
+	stop := make(chan struct{})
+	info := &heartbeatInfo{
+		projectID: projectID,
+		stop:      stop,
+	}
+	s.heartbeatStop.Store(workflowID, info)
+
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-stop:
+				s.logger.Debug("Heartbeat stopped",
+					zap.String("workflow_id", workflowID.String()))
+				return
+			case <-ticker.C:
+				ctx, cleanup, err := s.getTenantCtx(context.Background(), projectID)
+				if err != nil {
+					s.logger.Error("Failed to acquire DB connection for heartbeat",
+						zap.String("workflow_id", workflowID.String()),
+						zap.Error(err))
+					continue
+				}
+				if err := s.workflowRepo.UpdateHeartbeat(ctx, workflowID, s.serverInstanceID); err != nil {
+					s.logger.Error("Failed to update heartbeat",
+						zap.String("workflow_id", workflowID.String()),
+						zap.Error(err))
+				}
+				cleanup()
+			}
+		}
+	}()
+
+	s.logger.Debug("Heartbeat started",
+		zap.String("workflow_id", workflowID.String()),
+		zap.String("server_instance_id", s.serverInstanceID.String()))
+}
+
+// stopHeartbeat stops the heartbeat goroutine for a workflow.
+func (s *ontologyWorkflowService) stopHeartbeat(workflowID uuid.UUID) {
+	if infoVal, ok := s.heartbeatStop.LoadAndDelete(workflowID); ok {
+		info := infoVal.(*heartbeatInfo)
+		close(info.stop)
+	}
+}
+
+// ============================================================================
+// Graceful Shutdown
+// ============================================================================
+
+// Shutdown gracefully stops all active workflows owned by this server.
+// Called during server shutdown to release ownership so new servers can take over.
+func (s *ontologyWorkflowService) Shutdown(ctx context.Context) error {
+	s.logger.Info("Shutting down workflow service",
+		zap.String("server_instance_id", s.serverInstanceID.String()))
+
+	var wg sync.WaitGroup
+
+	// Cancel all active queues and release ownership
+	s.activeQueues.Range(func(key, value any) bool {
+		workflowID := key.(uuid.UUID)
+		queue := value.(*workqueue.Queue)
+
+		// Get project ID from heartbeat info if available
+		var projectID uuid.UUID
+		if infoVal, ok := s.heartbeatStop.Load(workflowID); ok {
+			info := infoVal.(*heartbeatInfo)
+			projectID = info.projectID
+		}
+
+		wg.Add(1)
+		go func(wfID uuid.UUID, q *workqueue.Queue, pID uuid.UUID) {
+			defer wg.Done()
+
+			s.logger.Info("Cancelling workflow for shutdown",
+				zap.String("workflow_id", wfID.String()))
+
+			// Cancel the queue (signals tasks to stop)
+			q.Cancel()
+
+			// Stop heartbeat
+			s.stopHeartbeat(wfID)
+
+			// Release ownership if we have a project ID
+			if pID != uuid.Nil {
+				tenantCtx, cleanup, err := s.getTenantCtx(context.Background(), pID)
+				if err == nil {
+					if releaseErr := s.workflowRepo.ReleaseOwnership(tenantCtx, wfID); releaseErr != nil {
+						s.logger.Error("Failed to release ownership during shutdown",
+							zap.String("workflow_id", wfID.String()),
+							zap.Error(releaseErr))
+					}
+					cleanup()
+				}
+			}
+		}(workflowID, queue, projectID)
+
+		return true
+	})
+
+	// Wait for all cancellations with timeout
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		s.logger.Info("All workflows cancelled successfully")
+		return nil
+	case <-ctx.Done():
+		s.logger.Warn("Shutdown timed out, some workflows may not have been cleaned up")
+		return ctx.Err()
+	}
+}
+
+// GetSchemaEntityCount returns the total number of entities (1 global + tables + columns)
+// that would be processed by an ontology extraction workflow.
+func (s *ontologyWorkflowService) GetSchemaEntityCount(ctx context.Context, projectID uuid.UUID) (int, error) {
+	// Get datasources for this project to find the one to count entities from
+	datasources, err := s.dsSvc.List(ctx, projectID)
+	if err != nil {
+		return 0, fmt.Errorf("list datasources: %w", err)
+	}
+
+	if len(datasources) == 0 {
+		return 0, fmt.Errorf("no datasource configured for project")
+	}
+
+	// Use the first datasource. Projects typically have one datasource, or the first
+	// is the primary one used for ontology extraction. A more robust approach would
+	// be to use the project's default_datasource_id, but that requires ProjectService.
+	datasourceID := datasources[0].ID
+
+	// Count tables
+	tables, err := s.schemaRepo.ListTablesByDatasource(ctx, projectID, datasourceID)
+	if err != nil {
+		return 0, fmt.Errorf("list tables: %w", err)
+	}
+
+	// Count columns
+	columns, err := s.schemaRepo.ListColumnsByDatasource(ctx, projectID, datasourceID)
+	if err != nil {
+		return 0, fmt.Errorf("list columns: %w", err)
+	}
+
+	// Total = 1 (global) + tables + columns
+	return 1 + len(tables) + len(columns), nil
+}

--- a/pkg/services/ontology_workflow_state_integration_test.go
+++ b/pkg/services/ontology_workflow_state_integration_test.go
@@ -1,0 +1,356 @@
+//go:build integration
+
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/adapters/datasource"
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
+	"github.com/ekaya-inc/ekaya-engine/pkg/testhelpers"
+)
+
+// workflowStateTestContext holds all dependencies for workflow state integration tests.
+type workflowStateTestContext struct {
+	t               *testing.T
+	engineDB        *testhelpers.EngineDB
+	workflowService OntologyWorkflowService
+	stateRepo       repositories.WorkflowStateRepository
+	schemaRepo      repositories.SchemaRepository
+	workflowRepo    repositories.OntologyWorkflowRepository
+	ontologyRepo    repositories.OntologyRepository
+	projectID       uuid.UUID
+	dsID            uuid.UUID
+	logger          *zap.Logger
+}
+
+// setupWorkflowStateTest creates a test context with real database.
+func setupWorkflowStateTest(t *testing.T) *workflowStateTestContext {
+	t.Helper()
+
+	engineDB := testhelpers.GetEngineDB(t)
+	logger := zap.NewNop()
+
+	// Create repositories
+	workflowRepo := repositories.NewOntologyWorkflowRepository()
+	ontologyRepo := repositories.NewOntologyRepository()
+	schemaRepo := repositories.NewSchemaRepository()
+	stateRepo := repositories.NewWorkflowStateRepository()
+
+	// Create mock dependencies for the service
+	adapterFactory := datasource.NewDatasourceAdapterFactory()
+
+	// Create getTenantCtx function
+	getTenantCtx := func(ctx context.Context, projectID uuid.UUID) (context.Context, func(), error) {
+		scope, err := engineDB.DB.WithTenant(ctx, projectID)
+		if err != nil {
+			return nil, nil, err
+		}
+		tenantCtx := database.SetTenantScope(ctx, scope)
+		return tenantCtx, func() { scope.Close() }, nil
+	}
+
+	// Create a minimal builder service (we won't actually use LLM)
+	builderService := NewOntologyBuilderService(
+		ontologyRepo, schemaRepo, workflowRepo, nil, stateRepo, nil, logger)
+
+	// Create workflow service with all dependencies
+	questionRepo := repositories.NewOntologyQuestionRepository()
+	workflowService := NewOntologyWorkflowService(
+		workflowRepo, ontologyRepo, schemaRepo, stateRepo, questionRepo,
+		nil, adapterFactory, builderService, getTenantCtx, logger)
+
+	// Use unique project ID for test isolation
+	projectID := uuid.MustParse("00000000-0000-0000-0000-000000000201")
+	dsID := uuid.MustParse("00000000-0000-0000-0000-000000000202")
+
+	tc := &workflowStateTestContext{
+		t:               t,
+		engineDB:        engineDB,
+		workflowService: workflowService,
+		stateRepo:       stateRepo,
+		schemaRepo:      schemaRepo,
+		workflowRepo:    workflowRepo,
+		ontologyRepo:    ontologyRepo,
+		projectID:       projectID,
+		dsID:            dsID,
+		logger:          logger,
+	}
+
+	// Ensure project and datasource exist
+	tc.ensureTestProject()
+	tc.ensureTestDatasource()
+
+	return tc
+}
+
+// createTestContext creates a context with tenant scope and returns a cleanup function.
+func (tc *workflowStateTestContext) createTestContext() (context.Context, func()) {
+	tc.t.Helper()
+
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithTenant(ctx, tc.projectID)
+	if err != nil {
+		tc.t.Fatalf("Failed to create tenant scope: %v", err)
+	}
+
+	ctx = database.SetTenantScope(ctx, scope)
+
+	return ctx, func() {
+		scope.Close()
+	}
+}
+
+// ensureTestProject creates the test project if it doesn't exist.
+func (tc *workflowStateTestContext) ensureTestProject() {
+	tc.t.Helper()
+
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("Failed to create scope for project setup: %v", err)
+	}
+	defer scope.Close()
+
+	_, err = scope.Conn.Exec(ctx, `
+		INSERT INTO engine_projects (id, name, status)
+		VALUES ($1, $2, 'active')
+		ON CONFLICT (id) DO NOTHING
+	`, tc.projectID, "Workflow State Test Project")
+	if err != nil {
+		tc.t.Fatalf("Failed to ensure test project: %v", err)
+	}
+}
+
+// ensureTestDatasource creates the test datasource if it doesn't exist.
+func (tc *workflowStateTestContext) ensureTestDatasource() {
+	tc.t.Helper()
+
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithTenant(ctx, tc.projectID)
+	if err != nil {
+		tc.t.Fatalf("Failed to create tenant scope for datasource setup: %v", err)
+	}
+	defer scope.Close()
+
+	_, err = scope.Conn.Exec(ctx, `
+		INSERT INTO engine_datasources (id, project_id, name, datasource_type, datasource_config)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (id) DO NOTHING
+	`, tc.dsID, tc.projectID, "Workflow State Test Datasource", "postgres", "{}")
+	if err != nil {
+		tc.t.Fatalf("Failed to ensure test datasource: %v", err)
+	}
+}
+
+// cleanup removes all test data.
+func (tc *workflowStateTestContext) cleanup() {
+	tc.t.Helper()
+
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithTenant(ctx, tc.projectID)
+	if err != nil {
+		tc.t.Fatalf("Failed to create tenant scope for cleanup: %v", err)
+	}
+	defer scope.Close()
+
+	// Delete in order: workflow_state -> workflows -> ontologies -> schema
+	_, _ = scope.Conn.Exec(ctx, `DELETE FROM engine_workflow_state WHERE project_id = $1`, tc.projectID)
+	_, _ = scope.Conn.Exec(ctx, `DELETE FROM engine_ontology_workflows WHERE project_id = $1`, tc.projectID)
+	_, _ = scope.Conn.Exec(ctx, `DELETE FROM engine_tiered_ontologies WHERE project_id = $1`, tc.projectID)
+	_, _ = scope.Conn.Exec(ctx, `DELETE FROM engine_schema_columns WHERE project_id = $1`, tc.projectID)
+	_, _ = scope.Conn.Exec(ctx, `DELETE FROM engine_schema_tables WHERE project_id = $1`, tc.projectID)
+}
+
+// createTestTable creates a test table and returns it.
+func (tc *workflowStateTestContext) createTestTable(ctx context.Context, schemaName, tableName string) *models.SchemaTable {
+	tc.t.Helper()
+
+	table := &models.SchemaTable{
+		ProjectID:    tc.projectID,
+		DatasourceID: tc.dsID,
+		SchemaName:   schemaName,
+		TableName:    tableName,
+		IsSelected:   true,
+	}
+
+	if err := tc.schemaRepo.UpsertTable(ctx, table); err != nil {
+		tc.t.Fatalf("Failed to create test table: %v", err)
+	}
+
+	return table
+}
+
+// createTestColumn creates a test column and returns it.
+func (tc *workflowStateTestContext) createTestColumn(ctx context.Context, tableID uuid.UUID, columnName, dataType string, ordinal int) *models.SchemaColumn {
+	tc.t.Helper()
+
+	column := &models.SchemaColumn{
+		ProjectID:       tc.projectID,
+		SchemaTableID:   tableID,
+		ColumnName:      columnName,
+		DataType:        dataType,
+		IsNullable:      true,
+		IsPrimaryKey:    columnName == "id",
+		IsSelected:      true,
+		OrdinalPosition: ordinal,
+	}
+
+	if err := tc.schemaRepo.UpsertColumn(ctx, column); err != nil {
+		tc.t.Fatalf("Failed to create test column: %v", err)
+	}
+
+	return column
+}
+
+// ============================================================================
+// Integration Tests
+// ============================================================================
+
+func TestStartExtraction_InitializesWorkflowState_Integration(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+	defer tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create test tables and columns
+	usersTable := tc.createTestTable(ctx, "public", "users")
+	tc.createTestColumn(ctx, usersTable.ID, "id", "uuid", 1)
+	tc.createTestColumn(ctx, usersTable.ID, "email", "text", 2)
+	tc.createTestColumn(ctx, usersTable.ID, "name", "text", 3)
+
+	ordersTable := tc.createTestTable(ctx, "public", "orders")
+	tc.createTestColumn(ctx, ordersTable.ID, "id", "uuid", 1)
+	tc.createTestColumn(ctx, ordersTable.ID, "user_id", "uuid", 2)
+	tc.createTestColumn(ctx, ordersTable.ID, "total", "numeric", 3)
+
+	// Start extraction
+	config := &models.WorkflowConfig{
+		DatasourceID: tc.dsID,
+	}
+
+	workflow, err := tc.workflowService.StartExtraction(ctx, tc.projectID, config)
+	if err != nil {
+		t.Fatalf("StartExtraction failed: %v", err)
+	}
+
+	// Give the background goroutine a moment to start, but we don't need to wait for completion
+	// The entity state should be created synchronously before StartExtraction returns
+
+	// Verify workflow state rows were created
+	states, err := tc.stateRepo.ListByWorkflow(ctx, workflow.ID)
+	if err != nil {
+		t.Fatalf("ListByWorkflow failed: %v", err)
+	}
+
+	// Expected: 1 global + 2 tables + 6 columns = 9 entities
+	expectedCount := 1 + 2 + 6
+	if len(states) != expectedCount {
+		t.Errorf("expected %d workflow entities, got %d", expectedCount, len(states))
+	}
+
+	// Verify all entities have status='pending'
+	for _, state := range states {
+		if state.Status != models.WorkflowEntityStatusPending {
+			t.Errorf("expected status 'pending' for entity %s:%s, got %s",
+				state.EntityType, state.EntityKey, state.Status)
+		}
+	}
+
+	// Verify entity type counts
+	globalCount := 0
+	tableCount := 0
+	columnCount := 0
+	for _, state := range states {
+		switch state.EntityType {
+		case models.WorkflowEntityTypeGlobal:
+			globalCount++
+			if state.EntityKey != "" {
+				t.Errorf("expected empty entity_key for global, got %s", state.EntityKey)
+			}
+		case models.WorkflowEntityTypeTable:
+			tableCount++
+		case models.WorkflowEntityTypeColumn:
+			columnCount++
+		}
+	}
+
+	if globalCount != 1 {
+		t.Errorf("expected 1 global entity, got %d", globalCount)
+	}
+	if tableCount != 2 {
+		t.Errorf("expected 2 table entities, got %d", tableCount)
+	}
+	if columnCount != 6 {
+		t.Errorf("expected 6 column entities, got %d", columnCount)
+	}
+
+	// Verify column entity key format (table.column)
+	columnKeyFound := false
+	for _, state := range states {
+		if state.EntityType == models.WorkflowEntityTypeColumn {
+			if state.EntityKey == "users.email" || state.EntityKey == "orders.total" {
+				columnKeyFound = true
+				break
+			}
+		}
+	}
+	if !columnKeyFound {
+		t.Error("expected to find column entity with key like 'users.email' or 'orders.total'")
+	}
+
+	// Cancel the workflow to clean up background goroutines
+	_ = tc.workflowService.Cancel(ctx, workflow.ID)
+}
+
+func TestStartExtraction_EmptyDatasource_Integration(t *testing.T) {
+	tc := setupWorkflowStateTest(t)
+	tc.cleanup()
+	defer tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Don't create any tables - datasource is empty
+
+	// Start extraction
+	config := &models.WorkflowConfig{
+		DatasourceID: tc.dsID,
+	}
+
+	workflow, err := tc.workflowService.StartExtraction(ctx, tc.projectID, config)
+	if err != nil {
+		t.Fatalf("StartExtraction failed: %v", err)
+	}
+
+	// Verify workflow state rows were created
+	states, err := tc.stateRepo.ListByWorkflow(ctx, workflow.ID)
+	if err != nil {
+		t.Fatalf("ListByWorkflow failed: %v", err)
+	}
+
+	// Expected: 1 global only (no tables, no columns)
+	if len(states) != 1 {
+		t.Errorf("expected 1 workflow entity (global only), got %d", len(states))
+	}
+
+	if len(states) > 0 {
+		if states[0].EntityType != models.WorkflowEntityTypeGlobal {
+			t.Errorf("expected global entity, got %s", states[0].EntityType)
+		}
+		if states[0].Status != models.WorkflowEntityStatusPending {
+			t.Errorf("expected status 'pending', got %s", states[0].Status)
+		}
+	}
+
+	// Cancel the workflow to clean up background goroutines
+	_ = tc.workflowService.Cancel(ctx, workflow.ID)
+}

--- a/pkg/services/relationship_discovery.go
+++ b/pkg/services/relationship_discovery.go
@@ -131,13 +131,13 @@ func (s *relationshipDiscoveryService) DiscoverRelationships(ctx context.Context
 		// Skip empty tables
 		if table.RowCount == nil || *table.RowCount == 0 {
 			results.EmptyTables++
-			results.EmptyTableNames = append(results.EmptyTableNames, table.SchemaName+"."+table.TableName)
+			results.EmptyTableNames = append(results.EmptyTableNames, table.TableName)
 			continue
 		}
 
 		columns, err := s.schemaRepo.ListColumnsByTable(ctx, projectID, table.ID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list columns for %s.%s: %w", table.SchemaName, table.TableName, err)
+			return nil, fmt.Errorf("failed to list columns for %s: %w", table.TableName, err)
 		}
 
 		// Batch analyze column stats
@@ -149,7 +149,7 @@ func (s *relationshipDiscoveryService) DiscoverRelationships(ctx context.Context
 		stats, err := s.analyzeColumnStats(ctx, discoverer, table, columnNames)
 		if err != nil {
 			s.logger.Warn("Failed to analyze column stats, skipping table",
-				zap.String("table", table.SchemaName+"."+table.TableName),
+				zap.String("table", table.TableName),
 				zap.Error(err))
 			continue
 		}
@@ -368,7 +368,7 @@ func (s *relationshipDiscoveryService) DiscoverRelationships(ctx context.Context
 		if table.RowCount != nil && *table.RowCount > 0 {
 			if !tablesWithOutbound[table.ID] && !tablesWithInbound[table.ID] {
 				results.TablesWithoutRelationships++
-				results.OrphanTableNames = append(results.OrphanTableNames, table.SchemaName+"."+table.TableName)
+				results.OrphanTableNames = append(results.OrphanTableNames, table.TableName)
 			}
 		}
 	}

--- a/pkg/services/relationship_discovery_integration_test.go
+++ b/pkg/services/relationship_discovery_integration_test.go
@@ -241,19 +241,19 @@ func TestSchemaService_GetRelationshipsResponse_Integration(t *testing.T) {
 	if relDetail.TargetColumnType != "uuid" {
 		t.Errorf("expected target column type 'uuid', got %q", relDetail.TargetColumnType)
 	}
-	if relDetail.SourceTableName != "public.orders" {
-		t.Errorf("expected source table 'public.orders', got %q", relDetail.SourceTableName)
+	if relDetail.SourceTableName != "orders" {
+		t.Errorf("expected source table 'orders', got %q", relDetail.SourceTableName)
 	}
-	if relDetail.TargetTableName != "public.users" {
-		t.Errorf("expected target table 'public.users', got %q", relDetail.TargetTableName)
+	if relDetail.TargetTableName != "users" {
+		t.Errorf("expected target table 'users', got %q", relDetail.TargetTableName)
 	}
 
 	// Verify empty tables list
 	if len(response.EmptyTables) != 1 {
 		t.Errorf("expected 1 empty table, got %d", len(response.EmptyTables))
 	}
-	if len(response.EmptyTables) > 0 && response.EmptyTables[0] != "public.audit_logs" {
-		t.Errorf("expected empty table 'public.audit_logs', got %q", response.EmptyTables[0])
+	if len(response.EmptyTables) > 0 && response.EmptyTables[0] != "audit_logs" {
+		t.Errorf("expected empty table 'audit_logs', got %q", response.EmptyTables[0])
 	}
 }
 
@@ -301,8 +301,8 @@ func TestSchemaService_GetRelationshipsResponse_OrphanTables_Integration(t *test
 	if len(response.OrphanTables) != 1 {
 		t.Errorf("expected 1 orphan table, got %d", len(response.OrphanTables))
 	}
-	if len(response.OrphanTables) > 0 && response.OrphanTables[0] != "public.settings" {
-		t.Errorf("expected orphan table 'public.settings', got %q", response.OrphanTables[0])
+	if len(response.OrphanTables) > 0 && response.OrphanTables[0] != "settings" {
+		t.Errorf("expected orphan table 'settings', got %q", response.OrphanTables[0])
 	}
 }
 
@@ -540,11 +540,11 @@ func TestSchemaService_ManualRelationship_CRUD_Integration(t *testing.T) {
 	tc.createTestColumn(ctx, ordersTable.ID, "id", "uuid", 1, true)
 	tc.createTestColumn(ctx, ordersTable.ID, "user_id", "uuid", 2, false)
 
-	// Create manual relationship
+	// Create manual relationship (API accepts just table names now)
 	req := &models.AddRelationshipRequest{
-		SourceTableName:  "public.orders",
+		SourceTableName:  "orders",
 		SourceColumnName: "user_id",
-		TargetTableName:  "public.users",
+		TargetTableName:  "users",
 		TargetColumnName: "id",
 	}
 

--- a/pkg/services/users.go
+++ b/pkg/services/users.go
@@ -7,8 +7,6 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
-	"github.com/ekaya-inc/ekaya-engine/pkg/apperrors"
-	"github.com/ekaya-inc/ekaya-engine/pkg/database"
 	"github.com/ekaya-inc/ekaya-engine/pkg/models"
 	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
 )
@@ -53,51 +51,7 @@ func (s *userService) Add(ctx context.Context, projectID, userID uuid.UUID, role
 // Remove removes a user from a project.
 // Returns ErrLastAdmin if attempting to remove the last admin.
 func (s *userService) Remove(ctx context.Context, projectID, userID uuid.UUID) error {
-	scope, ok := database.GetTenantScope(ctx)
-	if !ok {
-		return fmt.Errorf("no tenant scope in context")
-	}
-
-	// Start transaction for atomic check-and-delete
-	tx, err := scope.Conn.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() {
-		if err != nil {
-			_ = tx.Rollback(ctx)
-		}
-	}()
-
-	// Check if user is an admin
-	user, err := s.userRepo.GetByID(ctx, projectID, userID)
-	if err != nil {
-		return err
-	}
-
-	// If user is admin, check if they're the last one
-	if user.Role == models.RoleAdmin {
-		adminCount, err := s.userRepo.CountAdmins(ctx, projectID)
-		if err != nil {
-			return fmt.Errorf("failed to count admins: %w", err)
-		}
-
-		if adminCount <= 1 {
-			return apperrors.ErrLastAdmin
-		}
-	}
-
-	// Remove the user
-	if err = s.userRepo.Remove(ctx, projectID, userID); err != nil {
-		return err
-	}
-
-	// Commit transaction
-	if err = tx.Commit(ctx); err != nil {
-		return fmt.Errorf("failed to commit transaction: %w", err)
-	}
-
-	return nil
+	return s.userRepo.RemoveWithOwnerCheck(ctx, projectID, userID)
 }
 
 // Update updates a user's role in a project.
@@ -107,51 +61,7 @@ func (s *userService) Update(ctx context.Context, projectID, userID uuid.UUID, n
 		return fmt.Errorf("invalid role: %s", newRole)
 	}
 
-	scope, ok := database.GetTenantScope(ctx)
-	if !ok {
-		return fmt.Errorf("no tenant scope in context")
-	}
-
-	// Start transaction for atomic check-and-update
-	tx, err := scope.Conn.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() {
-		if err != nil {
-			_ = tx.Rollback(ctx)
-		}
-	}()
-
-	// Get current user
-	user, err := s.userRepo.GetByID(ctx, projectID, userID)
-	if err != nil {
-		return err
-	}
-
-	// If demoting from admin, check if they're the last one
-	if user.Role == models.RoleAdmin && newRole != models.RoleAdmin {
-		adminCount, err := s.userRepo.CountAdmins(ctx, projectID)
-		if err != nil {
-			return fmt.Errorf("failed to count admins: %w", err)
-		}
-
-		if adminCount <= 1 {
-			return apperrors.ErrLastAdmin
-		}
-	}
-
-	// Update the user's role
-	if err = s.userRepo.Update(ctx, projectID, userID, newRole); err != nil {
-		return err
-	}
-
-	// Commit transaction
-	if err = tx.Commit(ctx); err != nil {
-		return fmt.Errorf("failed to commit transaction: %w", err)
-	}
-
-	return nil
+	return s.userRepo.UpdateRoleWithOwnerCheck(ctx, projectID, userID, newRole)
 }
 
 // GetByProject retrieves all users for a project.

--- a/pkg/services/users_test.go
+++ b/pkg/services/users_test.go
@@ -1,0 +1,303 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/apperrors"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+)
+
+// mockUserRepository is a configurable mock for testing UserService.
+type mockUserRepository struct {
+	user       *models.User
+	users      []*models.User
+	adminCount int
+	addErr     error
+	removeErr  error
+	updateErr  error
+	getErr     error
+	listErr    error
+	countErr   error
+
+	// Capture inputs for verification
+	capturedUser    *models.User
+	capturedRole    string
+	capturedUserID  uuid.UUID
+	capturedProject uuid.UUID
+}
+
+func (m *mockUserRepository) Add(ctx context.Context, user *models.User) error {
+	m.capturedUser = user
+	return m.addErr
+}
+
+func (m *mockUserRepository) Remove(ctx context.Context, projectID, userID uuid.UUID) error {
+	m.capturedProject = projectID
+	m.capturedUserID = userID
+	return m.removeErr
+}
+
+func (m *mockUserRepository) Update(ctx context.Context, projectID, userID uuid.UUID, newRole string) error {
+	m.capturedProject = projectID
+	m.capturedUserID = userID
+	m.capturedRole = newRole
+	return m.updateErr
+}
+
+func (m *mockUserRepository) GetByProject(ctx context.Context, projectID uuid.UUID) ([]*models.User, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return m.users, nil
+}
+
+func (m *mockUserRepository) GetByID(ctx context.Context, projectID, userID uuid.UUID) (*models.User, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	return m.user, nil
+}
+
+func (m *mockUserRepository) CountAdmins(ctx context.Context, projectID uuid.UUID) (int, error) {
+	if m.countErr != nil {
+		return 0, m.countErr
+	}
+	return m.adminCount, nil
+}
+
+func (m *mockUserRepository) RemoveWithOwnerCheck(ctx context.Context, projectID, userID uuid.UUID) error {
+	m.capturedProject = projectID
+	m.capturedUserID = userID
+	return m.removeErr
+}
+
+func (m *mockUserRepository) UpdateRoleWithOwnerCheck(ctx context.Context, projectID, userID uuid.UUID, newRole string) error {
+	m.capturedProject = projectID
+	m.capturedUserID = userID
+	m.capturedRole = newRole
+	return m.updateErr
+}
+
+func newTestUserService(repo *mockUserRepository) UserService {
+	return NewUserService(repo, zap.NewNop())
+}
+
+func TestUserService_Add_Success(t *testing.T) {
+	repo := &mockUserRepository{}
+	service := newTestUserService(repo)
+
+	projectID := uuid.New()
+	userID := uuid.New()
+
+	err := service.Add(context.Background(), projectID, userID, models.RoleAdmin)
+	if err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+
+	if repo.capturedUser == nil {
+		t.Fatal("expected user to be captured")
+	}
+	if repo.capturedUser.ProjectID != projectID {
+		t.Errorf("expected project ID %v, got %v", projectID, repo.capturedUser.ProjectID)
+	}
+	if repo.capturedUser.UserID != userID {
+		t.Errorf("expected user ID %v, got %v", userID, repo.capturedUser.UserID)
+	}
+	if repo.capturedUser.Role != models.RoleAdmin {
+		t.Errorf("expected role admin, got %q", repo.capturedUser.Role)
+	}
+}
+
+func TestUserService_Add_InvalidRole(t *testing.T) {
+	repo := &mockUserRepository{}
+	service := newTestUserService(repo)
+
+	err := service.Add(context.Background(), uuid.New(), uuid.New(), "invalid-role")
+	if err == nil {
+		t.Fatal("expected error for invalid role")
+	}
+	if repo.capturedUser != nil {
+		t.Error("should not have called repository for invalid role")
+	}
+}
+
+func TestUserService_Add_RepoError(t *testing.T) {
+	repo := &mockUserRepository{
+		addErr: errors.New("database error"),
+	}
+	service := newTestUserService(repo)
+
+	err := service.Add(context.Background(), uuid.New(), uuid.New(), models.RoleUser)
+	if err == nil {
+		t.Fatal("expected error from repo")
+	}
+}
+
+func TestUserService_Remove_Success(t *testing.T) {
+	repo := &mockUserRepository{}
+	service := newTestUserService(repo)
+
+	projectID := uuid.New()
+	userID := uuid.New()
+
+	err := service.Remove(context.Background(), projectID, userID)
+	if err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+
+	if repo.capturedProject != projectID {
+		t.Errorf("expected project ID %v, got %v", projectID, repo.capturedProject)
+	}
+	if repo.capturedUserID != userID {
+		t.Errorf("expected user ID %v, got %v", userID, repo.capturedUserID)
+	}
+}
+
+func TestUserService_Remove_LastAdmin(t *testing.T) {
+	repo := &mockUserRepository{
+		removeErr: apperrors.ErrLastAdmin,
+	}
+	service := newTestUserService(repo)
+
+	err := service.Remove(context.Background(), uuid.New(), uuid.New())
+	if err == nil {
+		t.Fatal("expected error when removing last admin")
+	}
+	if !errors.Is(err, apperrors.ErrLastAdmin) {
+		t.Errorf("expected ErrLastAdmin, got: %v", err)
+	}
+}
+
+func TestUserService_Remove_RepoError(t *testing.T) {
+	repo := &mockUserRepository{
+		removeErr: errors.New("database error"),
+	}
+	service := newTestUserService(repo)
+
+	err := service.Remove(context.Background(), uuid.New(), uuid.New())
+	if err == nil {
+		t.Fatal("expected error from repo")
+	}
+}
+
+func TestUserService_Update_Success(t *testing.T) {
+	repo := &mockUserRepository{}
+	service := newTestUserService(repo)
+
+	projectID := uuid.New()
+	userID := uuid.New()
+
+	err := service.Update(context.Background(), projectID, userID, models.RoleData)
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	if repo.capturedProject != projectID {
+		t.Errorf("expected project ID %v, got %v", projectID, repo.capturedProject)
+	}
+	if repo.capturedUserID != userID {
+		t.Errorf("expected user ID %v, got %v", userID, repo.capturedUserID)
+	}
+	if repo.capturedRole != models.RoleData {
+		t.Errorf("expected role data, got %q", repo.capturedRole)
+	}
+}
+
+func TestUserService_Update_InvalidRole(t *testing.T) {
+	repo := &mockUserRepository{}
+	service := newTestUserService(repo)
+
+	err := service.Update(context.Background(), uuid.New(), uuid.New(), "invalid-role")
+	if err == nil {
+		t.Fatal("expected error for invalid role")
+	}
+	if repo.capturedRole != "" {
+		t.Error("should not have called repository for invalid role")
+	}
+}
+
+func TestUserService_Update_LastAdminDemotion(t *testing.T) {
+	repo := &mockUserRepository{
+		updateErr: apperrors.ErrLastAdmin,
+	}
+	service := newTestUserService(repo)
+
+	err := service.Update(context.Background(), uuid.New(), uuid.New(), models.RoleUser)
+	if err == nil {
+		t.Fatal("expected error when demoting last admin")
+	}
+	if !errors.Is(err, apperrors.ErrLastAdmin) {
+		t.Errorf("expected ErrLastAdmin, got: %v", err)
+	}
+}
+
+func TestUserService_Update_RepoError(t *testing.T) {
+	repo := &mockUserRepository{
+		updateErr: errors.New("database error"),
+	}
+	service := newTestUserService(repo)
+
+	err := service.Update(context.Background(), uuid.New(), uuid.New(), models.RoleAdmin)
+	if err == nil {
+		t.Fatal("expected error from repo")
+	}
+}
+
+func TestUserService_GetByProject_Success(t *testing.T) {
+	expectedUsers := []*models.User{
+		{UserID: uuid.New(), Role: models.RoleAdmin},
+		{UserID: uuid.New(), Role: models.RoleUser},
+	}
+	repo := &mockUserRepository{
+		users: expectedUsers,
+	}
+	service := newTestUserService(repo)
+
+	users, err := service.GetByProject(context.Background(), uuid.New())
+	if err != nil {
+		t.Fatalf("GetByProject failed: %v", err)
+	}
+
+	if len(users) != 2 {
+		t.Errorf("expected 2 users, got %d", len(users))
+	}
+}
+
+func TestUserService_GetByProject_Empty(t *testing.T) {
+	repo := &mockUserRepository{
+		users: []*models.User{},
+	}
+	service := newTestUserService(repo)
+
+	users, err := service.GetByProject(context.Background(), uuid.New())
+	if err != nil {
+		t.Fatalf("GetByProject failed: %v", err)
+	}
+
+	if len(users) != 0 {
+		t.Errorf("expected 0 users, got %d", len(users))
+	}
+}
+
+func TestUserService_GetByProject_RepoError(t *testing.T) {
+	repo := &mockUserRepository{
+		listErr: errors.New("database error"),
+	}
+	service := newTestUserService(repo)
+
+	_, err := service.GetByProject(context.Background(), uuid.New())
+	if err == nil {
+		t.Fatal("expected error from repo")
+	}
+}
+
+func TestUserService_Interface(t *testing.T) {
+	repo := &mockUserRepository{}
+	service := newTestUserService(repo)
+	var _ UserService = service
+}

--- a/pkg/services/workflow_orchestrator.go
+++ b/pkg/services/workflow_orchestrator.go
@@ -1,0 +1,518 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/adapters/datasource"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
+	"github.com/ekaya-inc/ekaya-engine/pkg/services/workqueue"
+)
+
+// WorkItems represents tasks that need to be enqueued by the orchestrator.
+type WorkItems struct {
+	ScanTasks    []string // entity keys that need scanning
+	AnalyzeTasks []string // entity keys that need analyzing
+}
+
+// DefaultPollInterval is the default interval for polling entity states.
+const DefaultPollInterval = 2 * time.Second
+
+// Orchestrator coordinates ontology extraction workflows by reading entity states
+// and determining what work needs to be done (scanning, analyzing, etc.).
+type Orchestrator struct {
+	// Core dependencies
+	stateRepo    repositories.WorkflowStateRepository
+	getTenantCtx TenantContextFunc
+	logger       *zap.Logger
+
+	// Queue for enqueuing tasks
+	queue *workqueue.Queue
+
+	// Configuration
+	pollInterval time.Duration
+
+	// Dependencies for task creation
+	workflowRepo   repositories.OntologyWorkflowRepository
+	schemaRepo     repositories.SchemaRepository
+	ontologyRepo   repositories.OntologyRepository
+	questionRepo   repositories.OntologyQuestionRepository
+	dsSvc          DatasourceService
+	adapterFactory datasource.DatasourceAdapterFactory
+	builder        OntologyBuilderService
+	workflowSvc    OntologyWorkflowService
+}
+
+// NewOrchestrator creates a new workflow orchestrator.
+// If pollInterval is 0, DefaultPollInterval is used.
+func NewOrchestrator(
+	stateRepo repositories.WorkflowStateRepository,
+	getTenantCtx TenantContextFunc,
+	logger *zap.Logger,
+	queue *workqueue.Queue,
+	workflowRepo repositories.OntologyWorkflowRepository,
+	schemaRepo repositories.SchemaRepository,
+	ontologyRepo repositories.OntologyRepository,
+	questionRepo repositories.OntologyQuestionRepository,
+	dsSvc DatasourceService,
+	adapterFactory datasource.DatasourceAdapterFactory,
+	builder OntologyBuilderService,
+	workflowSvc OntologyWorkflowService,
+	pollInterval time.Duration,
+) *Orchestrator {
+	if pollInterval == 0 {
+		pollInterval = DefaultPollInterval
+	}
+	return &Orchestrator{
+		stateRepo:      stateRepo,
+		getTenantCtx:   getTenantCtx,
+		logger:         logger.Named("orchestrator"),
+		queue:          queue,
+		pollInterval:   pollInterval,
+		workflowRepo:   workflowRepo,
+		schemaRepo:     schemaRepo,
+		ontologyRepo:   ontologyRepo,
+		questionRepo:   questionRepo,
+		dsSvc:          dsSvc,
+		adapterFactory: adapterFactory,
+		builder:        builder,
+		workflowSvc:    workflowSvc,
+	}
+}
+
+// Run executes the orchestration loop for a workflow.
+// Polls entity states and enqueues tasks until all entities complete.
+func (o *Orchestrator) Run(ctx context.Context, projectID, workflowID uuid.UUID) error {
+	o.logger.Info("Starting orchestrator",
+		zap.String("workflow_id", workflowID.String()))
+
+	for {
+		// Check context cancellation
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("context cancelled: %w", err)
+		}
+
+		// Get tenant context for database access
+		tenantCtx, cleanup, err := o.getTenantCtx(ctx, projectID)
+		if err != nil {
+			return fmt.Errorf("get tenant context: %w", err)
+		}
+
+		// Read current entity states
+		states, err := o.stateRepo.ListByWorkflow(tenantCtx, workflowID)
+		if err != nil {
+			cleanup()
+			return fmt.Errorf("list workflow states: %w", err)
+		}
+
+		// Determine what work is needed (table entities only)
+		items := o.determineWorkFromStates(states)
+
+		// Update progress based on current entity states
+		o.updateProgress(tenantCtx, workflowID, states, items)
+
+		// Release DB connection before potentially waiting
+		cleanup()
+
+		// Check if we should trigger global entity analysis
+		// This happens when all table entities are complete
+		globalTriggered, err := o.maybeEnqueueGlobalTask(ctx, projectID, workflowID, states)
+		if err != nil {
+			return fmt.Errorf("check global entity: %w", err)
+		}
+
+		// If no work for tables and no global task triggered
+		if len(items.ScanTasks) == 0 && len(items.AnalyzeTasks) == 0 && !globalTriggered {
+			if o.isAllComplete(states) {
+				o.logger.Info("Workflow complete - all entities in terminal state",
+					zap.String("workflow_id", workflowID.String()))
+				return o.finalizeWorkflow(ctx, projectID, workflowID)
+			}
+
+			// No work to do but not all complete (e.g., waiting for input or in-progress)
+			o.logger.Debug("No work to enqueue - waiting for in-progress tasks or user input",
+				zap.String("workflow_id", workflowID.String()))
+			time.Sleep(o.pollInterval)
+			continue
+		}
+
+		// Enqueue tasks for pending/scanned entities
+		if len(items.ScanTasks) > 0 || len(items.AnalyzeTasks) > 0 {
+			o.logger.Info("Enqueuing tasks",
+				zap.String("workflow_id", workflowID.String()),
+				zap.Int("scan_tasks", len(items.ScanTasks)),
+				zap.Int("analyze_tasks", len(items.AnalyzeTasks)))
+
+			if err := o.enqueueTasks(ctx, projectID, workflowID, items); err != nil {
+				return fmt.Errorf("enqueue tasks: %w", err)
+			}
+		}
+
+		// Wait for enqueued tasks to complete before next iteration
+		waitErr := o.queue.Wait(ctx)
+
+		// Update progress AFTER tasks complete (critical for accurate progress reporting)
+		tenantCtx2, cleanup2, err := o.getTenantCtx(ctx, projectID)
+		if err != nil {
+			return fmt.Errorf("get tenant context for progress update: %w", err)
+		}
+		updatedStates, err := o.stateRepo.ListByWorkflow(tenantCtx2, workflowID)
+		if err != nil {
+			cleanup2()
+			return fmt.Errorf("list workflow states for progress update: %w", err)
+		}
+		updatedItems := o.determineWorkFromStates(updatedStates)
+		o.updateProgress(tenantCtx2, workflowID, updatedStates, updatedItems)
+		cleanup2()
+
+		// Handle wait errors gracefully - don't fail the entire workflow for individual task failures
+		if waitErr != nil {
+			// Context cancellation is fatal
+			if ctx.Err() != nil {
+				return fmt.Errorf("context cancelled during wait: %w", waitErr)
+			}
+
+			// Log the task failure but continue processing
+			// The failed task's entity will be in "failed" state, and the workflow can still complete
+			// with partial results (other entities may succeed)
+			o.logger.Warn("Task failed during execution - continuing with remaining tasks",
+				zap.String("workflow_id", workflowID.String()),
+				zap.Error(waitErr))
+
+			// Continue the loop - the failed entity is now in terminal state (failed)
+			// and won't be retried. Other entities can still complete.
+		}
+	}
+}
+
+// determineWorkFromStates examines entity states and determines what work is needed.
+// Only considers TABLE entities - global and column entities are handled separately.
+func (o *Orchestrator) determineWorkFromStates(states []*models.WorkflowEntityState) *WorkItems {
+	items := &WorkItems{
+		ScanTasks:    make([]string, 0),
+		AnalyzeTasks: make([]string, 0),
+	}
+
+	for _, state := range states {
+		// Only process table entities - global and column entities are handled separately
+		if state.EntityType != models.WorkflowEntityTypeTable {
+			continue
+		}
+
+		switch state.Status {
+		case models.WorkflowEntityStatusPending:
+			// Pending table entities need to start scanning
+			items.ScanTasks = append(items.ScanTasks, state.EntityKey)
+
+		case models.WorkflowEntityStatusScanned:
+			// Scanned table entities need to start analyzing
+			items.AnalyzeTasks = append(items.AnalyzeTasks, state.EntityKey)
+
+		case models.WorkflowEntityStatusScanning,
+			models.WorkflowEntityStatusAnalyzing,
+			models.WorkflowEntityStatusNeedsInput,
+			models.WorkflowEntityStatusComplete,
+			models.WorkflowEntityStatusFailed:
+			// No action needed for these states
+		}
+	}
+
+	return items
+}
+
+// isAllComplete returns true if all entities are in terminal state.
+func (o *Orchestrator) isAllComplete(states []*models.WorkflowEntityState) bool {
+	for _, state := range states {
+		if !state.Status.IsTerminal() {
+			return false
+		}
+	}
+	return true
+}
+
+// allTablesComplete returns true if all table entities are complete.
+func (o *Orchestrator) allTablesComplete(states []*models.WorkflowEntityState) bool {
+	for _, state := range states {
+		if state.EntityType != models.WorkflowEntityTypeTable {
+			continue
+		}
+		if state.Status != models.WorkflowEntityStatusComplete {
+			return false
+		}
+	}
+	return true
+}
+
+// maybeEnqueueGlobalTask checks if all table entities are complete and
+// triggers the global entity analysis (BuildTieredOntologyTask) if so.
+// Returns true if a global task was enqueued.
+func (o *Orchestrator) maybeEnqueueGlobalTask(ctx context.Context, projectID, workflowID uuid.UUID, states []*models.WorkflowEntityState) (bool, error) {
+	// Find the global entity
+	var globalState *models.WorkflowEntityState
+	for _, state := range states {
+		if state.EntityType == models.WorkflowEntityTypeGlobal {
+			globalState = state
+			break
+		}
+	}
+
+	// If no global entity or already processing/complete, nothing to do
+	if globalState == nil {
+		return false, nil
+	}
+	if globalState.Status != models.WorkflowEntityStatusPending {
+		return false, nil
+	}
+
+	// Check if all table entities are complete
+	if !o.allTablesComplete(states) {
+		return false, nil
+	}
+
+	o.logger.Info("All table entities complete - triggering global analysis",
+		zap.String("workflow_id", workflowID.String()))
+
+	// Transition global entity: pending -> scanned -> analyzing
+	tenantCtx, cleanup, err := o.getTenantCtx(ctx, projectID)
+	if err != nil {
+		return false, fmt.Errorf("get tenant context: %w", err)
+	}
+	defer cleanup()
+
+	// Update to scanned (skip scanning phase - no data to scan for global)
+	if err := o.stateRepo.UpdateStatus(tenantCtx, globalState.ID, models.WorkflowEntityStatusScanned, nil); err != nil {
+		return false, fmt.Errorf("update global entity to scanned: %w", err)
+	}
+
+	// Update to analyzing
+	if err := o.stateRepo.UpdateStatus(tenantCtx, globalState.ID, models.WorkflowEntityStatusAnalyzing, nil); err != nil {
+		return false, fmt.Errorf("update global entity to analyzing: %w", err)
+	}
+
+	// Enqueue BuildTieredOntologyTask
+	task := NewBuildTieredOntologyTask(
+		o.builder,
+		o.getTenantCtx,
+		projectID,
+		workflowID,
+	)
+	o.queue.Enqueue(task)
+
+	return true, nil
+}
+
+// tableInfo holds cached table info for task creation.
+type tableInfo struct {
+	table       *models.SchemaTable
+	columnNames []string
+}
+
+// enqueueTasks creates and enqueues tasks for entities that need work.
+func (o *Orchestrator) enqueueTasks(ctx context.Context, projectID, workflowID uuid.UUID, items *WorkItems) error {
+	// Get tenant context to load table/column info
+	tenantCtx, cleanup, err := o.getTenantCtx(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("get tenant context: %w", err)
+	}
+	defer cleanup()
+
+	// Get workflow to get datasource ID
+	workflow, err := o.workflowRepo.GetByID(tenantCtx, workflowID)
+	if err != nil {
+		return fmt.Errorf("get workflow: %w", err)
+	}
+	datasourceID := workflow.Config.DatasourceID
+
+	// Load table info cache for all tables we need
+	tableInfoCache, err := o.loadTableInfoCache(tenantCtx, projectID, datasourceID, items)
+	if err != nil {
+		return fmt.Errorf("load table info: %w", err)
+	}
+
+	// Enqueue scan tasks for pending table entities
+	for _, entityKey := range items.ScanTasks {
+		info, ok := tableInfoCache[entityKey]
+		if !ok {
+			return fmt.Errorf("table not found in cache: %s", entityKey)
+		}
+		task := NewScanTableDataTask(
+			o.ontologyRepo,
+			o.stateRepo,
+			o.dsSvc,
+			o.adapterFactory,
+			o.getTenantCtx,
+			projectID,
+			workflowID,
+			datasourceID,
+			info.table.TableName,
+			info.table.SchemaName,
+			info.columnNames,
+		)
+		o.queue.Enqueue(task)
+	}
+
+	// Enqueue analyze tasks for scanned table entities
+	for _, entityKey := range items.AnalyzeTasks {
+		info, ok := tableInfoCache[entityKey]
+		if !ok {
+			return fmt.Errorf("table not found in cache: %s", entityKey)
+		}
+		task := NewUnderstandEntityTask(
+			o.ontologyRepo,
+			o.questionRepo,
+			o.stateRepo,
+			o.builder,
+			o.workflowSvc,
+			o.getTenantCtx,
+			projectID,
+			workflowID,
+			workflow.OntologyID,
+			info.table.TableName,
+			info.table.SchemaName,
+			info.columnNames,
+		)
+		o.queue.Enqueue(task)
+	}
+
+	return nil
+}
+
+// loadTableInfoCache loads table and column info for the tables we need to process.
+func (o *Orchestrator) loadTableInfoCache(ctx context.Context, projectID, datasourceID uuid.UUID, items *WorkItems) (map[string]*tableInfo, error) {
+	// Collect all table names we need
+	neededTables := make(map[string]bool)
+	for _, entityKey := range items.ScanTasks {
+		neededTables[entityKey] = true
+	}
+	for _, entityKey := range items.AnalyzeTasks {
+		neededTables[entityKey] = true
+	}
+
+	if len(neededTables) == 0 {
+		return make(map[string]*tableInfo), nil
+	}
+
+	// Load all tables for this datasource
+	tables, err := o.schemaRepo.ListTablesByDatasource(ctx, projectID, datasourceID)
+	if err != nil {
+		return nil, fmt.Errorf("list tables: %w", err)
+	}
+
+	// Build table by name map
+	tableByName := make(map[string]*models.SchemaTable)
+	for _, t := range tables {
+		tableByName[t.TableName] = t
+	}
+
+	// Load columns for each needed table
+	cache := make(map[string]*tableInfo)
+	for tableName := range neededTables {
+		table, ok := tableByName[tableName]
+		if !ok {
+			return nil, fmt.Errorf("table not found: %s", tableName)
+		}
+
+		columns, err := o.schemaRepo.ListColumnsByTable(ctx, projectID, table.ID)
+		if err != nil {
+			return nil, fmt.Errorf("list columns for %s: %w", tableName, err)
+		}
+
+		columnNames := make([]string, len(columns))
+		for i, col := range columns {
+			columnNames[i] = col.ColumnName
+		}
+
+		cache[tableName] = &tableInfo{
+			table:       table,
+			columnNames: columnNames,
+		}
+	}
+
+	return cache, nil
+}
+
+// finalizeWorkflow is called when all entities are complete.
+// It writes a clean ontology by stripping workflow fields (Status, ScanData),
+// then deletes ephemeral workflow state rows.
+func (o *Orchestrator) finalizeWorkflow(ctx context.Context, projectID, workflowID uuid.UUID) error {
+	o.logger.Info("Finalizing workflow - writing clean ontology",
+		zap.String("workflow_id", workflowID.String()))
+
+	// Get tenant context for database access
+	tenantCtx, cleanup, err := o.getTenantCtx(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("get tenant context: %w", err)
+	}
+	defer cleanup()
+
+	// Get entity count BEFORE deleting state (for accurate final progress)
+	states, err := o.stateRepo.ListByWorkflow(tenantCtx, workflowID)
+	if err != nil {
+		o.logger.Warn("Failed to get entity count for final progress", zap.Error(err))
+	}
+	entityCount := len(states)
+
+	// Update progress with final entity count before deletion
+	if entityCount > 0 {
+		_ = o.workflowRepo.UpdateProgress(tenantCtx, workflowID, &models.WorkflowProgress{
+			CurrentPhase: models.WorkflowPhaseCompleting,
+			Message:      "Finalizing ontology...",
+			Current:      entityCount,
+			Total:        entityCount,
+		})
+	}
+
+	// Write clean ontology (strips workflow fields)
+	if err := o.ontologyRepo.WriteCleanOntology(tenantCtx, projectID); err != nil {
+		return fmt.Errorf("write clean ontology: %w", err)
+	}
+
+	o.logger.Info("Clean ontology written successfully",
+		zap.String("workflow_id", workflowID.String()))
+
+	// Delete workflow state - ephemeral data no longer needed
+	if err := o.stateRepo.DeleteByWorkflow(tenantCtx, workflowID); err != nil {
+		return fmt.Errorf("delete workflow state: %w", err)
+	}
+
+	o.logger.Info("Workflow state cleaned up",
+		zap.String("workflow_id", workflowID.String()))
+
+	return nil
+}
+
+// updateProgress updates workflow progress based on current entity states.
+func (o *Orchestrator) updateProgress(ctx context.Context, workflowID uuid.UUID, states []*models.WorkflowEntityState, items *WorkItems) {
+	// Count completed and total entities (global + tables + columns)
+	completed := 0
+	total := len(states)
+	for _, state := range states {
+		if state.Status == models.WorkflowEntityStatusComplete {
+			completed++
+		}
+	}
+
+	// Determine the current phase based on remaining work
+	phase := models.WorkflowPhaseScanning
+	if len(items.ScanTasks) == 0 && len(items.AnalyzeTasks) > 0 {
+		phase = models.WorkflowPhaseAnalyzing
+	} else if len(items.ScanTasks) == 0 && len(items.AnalyzeTasks) == 0 && completed == total && total > 0 {
+		phase = models.WorkflowPhaseTier1Building
+	}
+
+	// Build message - always use "entities" terminology
+	message := fmt.Sprintf("Analyzing %d/%d entities...", completed, total)
+
+	// Update progress (ignore errors - progress is non-critical)
+	_ = o.workflowSvc.UpdateProgress(ctx, workflowID, &models.WorkflowProgress{
+		CurrentPhase: phase,
+		Message:      message,
+		Current:      completed,
+		Total:        total,
+	})
+}

--- a/pkg/services/workflow_orchestrator_integration_test.go
+++ b/pkg/services/workflow_orchestrator_integration_test.go
@@ -1,0 +1,273 @@
+//go:build integration
+
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
+	"github.com/ekaya-inc/ekaya-engine/pkg/testhelpers"
+)
+
+// orchestratorTestContext holds all dependencies for orchestrator integration tests.
+type orchestratorTestContext struct {
+	t            *testing.T
+	engineDB     *testhelpers.EngineDB
+	stateRepo    repositories.WorkflowStateRepository
+	workflowRepo repositories.OntologyWorkflowRepository
+	ontologyRepo repositories.OntologyRepository
+	getTenantCtx TenantContextFunc
+	projectID    uuid.UUID
+	logger       *zap.Logger
+}
+
+// setupOrchestratorTest creates a test context for orchestrator tests.
+func setupOrchestratorTest(t *testing.T) *orchestratorTestContext {
+	t.Helper()
+
+	engineDB := testhelpers.GetEngineDB(t)
+	logger := zap.NewNop()
+
+	// Create repositories
+	stateRepo := repositories.NewWorkflowStateRepository()
+	workflowRepo := repositories.NewOntologyWorkflowRepository()
+	ontologyRepo := repositories.NewOntologyRepository()
+
+	// Use unique project ID for test isolation
+	projectID := uuid.MustParse("00000000-0000-0000-0000-000000000301")
+
+	// Create getTenantCtx function
+	getTenantCtx := func(ctx context.Context, projectID uuid.UUID) (context.Context, func(), error) {
+		scope, err := engineDB.DB.WithTenant(ctx, projectID)
+		if err != nil {
+			return nil, nil, err
+		}
+		tenantCtx := database.SetTenantScope(ctx, scope)
+		return tenantCtx, func() { scope.Close() }, nil
+	}
+
+	tc := &orchestratorTestContext{
+		t:            t,
+		engineDB:     engineDB,
+		stateRepo:    stateRepo,
+		workflowRepo: workflowRepo,
+		ontologyRepo: ontologyRepo,
+		getTenantCtx: getTenantCtx,
+		projectID:    projectID,
+		logger:       logger,
+	}
+
+	// Ensure project exists
+	tc.ensureTestProject()
+
+	return tc
+}
+
+// createTestContext creates a context with tenant scope and returns a cleanup function.
+func (tc *orchestratorTestContext) createTestContext() (context.Context, func()) {
+	tc.t.Helper()
+
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithTenant(ctx, tc.projectID)
+	if err != nil {
+		tc.t.Fatalf("Failed to create tenant scope: %v", err)
+	}
+
+	ctx = database.SetTenantScope(ctx, scope)
+
+	return ctx, func() {
+		scope.Close()
+	}
+}
+
+// ensureTestProject creates the test project if it doesn't exist.
+func (tc *orchestratorTestContext) ensureTestProject() {
+	tc.t.Helper()
+
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithoutTenant(ctx)
+	if err != nil {
+		tc.t.Fatalf("Failed to create scope for project setup: %v", err)
+	}
+	defer scope.Close()
+
+	_, err = scope.Conn.Exec(ctx, `
+		INSERT INTO engine_projects (id, name, status)
+		VALUES ($1, $2, 'active')
+		ON CONFLICT (id) DO NOTHING
+	`, tc.projectID, "Orchestrator Test Project")
+	if err != nil {
+		tc.t.Fatalf("Failed to ensure test project: %v", err)
+	}
+}
+
+// cleanup removes all test data.
+func (tc *orchestratorTestContext) cleanup() {
+	tc.t.Helper()
+
+	ctx := context.Background()
+	scope, err := tc.engineDB.DB.WithTenant(ctx, tc.projectID)
+	if err != nil {
+		tc.t.Fatalf("Failed to create tenant scope for cleanup: %v", err)
+	}
+	defer scope.Close()
+
+	// Delete in order respecting foreign keys
+	_, _ = scope.Conn.Exec(ctx, `DELETE FROM engine_workflow_state WHERE project_id = $1`, tc.projectID)
+	_, _ = scope.Conn.Exec(ctx, `DELETE FROM engine_ontology_workflows WHERE project_id = $1`, tc.projectID)
+	_, _ = scope.Conn.Exec(ctx, `DELETE FROM engine_ontologies WHERE project_id = $1`, tc.projectID)
+}
+
+// createTestWorkflow creates a workflow record for testing.
+func (tc *orchestratorTestContext) createTestWorkflow(ctx context.Context, ontologyID uuid.UUID) *models.OntologyWorkflow {
+	tc.t.Helper()
+
+	workflow := &models.OntologyWorkflow{
+		ID:         uuid.New(),
+		ProjectID:  tc.projectID,
+		OntologyID: ontologyID,
+		State:      models.WorkflowStateRunning,
+		Config: &models.WorkflowConfig{
+			DatasourceID: uuid.New(),
+		},
+	}
+
+	if err := tc.workflowRepo.Create(ctx, workflow); err != nil {
+		tc.t.Fatalf("Failed to create workflow: %v", err)
+	}
+
+	return workflow
+}
+
+// createTestOntology creates an active ontology for testing.
+func (tc *orchestratorTestContext) createTestOntology(ctx context.Context) *models.TieredOntology {
+	tc.t.Helper()
+
+	ontology := &models.TieredOntology{
+		ID:        uuid.New(),
+		ProjectID: tc.projectID,
+		Version:   1,
+		IsActive:  true,
+		EntitySummaries: map[string]*models.EntitySummary{
+			"test_table": {
+				TableName:   "test_table",
+				Description: "Test table",
+			},
+		},
+	}
+
+	if err := tc.ontologyRepo.Create(ctx, ontology); err != nil {
+		tc.t.Fatalf("Failed to create ontology: %v", err)
+	}
+
+	return ontology
+}
+
+// createWorkflowStates creates test workflow state rows.
+func (tc *orchestratorTestContext) createWorkflowStates(ctx context.Context, workflowID, ontologyID uuid.UUID) []*models.WorkflowEntityState {
+	tc.t.Helper()
+
+	states := []*models.WorkflowEntityState{
+		{
+			ID:         uuid.New(),
+			ProjectID:  tc.projectID,
+			OntologyID: ontologyID,
+			WorkflowID: workflowID,
+			EntityType: models.WorkflowEntityTypeGlobal,
+			EntityKey:  "",
+			Status:     models.WorkflowEntityStatusComplete,
+		},
+		{
+			ID:         uuid.New(),
+			ProjectID:  tc.projectID,
+			OntologyID: ontologyID,
+			WorkflowID: workflowID,
+			EntityType: models.WorkflowEntityTypeTable,
+			EntityKey:  "test_table",
+			Status:     models.WorkflowEntityStatusComplete,
+		},
+		{
+			ID:         uuid.New(),
+			ProjectID:  tc.projectID,
+			OntologyID: ontologyID,
+			WorkflowID: workflowID,
+			EntityType: models.WorkflowEntityTypeColumn,
+			EntityKey:  "test_table.id",
+			Status:     models.WorkflowEntityStatusComplete,
+		},
+	}
+
+	for _, state := range states {
+		if err := tc.stateRepo.Create(ctx, state); err != nil {
+			tc.t.Fatalf("Failed to create workflow state: %v", err)
+		}
+	}
+
+	return states
+}
+
+// ============================================================================
+// Integration Tests
+// ============================================================================
+
+func TestOrchestrator_FinalizeWorkflow_CleansUpState_Integration(t *testing.T) {
+	tc := setupOrchestratorTest(t)
+	tc.cleanup()
+	defer tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	// Create test data (order matters: ontology first, then workflow with ontology ID)
+	ontology := tc.createTestOntology(ctx)
+	workflow := tc.createTestWorkflow(ctx, ontology.ID)
+	tc.createWorkflowStates(ctx, workflow.ID, ontology.ID)
+
+	// Verify states exist before finalization
+	statesBefore, err := tc.stateRepo.ListByWorkflow(ctx, workflow.ID)
+	if err != nil {
+		t.Fatalf("ListByWorkflow failed: %v", err)
+	}
+	if len(statesBefore) != 3 {
+		t.Fatalf("expected 3 workflow states before finalization, got %d", len(statesBefore))
+	}
+
+	// Create orchestrator with minimal dependencies
+	orch := &Orchestrator{
+		stateRepo:    tc.stateRepo,
+		workflowRepo: tc.workflowRepo,
+		ontologyRepo: tc.ontologyRepo,
+		getTenantCtx: tc.getTenantCtx,
+		logger:       tc.logger,
+	}
+
+	// Call finalizeWorkflow
+	err = orch.finalizeWorkflow(context.Background(), tc.projectID, workflow.ID)
+	if err != nil {
+		t.Fatalf("finalizeWorkflow failed: %v", err)
+	}
+
+	// Verify states are deleted after finalization
+	statesAfter, err := tc.stateRepo.ListByWorkflow(ctx, workflow.ID)
+	if err != nil {
+		t.Fatalf("ListByWorkflow after finalization failed: %v", err)
+	}
+	if len(statesAfter) != 0 {
+		t.Errorf("expected 0 workflow states after finalization, got %d", len(statesAfter))
+	}
+
+	// Verify ontology still exists
+	activeOntology, err := tc.ontologyRepo.GetActive(ctx, tc.projectID)
+	if err != nil {
+		t.Fatalf("GetActive failed: %v", err)
+	}
+	if activeOntology == nil {
+		t.Error("expected active ontology to still exist after finalization")
+	}
+}

--- a/pkg/services/workflow_orchestrator_test.go
+++ b/pkg/services/workflow_orchestrator_test.go
@@ -1,0 +1,239 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+)
+
+// --- determineWorkFromStates Tests ---
+
+func TestOrchestrator_DetermineWorkFromStates_PendingTableEntities(t *testing.T) {
+	states := []*models.WorkflowEntityState{
+		{ID: uuid.New(), EntityType: models.WorkflowEntityTypeTable, EntityKey: "orders", Status: models.WorkflowEntityStatusPending},
+		{ID: uuid.New(), EntityType: models.WorkflowEntityTypeTable, EntityKey: "customers", Status: models.WorkflowEntityStatusPending},
+	}
+
+	orch := &Orchestrator{}
+	items := orch.determineWorkFromStates(states)
+
+	if len(items.ScanTasks) != 2 {
+		t.Errorf("expected 2 scan tasks, got %d", len(items.ScanTasks))
+	}
+	if len(items.AnalyzeTasks) != 0 {
+		t.Errorf("expected 0 analyze tasks, got %d", len(items.AnalyzeTasks))
+	}
+
+	// Verify entity keys are captured
+	expectedKeys := map[string]bool{"orders": true, "customers": true}
+	for _, key := range items.ScanTasks {
+		if !expectedKeys[key] {
+			t.Errorf("unexpected scan task key: %s", key)
+		}
+	}
+}
+
+func TestOrchestrator_DetermineWorkFromStates_ScannedTableEntities(t *testing.T) {
+	states := []*models.WorkflowEntityState{
+		{ID: uuid.New(), EntityType: models.WorkflowEntityTypeTable, EntityKey: "orders", Status: models.WorkflowEntityStatusScanned},
+		{ID: uuid.New(), EntityType: models.WorkflowEntityTypeTable, EntityKey: "customers", Status: models.WorkflowEntityStatusScanned},
+		{ID: uuid.New(), EntityType: models.WorkflowEntityTypeTable, EntityKey: "products", Status: models.WorkflowEntityStatusScanned},
+	}
+
+	orch := &Orchestrator{}
+	items := orch.determineWorkFromStates(states)
+
+	if len(items.ScanTasks) != 0 {
+		t.Errorf("expected 0 scan tasks, got %d", len(items.ScanTasks))
+	}
+	if len(items.AnalyzeTasks) != 3 {
+		t.Errorf("expected 3 analyze tasks, got %d", len(items.AnalyzeTasks))
+	}
+
+	// Verify entity keys are captured
+	expectedKeys := map[string]bool{"orders": true, "customers": true, "products": true}
+	for _, key := range items.AnalyzeTasks {
+		if !expectedKeys[key] {
+			t.Errorf("unexpected analyze task key: %s", key)
+		}
+	}
+}
+
+func TestOrchestrator_DetermineWorkFromStates_SkipsGlobalAndColumnEntities(t *testing.T) {
+	states := []*models.WorkflowEntityState{
+		// Global entity - should be skipped
+		{ID: uuid.New(), EntityType: models.WorkflowEntityTypeGlobal, EntityKey: "", Status: models.WorkflowEntityStatusPending},
+		// Column entities - should be skipped
+		{ID: uuid.New(), EntityType: models.WorkflowEntityTypeColumn, EntityKey: "orders.status", Status: models.WorkflowEntityStatusPending},
+		{ID: uuid.New(), EntityType: models.WorkflowEntityTypeColumn, EntityKey: "orders.total", Status: models.WorkflowEntityStatusScanned},
+		// Table entity - should be included
+		{ID: uuid.New(), EntityType: models.WorkflowEntityTypeTable, EntityKey: "orders", Status: models.WorkflowEntityStatusPending},
+	}
+
+	orch := &Orchestrator{}
+	items := orch.determineWorkFromStates(states)
+
+	// Only the table entity should generate a task
+	if len(items.ScanTasks) != 1 {
+		t.Errorf("expected 1 scan task (table only), got %d", len(items.ScanTasks))
+	}
+	if len(items.AnalyzeTasks) != 0 {
+		t.Errorf("expected 0 analyze tasks, got %d", len(items.AnalyzeTasks))
+	}
+
+	if items.ScanTasks[0] != "orders" {
+		t.Errorf("expected scan task 'orders', got %s", items.ScanTasks[0])
+	}
+}
+
+func TestOrchestrator_DetermineWorkFromStates_MixedStates(t *testing.T) {
+	states := []*models.WorkflowEntityState{
+		// Should be in ScanTasks
+		{ID: uuid.New(), EntityType: models.WorkflowEntityTypeTable, EntityKey: "orders", Status: models.WorkflowEntityStatusPending},
+		// Should be in AnalyzeTasks
+		{ID: uuid.New(), EntityType: models.WorkflowEntityTypeTable, EntityKey: "customers", Status: models.WorkflowEntityStatusScanned},
+		// Already scanning - no action
+		{ID: uuid.New(), EntityType: models.WorkflowEntityTypeTable, EntityKey: "products", Status: models.WorkflowEntityStatusScanning},
+		// Already analyzing - no action
+		{ID: uuid.New(), EntityType: models.WorkflowEntityTypeTable, EntityKey: "items", Status: models.WorkflowEntityStatusAnalyzing},
+		// Waiting for input - no action
+		{ID: uuid.New(), EntityType: models.WorkflowEntityTypeTable, EntityKey: "categories", Status: models.WorkflowEntityStatusNeedsInput},
+		// Complete - no action
+		{ID: uuid.New(), EntityType: models.WorkflowEntityTypeTable, EntityKey: "users", Status: models.WorkflowEntityStatusComplete},
+		// Failed - no action
+		{ID: uuid.New(), EntityType: models.WorkflowEntityTypeTable, EntityKey: "logs", Status: models.WorkflowEntityStatusFailed},
+	}
+
+	orch := &Orchestrator{}
+	items := orch.determineWorkFromStates(states)
+
+	if len(items.ScanTasks) != 1 {
+		t.Errorf("expected 1 scan task, got %d", len(items.ScanTasks))
+	}
+	if len(items.AnalyzeTasks) != 1 {
+		t.Errorf("expected 1 analyze task, got %d", len(items.AnalyzeTasks))
+	}
+
+	if items.ScanTasks[0] != "orders" {
+		t.Errorf("expected scan task 'orders', got %s", items.ScanTasks[0])
+	}
+	if items.AnalyzeTasks[0] != "customers" {
+		t.Errorf("expected analyze task 'customers', got %s", items.AnalyzeTasks[0])
+	}
+}
+
+// --- isAllComplete Tests ---
+
+func TestOrchestrator_IsAllComplete_TerminalStates(t *testing.T) {
+	states := []*models.WorkflowEntityState{
+		{Status: models.WorkflowEntityStatusComplete},
+		{Status: models.WorkflowEntityStatusFailed},
+		{Status: models.WorkflowEntityStatusComplete},
+	}
+
+	orch := &Orchestrator{}
+	if !orch.isAllComplete(states) {
+		t.Error("expected isAllComplete to return true for all terminal states")
+	}
+}
+
+func TestOrchestrator_IsAllComplete_NonTerminalStates(t *testing.T) {
+	testCases := []struct {
+		name   string
+		states []*models.WorkflowEntityState
+	}{
+		{
+			name: "has pending",
+			states: []*models.WorkflowEntityState{
+				{Status: models.WorkflowEntityStatusComplete},
+				{Status: models.WorkflowEntityStatusPending},
+			},
+		},
+		{
+			name: "has scanning",
+			states: []*models.WorkflowEntityState{
+				{Status: models.WorkflowEntityStatusScanning},
+			},
+		},
+		{
+			name: "has scanned",
+			states: []*models.WorkflowEntityState{
+				{Status: models.WorkflowEntityStatusScanned},
+			},
+		},
+		{
+			name: "has analyzing",
+			states: []*models.WorkflowEntityState{
+				{Status: models.WorkflowEntityStatusAnalyzing},
+			},
+		},
+		{
+			name: "has needs_input",
+			states: []*models.WorkflowEntityState{
+				{Status: models.WorkflowEntityStatusNeedsInput},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			orch := &Orchestrator{}
+			if orch.isAllComplete(tc.states) {
+				t.Error("expected isAllComplete to return false for non-terminal states")
+			}
+		})
+	}
+}
+
+func TestOrchestrator_IsAllComplete_EmptyStates(t *testing.T) {
+	orch := &Orchestrator{}
+	// Empty list means all entities (none) are complete
+	if !orch.isAllComplete([]*models.WorkflowEntityState{}) {
+		t.Error("expected isAllComplete to return true for empty states")
+	}
+}
+
+// --- allTablesComplete Tests ---
+
+func TestOrchestrator_AllTablesComplete_AllComplete(t *testing.T) {
+	states := []*models.WorkflowEntityState{
+		{EntityType: models.WorkflowEntityTypeTable, Status: models.WorkflowEntityStatusComplete},
+		{EntityType: models.WorkflowEntityTypeTable, Status: models.WorkflowEntityStatusComplete},
+		// Column entities are ignored
+		{EntityType: models.WorkflowEntityTypeColumn, Status: models.WorkflowEntityStatusScanned},
+		// Global entity is ignored
+		{EntityType: models.WorkflowEntityTypeGlobal, Status: models.WorkflowEntityStatusPending},
+	}
+
+	orch := &Orchestrator{}
+	if !orch.allTablesComplete(states) {
+		t.Error("expected allTablesComplete to return true when all tables are complete")
+	}
+}
+
+func TestOrchestrator_AllTablesComplete_OneNotComplete(t *testing.T) {
+	states := []*models.WorkflowEntityState{
+		{EntityType: models.WorkflowEntityTypeTable, Status: models.WorkflowEntityStatusComplete},
+		{EntityType: models.WorkflowEntityTypeTable, Status: models.WorkflowEntityStatusAnalyzing}, // Not complete
+	}
+
+	orch := &Orchestrator{}
+	if orch.allTablesComplete(states) {
+		t.Error("expected allTablesComplete to return false when one table is not complete")
+	}
+}
+
+func TestOrchestrator_AllTablesComplete_NoTables(t *testing.T) {
+	states := []*models.WorkflowEntityState{
+		{EntityType: models.WorkflowEntityTypeGlobal, Status: models.WorkflowEntityStatusPending},
+		{EntityType: models.WorkflowEntityTypeColumn, Status: models.WorkflowEntityStatusScanned},
+	}
+
+	orch := &Orchestrator{}
+	// No tables means all tables (none) are complete
+	if !orch.allTablesComplete(states) {
+		t.Error("expected allTablesComplete to return true when there are no tables")
+	}
+}

--- a/pkg/services/workqueue/queue.go
+++ b/pkg/services/workqueue/queue.go
@@ -1,0 +1,462 @@
+package workqueue
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"go.uber.org/zap"
+)
+
+// Queue manages task execution with configurable concurrency control.
+// The concurrency strategy determines how tasks are allowed to run:
+// - SerializedStrategy: one LLM task at a time, one data task at a time (default)
+// - ParallelLLMStrategy: unlimited parallel LLM tasks
+// - ThrottledLLMStrategy: up to N concurrent LLM tasks
+type Queue struct {
+	mu        sync.Mutex
+	tasks     []*TaskState
+	cancelled bool
+	paused    bool // distinguishes pause from cancel for task status
+
+	// Concurrency control strategy
+	strategy ConcurrencyStrategy
+
+	// done is closed when all tasks complete
+	done chan struct{}
+	// wg tracks running goroutines
+	wg sync.WaitGroup
+
+	// Cancellation context for running tasks
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// Callbacks
+	onUpdate func([]TaskSnapshot)
+
+	logger *zap.Logger
+}
+
+// NewQueue creates a new work queue with the default serialized strategy.
+func NewQueue(logger *zap.Logger) *Queue {
+	return NewQueueWithStrategy(logger, nil)
+}
+
+// NewQueueWithStrategy creates a new work queue with a custom concurrency strategy.
+// If strategy is nil, defaults to SerializedStrategy (original behavior).
+func NewQueueWithStrategy(logger *zap.Logger, strategy ConcurrencyStrategy) *Queue {
+	if strategy == nil {
+		strategy = NewSerializedStrategy()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Queue{
+		tasks:    make([]*TaskState, 0),
+		strategy: strategy,
+		done:     make(chan struct{}),
+		ctx:      ctx,
+		cancel:   cancel,
+		logger:   logger.Named("workqueue"),
+	}
+}
+
+// SetOnUpdate sets the callback invoked when task state changes.
+// The callback receives a snapshot of all tasks.
+//
+// WARNING: The callback is invoked while holding the queue's internal lock.
+// Do NOT call any Queue methods from within the callback or it will deadlock.
+// The callback should be fast and non-blocking (e.g., send to a channel).
+func (q *Queue) SetOnUpdate(callback func([]TaskSnapshot)) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.onUpdate = callback
+}
+
+// Enqueue adds a task to the queue and attempts to start eligible tasks.
+func (q *Queue) Enqueue(task Task) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.cancelled {
+		q.logger.Warn("queue cancelled, ignoring enqueue",
+			zap.String("task_id", task.ID()),
+			zap.String("task_name", task.Name()))
+		return
+	}
+
+	// Reset done channel if it was closed from a previous batch
+	q.resetDoneLocked()
+
+	state := NewTaskState(task)
+	q.tasks = append(q.tasks, state)
+
+	q.logger.Info("task enqueued",
+		zap.String("task_id", task.ID()),
+		zap.String("task_name", task.Name()),
+		zap.Bool("requires_llm", task.RequiresLLM()))
+
+	q.notifyUpdateLocked()
+	q.tryStartTasksLocked()
+}
+
+// tryStartTasksLocked checks constraints and starts eligible tasks.
+// Uses the configured concurrency strategy to determine which tasks can start.
+// Must be called with lock held.
+func (q *Queue) tryStartTasksLocked() {
+	if q.cancelled {
+		return
+	}
+
+	for _, ts := range q.tasks {
+		if ts.GetStatus() != TaskStatusPending {
+			continue
+		}
+
+		isLLMTask := ts.Task.RequiresLLM()
+
+		// Check with strategy if task can start
+		if isLLMTask && !q.strategy.CanStartLLM() {
+			continue
+		}
+		if !isLLMTask && !q.strategy.CanStartData() {
+			continue
+		}
+
+		// Notify strategy that task is starting
+		if isLLMTask {
+			q.strategy.OnStartLLM()
+		} else {
+			q.strategy.OnStartData()
+		}
+		ts.SetStatus(TaskStatusRunning)
+		q.notifyUpdateLocked()
+
+		q.logger.Info("starting task",
+			zap.String("task_id", ts.Task.ID()),
+			zap.String("task_name", ts.Task.Name()))
+
+		q.wg.Add(1)
+		go q.runTask(ts)
+	}
+}
+
+// runTask executes a task and handles completion.
+func (q *Queue) runTask(ts *TaskState) {
+	defer q.wg.Done()
+
+	// Use the queue's cancellable context - decoupled from HTTP request lifecycle
+	// but can be cancelled when user requests queue cancellation (e.g., "Stop" button)
+	err := ts.Task.Execute(q.ctx, q)
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	// Notify strategy that task completed
+	if ts.Task.RequiresLLM() {
+		q.strategy.OnCompleteLLM()
+	} else {
+		q.strategy.OnCompleteData()
+	}
+
+	if err != nil {
+		// Distinguish between pause, cancellation, and actual failures
+		if errors.Is(err, context.Canceled) {
+			if q.paused {
+				ts.SetStatus(TaskStatusPaused)
+				q.logger.Info("task paused",
+					zap.String("task_id", ts.Task.ID()),
+					zap.String("task_name", ts.Task.Name()))
+			} else {
+				ts.SetStatus(TaskStatusCancelled)
+				q.logger.Info("task cancelled",
+					zap.String("task_id", ts.Task.ID()),
+					zap.String("task_name", ts.Task.Name()))
+			}
+		} else {
+			ts.SetStatus(TaskStatusFailed)
+			ts.SetError(err)
+			q.logger.Error("task failed",
+				zap.String("task_id", ts.Task.ID()),
+				zap.String("task_name", ts.Task.Name()),
+				zap.Error(err))
+		}
+	} else {
+		ts.SetStatus(TaskStatusCompleted)
+		q.logger.Info("task completed",
+			zap.String("task_id", ts.Task.ID()),
+			zap.String("task_name", ts.Task.Name()))
+	}
+
+	q.notifyUpdateLocked()
+
+	// Check if all tasks are done
+	if q.allTasksDoneLocked() {
+		q.closeDoneLocked()
+		return
+	}
+
+	// Try to start more tasks
+	q.tryStartTasksLocked()
+}
+
+// allTasksDoneLocked returns true if all tasks are in a terminal state.
+// Must be called with lock held.
+func (q *Queue) allTasksDoneLocked() bool {
+	for _, ts := range q.tasks {
+		status := ts.GetStatus()
+		if status == TaskStatusPending || status == TaskStatusRunning {
+			return false
+		}
+	}
+	return true
+}
+
+// closeDoneLocked safely closes the done channel.
+// Must be called with lock held.
+func (q *Queue) closeDoneLocked() {
+	select {
+	case <-q.done:
+		// Already closed
+	default:
+		close(q.done)
+	}
+}
+
+// resetDoneLocked recreates the done channel if it was closed.
+// This allows the queue to be reused for multiple batches of work.
+// Must be called with lock held.
+func (q *Queue) resetDoneLocked() {
+	select {
+	case <-q.done:
+		// Channel was closed, create a new one
+		q.done = make(chan struct{})
+	default:
+		// Channel is still open, nothing to do
+	}
+}
+
+// notifyUpdateLocked calls the update callback with a snapshot of all tasks.
+// Must be called with lock held.
+func (q *Queue) notifyUpdateLocked() {
+	if q.onUpdate == nil {
+		return
+	}
+
+	snapshots := make([]TaskSnapshot, len(q.tasks))
+	for i, ts := range q.tasks {
+		snapshots[i] = ts.Snapshot()
+	}
+	q.onUpdate(snapshots)
+}
+
+// GetTasks returns a snapshot of all tasks.
+func (q *Queue) GetTasks() []TaskSnapshot {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	snapshots := make([]TaskSnapshot, len(q.tasks))
+	for i, ts := range q.tasks {
+		snapshots[i] = ts.Snapshot()
+	}
+	return snapshots
+}
+
+// Wait blocks until all tasks complete or the context is cancelled.
+// Returns nil if all tasks completed successfully or queue is empty.
+// Returns the first task error if any task failed.
+// Returns ctx.Err() if the context was cancelled.
+func (q *Queue) Wait(ctx context.Context) error {
+	// Handle empty queue - nothing to wait for
+	q.mu.Lock()
+	if len(q.tasks) == 0 {
+		q.mu.Unlock()
+		return nil
+	}
+	q.mu.Unlock()
+
+	select {
+	case <-q.done:
+		// Check for failed tasks
+		q.mu.Lock()
+		defer q.mu.Unlock()
+		for _, ts := range q.tasks {
+			if ts.GetStatus() == TaskStatusFailed {
+				return ts.GetError()
+			}
+		}
+		return nil
+	case <-ctx.Done():
+		q.Cancel()
+		return ctx.Err()
+	}
+}
+
+// Cancel marks the queue as cancelled, signals running tasks to stop,
+// and stops accepting new tasks.
+func (q *Queue) Cancel() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.cancelled {
+		return
+	}
+
+	q.cancelled = true
+	q.logger.Info("queue cancelled, signaling running tasks to stop")
+
+	// Signal all running tasks to stop via context cancellation
+	q.cancel()
+
+	// Mark pending tasks as cancelled
+	for _, ts := range q.tasks {
+		if ts.GetStatus() == TaskStatusPending {
+			ts.SetStatus(TaskStatusCancelled)
+		}
+	}
+
+	q.notifyUpdateLocked()
+
+	// If no tasks are running, close done channel
+	if q.allTasksDoneLocked() {
+		q.closeDoneLocked()
+	}
+}
+
+// Pause marks the queue as paused, signals running tasks to stop,
+// and marks pending/running tasks as paused for later resumption.
+// Unlike Cancel, paused tasks can be resumed.
+func (q *Queue) Pause() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.cancelled {
+		return
+	}
+
+	q.cancelled = true // Reuse to prevent new enqueues
+	q.paused = true    // Mark as paused (not cancelled)
+	q.logger.Info("queue paused, signaling running tasks to stop")
+
+	// Signal all running tasks to stop via context cancellation
+	q.cancel()
+
+	// Mark pending tasks as paused (running tasks will be marked in runTask)
+	for _, ts := range q.tasks {
+		if ts.GetStatus() == TaskStatusPending {
+			ts.SetStatus(TaskStatusPaused)
+		}
+	}
+
+	q.notifyUpdateLocked()
+
+	// If no tasks are running, close done channel
+	if q.allTasksDoneLocked() {
+		q.closeDoneLocked()
+	}
+}
+
+// IsPaused returns true if the queue was paused (vs cancelled).
+func (q *Queue) IsPaused() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.paused
+}
+
+// IsComplete returns true if all tasks have completed (success or failure).
+func (q *Queue) IsComplete() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.allTasksDoneLocked()
+}
+
+// HasFailures returns true if any task failed.
+func (q *Queue) HasFailures() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	for _, ts := range q.tasks {
+		if ts.GetStatus() == TaskStatusFailed {
+			return true
+		}
+	}
+	return false
+}
+
+// TaskCount returns the total number of tasks.
+func (q *Queue) TaskCount() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.tasks)
+}
+
+// PendingCount returns the number of pending tasks.
+func (q *Queue) PendingCount() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	count := 0
+	for _, ts := range q.tasks {
+		if ts.GetStatus() == TaskStatusPending {
+			count++
+		}
+	}
+	return count
+}
+
+// CompletedCount returns the number of completed tasks.
+func (q *Queue) CompletedCount() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	count := 0
+	for _, ts := range q.tasks {
+		if ts.GetStatus() == TaskStatusCompleted {
+			count++
+		}
+	}
+	return count
+}
+
+// Progress returns a progress summary.
+func (q *Queue) Progress() Progress {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	p := Progress{Total: len(q.tasks)}
+	for _, ts := range q.tasks {
+		switch ts.GetStatus() {
+		case TaskStatusPending:
+			p.Pending++
+		case TaskStatusRunning:
+			p.Running++
+		case TaskStatusCompleted:
+			p.Completed++
+		case TaskStatusFailed:
+			p.Failed++
+		case TaskStatusCancelled:
+			p.Cancelled++
+		case TaskStatusPaused:
+			p.Paused++
+		}
+	}
+	return p
+}
+
+// Progress holds queue progress statistics.
+type Progress struct {
+	Total     int `json:"total"`
+	Pending   int `json:"pending"`
+	Running   int `json:"running"`
+	Completed int `json:"completed"`
+	Failed    int `json:"failed"`
+	Cancelled int `json:"cancelled"`
+	Paused    int `json:"paused"`
+}
+
+// Percentage returns the completion percentage (0-100).
+func (p Progress) Percentage() int {
+	if p.Total == 0 {
+		return 100
+	}
+	done := p.Completed + p.Failed + p.Cancelled + p.Paused
+	return (done * 100) / p.Total
+}

--- a/pkg/services/workqueue/queue_test.go
+++ b/pkg/services/workqueue/queue_test.go
@@ -1,0 +1,1047 @@
+package workqueue
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// testTask is a simple task for testing.
+type testTask struct {
+	BaseTask
+	executeFunc func(ctx context.Context, enqueuer TaskEnqueuer) error
+}
+
+func newTestTask(name string, requiresLLM bool, fn func(ctx context.Context, enqueuer TaskEnqueuer) error) *testTask {
+	return &testTask{
+		BaseTask:    NewBaseTask(name, requiresLLM),
+		executeFunc: fn,
+	}
+}
+
+func (t *testTask) Execute(ctx context.Context, enqueuer TaskEnqueuer) error {
+	if t.executeFunc != nil {
+		return t.executeFunc(ctx, enqueuer)
+	}
+	return nil
+}
+
+func TestQueue_EnqueueAndComplete(t *testing.T) {
+	q := NewQueue(zap.NewNop())
+
+	executed := false
+	task := newTestTask("test-task", false, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		executed = true
+		return nil
+	})
+
+	q.Enqueue(task)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := q.Wait(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !executed {
+		t.Error("task was not executed")
+	}
+
+	if q.CompletedCount() != 1 {
+		t.Errorf("expected 1 completed, got %d", q.CompletedCount())
+	}
+}
+
+func TestQueue_TaskFailure(t *testing.T) {
+	q := NewQueue(zap.NewNop())
+
+	expectedErr := errors.New("task failed")
+	task := newTestTask("failing-task", false, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		return expectedErr
+	})
+
+	q.Enqueue(task)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := q.Wait(ctx)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("expected %v, got %v", expectedErr, err)
+	}
+
+	if !q.HasFailures() {
+		t.Error("expected HasFailures to return true")
+	}
+}
+
+func TestQueue_LLMSerialization(t *testing.T) {
+	q := NewQueue(zap.NewNop())
+
+	var running int32
+	var maxConcurrent int32
+	var mu sync.Mutex
+
+	// Create 3 LLM tasks that track concurrent execution
+	for i := 0; i < 3; i++ {
+		task := newTestTask("llm-task", true, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+			current := atomic.AddInt32(&running, 1)
+			mu.Lock()
+			if current > maxConcurrent {
+				maxConcurrent = current
+			}
+			mu.Unlock()
+
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt32(&running, -1)
+			return nil
+		})
+		q.Enqueue(task)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := q.Wait(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	mc := maxConcurrent
+	mu.Unlock()
+
+	if mc > 1 {
+		t.Errorf("LLM tasks ran concurrently: max concurrent was %d", mc)
+	}
+}
+
+func TestQueue_DataTasksSerialized(t *testing.T) {
+	q := NewQueue(zap.NewNop())
+
+	var running int32
+	var maxConcurrent int32
+	var mu sync.Mutex
+
+	// Create 3 data (non-LLM) tasks - they should serialize (only 1 at a time)
+	for i := 0; i < 3; i++ {
+		task := newTestTask("data-task", false, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+			current := atomic.AddInt32(&running, 1)
+			mu.Lock()
+			if current > maxConcurrent {
+				maxConcurrent = current
+			}
+			mu.Unlock()
+
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt32(&running, -1)
+			return nil
+		})
+		q.Enqueue(task)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := q.Wait(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	mc := maxConcurrent
+	mu.Unlock()
+
+	// Data tasks should serialize (max 1 concurrent)
+	if mc > 1 {
+		t.Errorf("expected data tasks to serialize, but max concurrent was %d", mc)
+	}
+}
+
+func TestQueue_TwoLaneParallelism(t *testing.T) {
+	q := NewQueue(zap.NewNop())
+
+	var running int32
+	var maxConcurrent int32
+	var mu sync.Mutex
+
+	started := make(chan struct{})
+	proceed := make(chan struct{})
+
+	// Enqueue an LLM task that waits
+	q.Enqueue(newTestTask("llm-task", true, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		current := atomic.AddInt32(&running, 1)
+		mu.Lock()
+		if current > maxConcurrent {
+			maxConcurrent = current
+		}
+		mu.Unlock()
+
+		started <- struct{}{} // Signal that LLM task started
+		<-proceed             // Wait for signal to continue
+		atomic.AddInt32(&running, -1)
+		return nil
+	}))
+
+	// Enqueue a data task
+	q.Enqueue(newTestTask("data-task", false, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		current := atomic.AddInt32(&running, 1)
+		mu.Lock()
+		if current > maxConcurrent {
+			maxConcurrent = current
+		}
+		mu.Unlock()
+
+		started <- struct{}{} // Signal that data task started
+		<-proceed             // Wait for signal to continue
+		atomic.AddInt32(&running, -1)
+		return nil
+	}))
+
+	// Wait for both tasks to start (they should run in parallel)
+	<-started
+	<-started
+
+	mu.Lock()
+	mc := maxConcurrent
+	mu.Unlock()
+
+	// Both tasks should be running in parallel (2 concurrent)
+	if mc != 2 {
+		t.Errorf("expected LLM and data tasks to run in parallel, but max concurrent was %d", mc)
+	}
+
+	// Let tasks complete
+	close(proceed)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := q.Wait(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestQueue_MixedTasks(t *testing.T) {
+	q := NewQueue(zap.NewNop())
+
+	var executionOrder []string
+	var mu sync.Mutex
+
+	record := func(name string) {
+		mu.Lock()
+		executionOrder = append(executionOrder, name)
+		mu.Unlock()
+	}
+
+	// Enqueue: non-LLM, LLM, non-LLM, LLM
+	q.Enqueue(newTestTask("non-llm-1", false, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		record("non-llm-1")
+		time.Sleep(10 * time.Millisecond)
+		return nil
+	}))
+	q.Enqueue(newTestTask("llm-1", true, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		record("llm-1")
+		time.Sleep(10 * time.Millisecond)
+		return nil
+	}))
+	q.Enqueue(newTestTask("non-llm-2", false, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		record("non-llm-2")
+		time.Sleep(10 * time.Millisecond)
+		return nil
+	}))
+	q.Enqueue(newTestTask("llm-2", true, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		record("llm-2")
+		time.Sleep(10 * time.Millisecond)
+		return nil
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := q.Wait(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// All tasks should complete
+	if q.CompletedCount() != 4 {
+		t.Errorf("expected 4 completed, got %d", q.CompletedCount())
+	}
+
+	// Verify both LLM tasks executed
+	mu.Lock()
+	hasLLM1 := contains(executionOrder, "llm-1")
+	hasLLM2 := contains(executionOrder, "llm-2")
+	mu.Unlock()
+
+	if !hasLLM1 || !hasLLM2 {
+		t.Error("not all LLM tasks executed")
+	}
+}
+
+func TestQueue_TaskEnqueuesMoreTasks(t *testing.T) {
+	q := NewQueue(zap.NewNop())
+
+	var executed []string
+	var mu sync.Mutex
+
+	// First task enqueues a second task
+	task1 := newTestTask("task-1", false, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		mu.Lock()
+		executed = append(executed, "task-1")
+		mu.Unlock()
+
+		enqueuer.Enqueue(newTestTask("task-2", false, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+			mu.Lock()
+			executed = append(executed, "task-2")
+			mu.Unlock()
+			return nil
+		}))
+		return nil
+	})
+
+	q.Enqueue(task1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := q.Wait(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(executed) != 2 {
+		t.Errorf("expected 2 tasks executed, got %d", len(executed))
+	}
+	if !contains(executed, "task-1") || !contains(executed, "task-2") {
+		t.Errorf("expected task-1 and task-2, got %v", executed)
+	}
+}
+
+func TestQueue_Cancel(t *testing.T) {
+	q := NewQueue(zap.NewNop())
+
+	// Use an LLM task to block other LLM tasks
+	started := make(chan struct{})
+	task := newTestTask("slow-llm-task", true, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		close(started)
+		time.Sleep(5 * time.Second)
+		return nil
+	})
+
+	q.Enqueue(task)
+
+	// Wait for task to start
+	<-started
+
+	// Enqueue another LLM task - it must wait since LLM is serialized
+	q.Enqueue(newTestTask("pending-llm-task", true, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		return nil
+	}))
+
+	// Give the queue a moment to process the enqueue
+	time.Sleep(10 * time.Millisecond)
+
+	// Cancel the queue
+	q.Cancel()
+
+	// The pending LLM task should be marked as cancelled (it couldn't start)
+	tasks := q.GetTasks()
+	for _, ts := range tasks {
+		if ts.Name == "pending-llm-task" && ts.Status != TaskStatusCancelled {
+			t.Errorf("expected pending-llm-task to be cancelled, got %s", ts.Status)
+		}
+	}
+}
+
+func TestQueue_ContextCancellation(t *testing.T) {
+	q := NewQueue(zap.NewNop())
+
+	task := newTestTask("slow-task", false, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		time.Sleep(10 * time.Second)
+		return nil
+	})
+
+	q.Enqueue(task)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := q.Wait(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected context.DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestQueue_CancelRunningTasks(t *testing.T) {
+	q := NewQueue(zap.NewNop())
+
+	taskStarted := make(chan struct{})
+	taskCancelled := make(chan struct{})
+
+	// Task that respects context cancellation
+	task := newTestTask("cancellable-task", false, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		close(taskStarted)
+		select {
+		case <-ctx.Done():
+			close(taskCancelled)
+			return ctx.Err()
+		case <-time.After(10 * time.Second):
+			return nil
+		}
+	})
+
+	q.Enqueue(task)
+
+	// Wait for task to start
+	<-taskStarted
+
+	// Cancel the queue
+	q.Cancel()
+
+	// Task should receive cancellation
+	select {
+	case <-taskCancelled:
+		// Good - task was cancelled
+	case <-time.After(1 * time.Second):
+		t.Fatal("task did not receive cancellation signal")
+	}
+
+	// Wait for queue to finish
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = q.Wait(ctx)
+
+	// Task should be marked as cancelled, not failed
+	tasks := q.GetTasks()
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	if tasks[0].Status != TaskStatusCancelled {
+		t.Errorf("expected task status Cancelled, got %s", tasks[0].Status)
+	}
+}
+
+func TestQueue_CancelMultipleRunningTasks(t *testing.T) {
+	q := NewQueue(zap.NewNop())
+
+	// With two-lane serialization, we can have at most 2 tasks running:
+	// 1 LLM task + 1 data task
+	const numTasks = 2
+	tasksStarted := make(chan struct{}, numTasks)
+	var cancelledCount int32
+
+	// Create 1 LLM task and 1 data task that can run in parallel
+	llmTask := newTestTask("llm-task", true, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		tasksStarted <- struct{}{}
+		select {
+		case <-ctx.Done():
+			atomic.AddInt32(&cancelledCount, 1)
+			return ctx.Err()
+		case <-time.After(10 * time.Second):
+			return nil
+		}
+	})
+	dataTask := newTestTask("data-task", false, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		tasksStarted <- struct{}{}
+		select {
+		case <-ctx.Done():
+			atomic.AddInt32(&cancelledCount, 1)
+			return ctx.Err()
+		case <-time.After(10 * time.Second):
+			return nil
+		}
+	})
+	q.Enqueue(llmTask)
+	q.Enqueue(dataTask)
+
+	// Wait for both tasks to start (they run in parallel - different lanes)
+	for i := 0; i < numTasks; i++ {
+		select {
+		case <-tasksStarted:
+		case <-time.After(1 * time.Second):
+			t.Fatal("tasks did not start in time")
+		}
+	}
+
+	// Cancel the queue
+	q.Cancel()
+
+	// Wait for queue to finish
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = q.Wait(ctx)
+
+	// All tasks should have been cancelled
+	if atomic.LoadInt32(&cancelledCount) != numTasks {
+		t.Errorf("expected %d tasks cancelled, got %d", numTasks, cancelledCount)
+	}
+
+	// All tasks should be marked as cancelled
+	tasks := q.GetTasks()
+	for _, ts := range tasks {
+		if ts.Status != TaskStatusCancelled {
+			t.Errorf("expected task %s status Cancelled, got %s", ts.Name, ts.Status)
+		}
+	}
+}
+
+func TestQueue_CancelWithPendingAndRunning(t *testing.T) {
+	q := NewQueue(zap.NewNop())
+
+	llmStarted := make(chan struct{})
+
+	// First: LLM task that blocks (only one LLM task runs at a time)
+	q.Enqueue(newTestTask("running-llm", true, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		close(llmStarted)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(10 * time.Second):
+			return nil
+		}
+	}))
+
+	// Second: Another LLM task that will be pending (can't run while first is running)
+	q.Enqueue(newTestTask("pending-llm", true, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		return nil
+	}))
+
+	// Wait for first task to start
+	<-llmStarted
+
+	// Give queue time to process - second task should still be pending
+	time.Sleep(10 * time.Millisecond)
+
+	// Cancel the queue
+	q.Cancel()
+
+	// Wait for queue to finish
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = q.Wait(ctx)
+
+	// Check final states
+	tasks := q.GetTasks()
+	if len(tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(tasks))
+	}
+
+	// Both should be cancelled
+	for _, ts := range tasks {
+		if ts.Status != TaskStatusCancelled {
+			t.Errorf("expected task %s status Cancelled, got %s", ts.Name, ts.Status)
+		}
+	}
+}
+
+func TestQueue_OnUpdateCallback(t *testing.T) {
+	q := NewQueue(zap.NewNop())
+
+	var updates [][]TaskSnapshot
+	var mu sync.Mutex
+
+	q.SetOnUpdate(func(snapshots []TaskSnapshot) {
+		mu.Lock()
+		// Make a copy
+		cp := make([]TaskSnapshot, len(snapshots))
+		copy(cp, snapshots)
+		updates = append(updates, cp)
+		mu.Unlock()
+	})
+
+	task := newTestTask("test-task", false, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		return nil
+	})
+
+	q.Enqueue(task)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := q.Wait(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Should have multiple updates: enqueue, start, complete
+	if len(updates) < 2 {
+		t.Errorf("expected at least 2 updates, got %d", len(updates))
+	}
+
+	// First update should have task in pending or running
+	if len(updates) > 0 {
+		first := updates[0]
+		if len(first) != 1 {
+			t.Errorf("expected 1 task in first update, got %d", len(first))
+		}
+	}
+
+	// Last update should have task completed
+	last := updates[len(updates)-1]
+	if len(last) != 1 || last[0].Status != TaskStatusCompleted {
+		t.Error("expected final update to show completed task")
+	}
+}
+
+func TestQueue_Progress(t *testing.T) {
+	q := NewQueue(zap.NewNop())
+
+	blocker := make(chan struct{})
+	// Use 1 LLM task and 1 data task so they can run in parallel
+	q.Enqueue(newTestTask("llm-task", true, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		<-blocker
+		return nil
+	}))
+	q.Enqueue(newTestTask("data-task", false, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		<-blocker
+		return nil
+	}))
+
+	// Give tasks time to start
+	time.Sleep(50 * time.Millisecond)
+
+	p := q.Progress()
+	if p.Total != 2 {
+		t.Errorf("expected total 2, got %d", p.Total)
+	}
+	if p.Running != 2 {
+		t.Errorf("expected running 2, got %d", p.Running)
+	}
+	if p.Percentage() != 0 {
+		t.Errorf("expected 0%%, got %d%%", p.Percentage())
+	}
+
+	// Unblock tasks
+	close(blocker)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := q.Wait(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	p = q.Progress()
+	if p.Completed != 2 {
+		t.Errorf("expected completed 2, got %d", p.Completed)
+	}
+	if p.Percentage() != 100 {
+		t.Errorf("expected 100%%, got %d%%", p.Percentage())
+	}
+}
+
+func TestQueue_EmptyQueue(t *testing.T) {
+	q := NewQueue(zap.NewNop())
+
+	// Empty queue should be complete by default
+	if !q.IsComplete() {
+		t.Error("empty queue should be complete")
+	}
+	if q.TaskCount() != 0 {
+		t.Errorf("expected 0 tasks, got %d", q.TaskCount())
+	}
+
+	// Wait on empty queue should return immediately
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := q.Wait(ctx)
+	if err != nil {
+		t.Errorf("expected nil error for empty queue, got %v", err)
+	}
+}
+
+func TestQueue_GetTasks(t *testing.T) {
+	q := NewQueue(zap.NewNop())
+
+	q.Enqueue(newTestTask("task-1", false, nil))
+	q.Enqueue(newTestTask("task-2", true, nil))
+
+	tasks := q.GetTasks()
+	if len(tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(tasks))
+	}
+
+	// Verify task properties are captured
+	found := false
+	for _, ts := range tasks {
+		if ts.Name == "task-2" && ts.RequiresLLM {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected to find task-2 with RequiresLLM=true")
+	}
+}
+
+func TestTaskSnapshot(t *testing.T) {
+	task := newTestTask("test-task", true, nil)
+	ts := NewTaskState(task)
+
+	snapshot := ts.Snapshot()
+	if snapshot.ID != task.ID() {
+		t.Errorf("expected ID %s, got %s", task.ID(), snapshot.ID)
+	}
+	if snapshot.Name != "test-task" {
+		t.Errorf("expected name 'test-task', got %s", snapshot.Name)
+	}
+	if !snapshot.RequiresLLM {
+		t.Error("expected RequiresLLM to be true")
+	}
+	if snapshot.Status != TaskStatusPending {
+		t.Errorf("expected status pending, got %s", snapshot.Status)
+	}
+	if snapshot.StartedAt != nil {
+		t.Error("expected StartedAt to be nil")
+	}
+}
+
+func TestTaskState_SetStatus(t *testing.T) {
+	task := newTestTask("test-task", false, nil)
+	ts := NewTaskState(task)
+
+	ts.SetStatus(TaskStatusRunning)
+	if ts.GetStatus() != TaskStatusRunning {
+		t.Errorf("expected running, got %s", ts.GetStatus())
+	}
+
+	snapshot := ts.Snapshot()
+	if snapshot.StartedAt == nil {
+		t.Error("expected StartedAt to be set")
+	}
+
+	ts.SetStatus(TaskStatusCompleted)
+	snapshot = ts.Snapshot()
+	if snapshot.CompletedAt == nil {
+		t.Error("expected CompletedAt to be set")
+	}
+}
+
+func TestProgress_Percentage(t *testing.T) {
+	tests := []struct {
+		name     string
+		progress Progress
+		expected int
+	}{
+		{"empty", Progress{Total: 0}, 100},
+		{"none complete", Progress{Total: 10, Pending: 10}, 0},
+		{"half complete", Progress{Total: 10, Completed: 5, Pending: 5}, 50},
+		{"all complete", Progress{Total: 10, Completed: 10}, 100},
+		{"mixed terminal states", Progress{Total: 10, Completed: 5, Failed: 3, Cancelled: 2}, 100},
+		{"partial with failures", Progress{Total: 10, Completed: 3, Failed: 2, Running: 5}, 50},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.progress.Percentage()
+			if got != tt.expected {
+				t.Errorf("expected %d%%, got %d%%", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestQueue_MultipleBatchesWait(t *testing.T) {
+	q := NewQueue(zap.NewNop())
+
+	// Batch 1: Enqueue and wait
+	executed := make([]string, 0)
+	var mu sync.Mutex
+
+	q.Enqueue(newTestTask("batch1-task1", false, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		mu.Lock()
+		executed = append(executed, "batch1-task1")
+		mu.Unlock()
+		return nil
+	}))
+
+	ctx := context.Background()
+	err := q.Wait(ctx)
+	if err != nil {
+		t.Fatalf("batch 1 wait failed: %v", err)
+	}
+
+	// Verify batch 1 completed
+	mu.Lock()
+	if !contains(executed, "batch1-task1") {
+		t.Fatalf("batch 1 task was not executed")
+	}
+	mu.Unlock()
+
+	// Batch 2: Enqueue a SLOW task to the SAME queue and wait again
+	// The task takes 100ms to complete - if Wait() returns immediately
+	// (due to closed done channel), it won't be executed yet
+	q.Enqueue(newTestTask("batch2-task1", false, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+		time.Sleep(100 * time.Millisecond)
+		mu.Lock()
+		executed = append(executed, "batch2-task1")
+		mu.Unlock()
+		return nil
+	}))
+
+	// This Wait() should block until batch 2 completes
+	// BUG: Currently returns immediately because done channel is closed
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	err = q.Wait(ctxWithTimeout)
+	if err != nil {
+		t.Fatalf("batch 2 wait failed: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(executed) != 2 {
+		t.Errorf("expected 2 tasks executed, got %d: %v", len(executed), executed)
+	}
+	if !contains(executed, "batch2-task1") {
+		t.Errorf("batch 2 task was not executed: %v", executed)
+	}
+}
+
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+// ============================================================================
+// Strategy Tests
+// ============================================================================
+
+func TestParallelLLMStrategy_AllowsConcurrentLLM(t *testing.T) {
+	q := NewQueueWithStrategy(zap.NewNop(), NewParallelLLMStrategy())
+
+	var running int32
+	var maxConcurrent int32
+	var mu sync.Mutex
+
+	// Create 5 LLM tasks that track concurrent execution
+	for i := 0; i < 5; i++ {
+		task := newTestTask("llm-task", true, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+			current := atomic.AddInt32(&running, 1)
+			mu.Lock()
+			if current > maxConcurrent {
+				maxConcurrent = current
+			}
+			mu.Unlock()
+
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt32(&running, -1)
+			return nil
+		})
+		q.Enqueue(task)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := q.Wait(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	mc := maxConcurrent
+	mu.Unlock()
+
+	// With parallel strategy, all 5 should run concurrently
+	if mc < 3 {
+		t.Errorf("ParallelLLMStrategy should allow concurrent LLM tasks: max concurrent was %d, expected >= 3", mc)
+	}
+}
+
+func TestParallelLLMStrategy_StillSerializesDataTasks(t *testing.T) {
+	q := NewQueueWithStrategy(zap.NewNop(), NewParallelLLMStrategy())
+
+	var running int32
+	var maxConcurrent int32
+	var mu sync.Mutex
+
+	// Create 3 data tasks - they should still serialize
+	for i := 0; i < 3; i++ {
+		task := newTestTask("data-task", false, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+			current := atomic.AddInt32(&running, 1)
+			mu.Lock()
+			if current > maxConcurrent {
+				maxConcurrent = current
+			}
+			mu.Unlock()
+
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt32(&running, -1)
+			return nil
+		})
+		q.Enqueue(task)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := q.Wait(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	mc := maxConcurrent
+	mu.Unlock()
+
+	// Data tasks should still serialize (max 1 at a time)
+	if mc > 1 {
+		t.Errorf("Data tasks should serialize even with ParallelLLMStrategy: max concurrent was %d", mc)
+	}
+}
+
+func TestThrottledLLMStrategy_RespectsLimit(t *testing.T) {
+	maxConcurrent := 3
+	q := NewQueueWithStrategy(zap.NewNop(), NewThrottledLLMStrategy(maxConcurrent))
+
+	var running int32
+	var observedMax int32
+	var mu sync.Mutex
+
+	// Create 10 LLM tasks
+	for i := 0; i < 10; i++ {
+		task := newTestTask("llm-task", true, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+			current := atomic.AddInt32(&running, 1)
+			mu.Lock()
+			if current > observedMax {
+				observedMax = current
+			}
+			mu.Unlock()
+
+			time.Sleep(30 * time.Millisecond)
+			atomic.AddInt32(&running, -1)
+			return nil
+		})
+		q.Enqueue(task)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := q.Wait(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	om := observedMax
+	mu.Unlock()
+
+	// Should respect the limit
+	if om > int32(maxConcurrent) {
+		t.Errorf("ThrottledLLMStrategy exceeded limit: observed max %d, limit was %d", om, maxConcurrent)
+	}
+	// Should actually use concurrency (not serialize to 1)
+	if om < 2 {
+		t.Errorf("ThrottledLLMStrategy should allow some concurrency: observed max was %d", om)
+	}
+}
+
+func TestThrottledLLMStrategy_StillSerializesDataTasks(t *testing.T) {
+	q := NewQueueWithStrategy(zap.NewNop(), NewThrottledLLMStrategy(10))
+
+	var running int32
+	var maxConcurrent int32
+	var mu sync.Mutex
+
+	// Create 3 data tasks - they should still serialize
+	for i := 0; i < 3; i++ {
+		task := newTestTask("data-task", false, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+			current := atomic.AddInt32(&running, 1)
+			mu.Lock()
+			if current > maxConcurrent {
+				maxConcurrent = current
+			}
+			mu.Unlock()
+
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt32(&running, -1)
+			return nil
+		})
+		q.Enqueue(task)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := q.Wait(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	mc := maxConcurrent
+	mu.Unlock()
+
+	if mc > 1 {
+		t.Errorf("Data tasks should serialize even with ThrottledLLMStrategy: max concurrent was %d", mc)
+	}
+}
+
+func TestSerializedStrategy_SerializesLLM(t *testing.T) {
+	// Explicitly test SerializedStrategy (same as default NewQueue behavior)
+	q := NewQueueWithStrategy(zap.NewNop(), NewSerializedStrategy())
+
+	var running int32
+	var maxConcurrent int32
+	var mu sync.Mutex
+
+	for i := 0; i < 3; i++ {
+		task := newTestTask("llm-task", true, func(ctx context.Context, enqueuer TaskEnqueuer) error {
+			current := atomic.AddInt32(&running, 1)
+			mu.Lock()
+			if current > maxConcurrent {
+				maxConcurrent = current
+			}
+			mu.Unlock()
+
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt32(&running, -1)
+			return nil
+		})
+		q.Enqueue(task)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := q.Wait(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mu.Lock()
+	mc := maxConcurrent
+	mu.Unlock()
+
+	if mc > 1 {
+		t.Errorf("SerializedStrategy should serialize LLM tasks: max concurrent was %d", mc)
+	}
+}

--- a/pkg/services/workqueue/strategy.go
+++ b/pkg/services/workqueue/strategy.go
@@ -1,0 +1,185 @@
+package workqueue
+
+import "sync"
+
+// ConcurrencyStrategy controls how tasks are allowed to start concurrently.
+// The strategy is responsible for tracking running tasks and determining
+// if a new task can start based on the current state.
+type ConcurrencyStrategy interface {
+	// CanStartLLM returns true if an LLM task can start given current state
+	CanStartLLM() bool
+	// CanStartData returns true if a data task can start given current state
+	CanStartData() bool
+	// OnStartLLM is called when an LLM task starts
+	OnStartLLM()
+	// OnStartData is called when a data task starts
+	OnStartData()
+	// OnCompleteLLM is called when an LLM task completes
+	OnCompleteLLM()
+	// OnCompleteData is called when a data task completes
+	OnCompleteData()
+}
+
+// ============================================================================
+// SerializedStrategy - Original behavior (1 LLM at a time, 1 data at a time)
+// ============================================================================
+
+// SerializedStrategy serializes both LLM and data tasks.
+// Only one LLM task and one data task can run at a time,
+// but an LLM task and a data task can run in parallel.
+type SerializedStrategy struct {
+	mu          sync.Mutex
+	llmRunning  bool
+	dataRunning bool
+}
+
+// NewSerializedStrategy creates a strategy that serializes LLM tasks
+// (only one at a time) and serializes data tasks (only one at a time).
+func NewSerializedStrategy() *SerializedStrategy {
+	return &SerializedStrategy{}
+}
+
+func (s *SerializedStrategy) CanStartLLM() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return !s.llmRunning
+}
+
+func (s *SerializedStrategy) CanStartData() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return !s.dataRunning
+}
+
+func (s *SerializedStrategy) OnStartLLM() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.llmRunning = true
+}
+
+func (s *SerializedStrategy) OnStartData() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.dataRunning = true
+}
+
+func (s *SerializedStrategy) OnCompleteLLM() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.llmRunning = false
+}
+
+func (s *SerializedStrategy) OnCompleteData() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.dataRunning = false
+}
+
+// ============================================================================
+// ParallelLLMStrategy - Unlimited parallel LLM tasks
+// ============================================================================
+
+// ParallelLLMStrategy allows unlimited parallel LLM tasks.
+// Data tasks are still serialized (only one at a time).
+type ParallelLLMStrategy struct {
+	mu          sync.Mutex
+	dataRunning bool
+}
+
+// NewParallelLLMStrategy creates a strategy that allows unlimited
+// parallel LLM tasks while serializing data tasks.
+func NewParallelLLMStrategy() *ParallelLLMStrategy {
+	return &ParallelLLMStrategy{}
+}
+
+func (s *ParallelLLMStrategy) CanStartLLM() bool {
+	return true // Always allow LLM tasks to start
+}
+
+func (s *ParallelLLMStrategy) CanStartData() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return !s.dataRunning
+}
+
+func (s *ParallelLLMStrategy) OnStartLLM() {
+	// No-op: we don't track LLM tasks
+}
+
+func (s *ParallelLLMStrategy) OnStartData() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.dataRunning = true
+}
+
+func (s *ParallelLLMStrategy) OnCompleteLLM() {
+	// No-op: we don't track LLM tasks
+}
+
+func (s *ParallelLLMStrategy) OnCompleteData() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.dataRunning = false
+}
+
+// ============================================================================
+// ThrottledLLMStrategy - Up to N parallel LLM tasks
+// ============================================================================
+
+// ThrottledLLMStrategy allows up to maxConcurrent LLM tasks to run in parallel.
+// Data tasks are still serialized (only one at a time).
+type ThrottledLLMStrategy struct {
+	mu            sync.Mutex
+	maxConcurrent int
+	llmRunning    int
+	dataRunning   bool
+}
+
+// NewThrottledLLMStrategy creates a strategy that allows up to maxConcurrent
+// LLM tasks to run in parallel while serializing data tasks.
+func NewThrottledLLMStrategy(maxConcurrent int) *ThrottledLLMStrategy {
+	if maxConcurrent < 1 {
+		maxConcurrent = 1
+	}
+	return &ThrottledLLMStrategy{
+		maxConcurrent: maxConcurrent,
+	}
+}
+
+func (s *ThrottledLLMStrategy) CanStartLLM() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.llmRunning < s.maxConcurrent
+}
+
+func (s *ThrottledLLMStrategy) CanStartData() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return !s.dataRunning
+}
+
+func (s *ThrottledLLMStrategy) OnStartLLM() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.llmRunning++
+}
+
+func (s *ThrottledLLMStrategy) OnStartData() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.dataRunning = true
+}
+
+func (s *ThrottledLLMStrategy) OnCompleteLLM() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.llmRunning > 0 {
+		s.llmRunning--
+	}
+}
+
+func (s *ThrottledLLMStrategy) OnCompleteData() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.dataRunning = false
+}

--- a/pkg/services/workqueue/task.go
+++ b/pkg/services/workqueue/task.go
@@ -1,0 +1,165 @@
+package workqueue
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TaskStatus represents the current state of a task.
+type TaskStatus string
+
+const (
+	TaskStatusPending   TaskStatus = "pending"
+	TaskStatusRunning   TaskStatus = "running"
+	TaskStatusCompleted TaskStatus = "completed"
+	TaskStatusFailed    TaskStatus = "failed"
+	TaskStatusCancelled TaskStatus = "cancelled"
+	TaskStatusPaused    TaskStatus = "paused"
+)
+
+// Task is the interface that all work queue tasks must implement.
+type Task interface {
+	// ID returns a unique identifier for this task.
+	ID() string
+
+	// Name returns a human-readable name for display in UI.
+	Name() string
+
+	// RequiresLLM returns true if this task makes LLM API calls.
+	// Only one LLM task can run at a time.
+	RequiresLLM() bool
+
+	// Execute runs the task. It receives:
+	// - ctx: context for cancellation
+	// - enqueuer: allows the task to enqueue follow-up tasks
+	// Returns an error if the task fails.
+	Execute(ctx context.Context, enqueuer TaskEnqueuer) error
+}
+
+// TaskEnqueuer allows tasks to enqueue follow-up tasks.
+type TaskEnqueuer interface {
+	Enqueue(task Task)
+}
+
+// TaskState holds the runtime state of a task.
+type TaskState struct {
+	Task        Task
+	Status      TaskStatus
+	StartedAt   *time.Time
+	CompletedAt *time.Time
+	Error       error
+
+	mu sync.RWMutex
+}
+
+// NewTaskState creates a new TaskState wrapping a task.
+func NewTaskState(task Task) *TaskState {
+	return &TaskState{
+		Task:   task,
+		Status: TaskStatusPending,
+	}
+}
+
+// GetStatus returns the current status (thread-safe).
+func (ts *TaskState) GetStatus() TaskStatus {
+	ts.mu.RLock()
+	defer ts.mu.RUnlock()
+	return ts.Status
+}
+
+// SetStatus updates the status and timestamps (thread-safe).
+func (ts *TaskState) SetStatus(status TaskStatus) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	ts.Status = status
+	now := time.Now()
+
+	switch status {
+	case TaskStatusRunning:
+		ts.StartedAt = &now
+	case TaskStatusCompleted, TaskStatusFailed, TaskStatusCancelled, TaskStatusPaused:
+		ts.CompletedAt = &now
+	}
+}
+
+// SetError sets the error (thread-safe).
+func (ts *TaskState) SetError(err error) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	ts.Error = err
+}
+
+// GetError returns the error (thread-safe).
+func (ts *TaskState) GetError() error {
+	ts.mu.RLock()
+	defer ts.mu.RUnlock()
+	return ts.Error
+}
+
+// Snapshot returns an immutable copy of the task state.
+func (ts *TaskState) Snapshot() TaskSnapshot {
+	ts.mu.RLock()
+	defer ts.mu.RUnlock()
+
+	var errMsg string
+	if ts.Error != nil {
+		errMsg = ts.Error.Error()
+	}
+
+	return TaskSnapshot{
+		ID:          ts.Task.ID(),
+		Name:        ts.Task.Name(),
+		RequiresLLM: ts.Task.RequiresLLM(),
+		Status:      ts.Status,
+		StartedAt:   ts.StartedAt,
+		CompletedAt: ts.CompletedAt,
+		Error:       errMsg,
+	}
+}
+
+// TaskSnapshot is an immutable view of task state for serialization.
+type TaskSnapshot struct {
+	ID          string     `json:"id"`
+	Name        string     `json:"name"`
+	RequiresLLM bool       `json:"requires_llm"`
+	Status      TaskStatus `json:"status"`
+	StartedAt   *time.Time `json:"started_at,omitempty"`
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+	Error       string     `json:"error,omitempty"`
+}
+
+// BaseTask provides common task functionality.
+// Embed this in concrete task implementations.
+type BaseTask struct {
+	id          string
+	name        string
+	requiresLLM bool
+}
+
+// NewBaseTask creates a new base task.
+func NewBaseTask(name string, requiresLLM bool) BaseTask {
+	return BaseTask{
+		id:          uuid.New().String(),
+		name:        name,
+		requiresLLM: requiresLLM,
+	}
+}
+
+// ID returns the task ID.
+func (t BaseTask) ID() string {
+	return t.id
+}
+
+// Name returns the task name.
+func (t BaseTask) Name() string {
+	return t.name
+}
+
+// RequiresLLM returns whether this task needs exclusive LLM access.
+func (t BaseTask) RequiresLLM() bool {
+	return t.requiresLLM
+}

--- a/test/docker/engine-test-db/Dockerfile
+++ b/test/docker/engine-test-db/Dockerfile
@@ -20,8 +20,27 @@ RUN echo '#!/bin/sh' > /docker-entrypoint-initdb.d/00-restore.sh && \
     echo 'echo "Creating ekaya_engine_test for engine integration tests..."' >> /docker-entrypoint-initdb.d/00-restore.sh && \
     echo 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "CREATE DATABASE ekaya_engine_test;"' >> /docker-entrypoint-initdb.d/00-restore.sh && \
     echo 'echo "ekaya_engine_test created successfully"' >> /docker-entrypoint-initdb.d/00-restore.sh && \
-    echo 'echo "EKAYA_TEST_DB_READY"' >> /docker-entrypoint-initdb.d/00-restore.sh && \
     chmod +x /docker-entrypoint-initdb.d/00-restore.sh
+
+# Create a startup wrapper that waits for PostgreSQL to fully restart after init
+# PostgreSQL starts twice: once for init (creating databases), then restarts for normal operation.
+# We need to wait for the second "ready" state, which we detect by:
+# 1. Waiting for pg_isready to succeed (database exists = init scripts ran)
+# 2. Waiting for pg_isready to fail (postgres is restarting)
+# 3. Waiting for pg_isready to succeed again (postgres restarted, truly ready)
+RUN echo '#!/bin/sh' > /usr/local/bin/startup-wrapper.sh && \
+    echo 'docker-entrypoint.sh postgres &' >> /usr/local/bin/startup-wrapper.sh && \
+    echo 'PG_PID=$!' >> /usr/local/bin/startup-wrapper.sh && \
+    echo '# Phase 1: Wait for init to complete (ekaya_engine_test exists)' >> /usr/local/bin/startup-wrapper.sh && \
+    echo 'while ! pg_isready -U ekaya -d ekaya_engine_test -q 2>/dev/null; do sleep 0.2; done' >> /usr/local/bin/startup-wrapper.sh && \
+    echo '# Phase 2: Wait for postgres restart (connection will fail during restart)' >> /usr/local/bin/startup-wrapper.sh && \
+    echo 'sleep 1' >> /usr/local/bin/startup-wrapper.sh && \
+    echo 'while pg_isready -U ekaya -d ekaya_engine_test -q 2>/dev/null; do sleep 0.2; done' >> /usr/local/bin/startup-wrapper.sh && \
+    echo '# Phase 3: Wait for postgres to come back up' >> /usr/local/bin/startup-wrapper.sh && \
+    echo 'while ! pg_isready -U ekaya -d ekaya_engine_test -q 2>/dev/null; do sleep 0.2; done' >> /usr/local/bin/startup-wrapper.sh && \
+    echo 'echo "EKAYA_TEST_DB_READY"' >> /usr/local/bin/startup-wrapper.sh && \
+    echo 'wait $PG_PID' >> /usr/local/bin/startup-wrapper.sh && \
+    chmod +x /usr/local/bin/startup-wrapper.sh
 
 # Expose PostgreSQL port
 EXPOSE 5432
@@ -29,3 +48,6 @@ EXPOSE 5432
 # Health check
 HEALTHCHECK --interval=5s --timeout=5s --retries=5 \
     CMD pg_isready -U ekaya -d test_data || exit 1
+
+# Use the wrapper script as the entrypoint
+ENTRYPOINT ["/usr/local/bin/startup-wrapper.sh"]

--- a/ui/src/components/ontology/WorkQueue.tsx
+++ b/ui/src/components/ontology/WorkQueue.tsx
@@ -10,6 +10,7 @@ import {
   Check,
   Circle,
   Loader2,
+  Pause,
   RefreshCw,
   Star,
   XCircle,
@@ -114,6 +115,8 @@ const getTaskStatusIcon = (status: TaskStatus, requiresLlm: boolean) => {
       );
     case 'queued':
       return <Circle className="h-4 w-4 text-text-tertiary" />;
+    case 'paused':
+      return <Pause className="h-4 w-4 text-amber-500" />;
     case 'failed':
       return <XCircle className="h-4 w-4 text-red-500" />;
     default:
@@ -129,6 +132,8 @@ const getTaskStatusLabel = (status: TaskStatus): string => {
       return 'Processing';
     case 'queued':
       return 'Queued';
+    case 'paused':
+      return 'Paused';
     case 'failed':
       return 'Failed';
     default:
@@ -140,6 +145,8 @@ const getTaskRowBackground = (status: TaskStatus): string => {
   switch (status) {
     case 'processing':
       return 'bg-blue-500/5 border-l-2 border-l-blue-500';
+    case 'paused':
+      return 'bg-amber-500/5 border-l-2 border-l-amber-500';
     case 'failed':
       return 'bg-red-500/5 border-l-2 border-l-red-500';
     default:
@@ -147,12 +154,13 @@ const getTaskRowBackground = (status: TaskStatus): string => {
   }
 };
 
-// Sort priority: processing > queued > complete > failed
+// Sort priority: processing > paused > queued > complete > failed
 const taskStatusPriority: Record<TaskStatus, number> = {
   processing: 0,
-  queued: 1,
-  complete: 2,
-  failed: 3,
+  paused: 1,
+  queued: 2,
+  complete: 3,
+  failed: 4,
 };
 
 // ============================================================================
@@ -288,9 +296,11 @@ const WorkQueue = ({ items, taskItems, maxHeight = '400px' }: WorkQueueProps) =>
                         ? 'bg-green-100 text-green-700'
                         : task.status === 'processing'
                           ? 'bg-blue-100 text-blue-700'
-                          : task.status === 'failed'
-                            ? 'bg-red-100 text-red-700'
-                            : 'bg-surface-tertiary text-text-secondary'
+                          : task.status === 'paused'
+                            ? 'bg-amber-100 text-amber-700'
+                            : task.status === 'failed'
+                              ? 'bg-red-100 text-red-700'
+                              : 'bg-surface-tertiary text-text-secondary'
                     }`}
                   >
                     {getTaskStatusLabel(task.status)}
@@ -400,7 +410,7 @@ const WorkQueue = ({ items, taskItems, maxHeight = '400px' }: WorkQueueProps) =>
   );
 
   return (
-    <div className="rounded-lg border border-border-light bg-surface-primary shadow-sm">
+    <div className="rounded-lg border border-border-light bg-surface-primary shadow-sm flex flex-col" style={{ minHeight: maxHeight }}>
       {useTaskQueue ? renderTaskQueue() : renderEntityQueue()}
     </div>
   );

--- a/ui/src/pages/OntologyPage.tsx
+++ b/ui/src/pages/OntologyPage.tsx
@@ -3,7 +3,7 @@
  * Living document with work queue model
  */
 
-import { ArrowLeft, Brain, CheckCircle, Play } from 'lucide-react';
+import { AlertTriangle, ArrowLeft, Brain, CheckCircle, Play, RefreshCw, X } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -13,7 +13,7 @@ import QuestionPanel from '../components/ontology/QuestionPanel';
 import WorkQueue from '../components/ontology/WorkQueue';
 import { Button } from '../components/ui/Button';
 import ontologyApi from '../services/ontologyApi';
-import { realOntologyService } from '../services/realOntologyService';
+import { ontologyService } from '../services/ontologyService';
 import type { OntologyWorkflowStatus } from '../types';
 
 const OntologyPage = () => {
@@ -23,85 +23,130 @@ const OntologyPage = () => {
   const [status, setStatus] = useState<OntologyWorkflowStatus | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const [hasPendingQuestions, setHasPendingQuestions] = useState(false);
   const [allQuestionsComplete, setAllQuestionsComplete] = useState(false);
+  const [projectDescription, setProjectDescription] = useState('');
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [showCancelConfirm, setShowCancelConfirm] = useState(false);
 
   // Initialize and subscribe to status updates
   useEffect(() => {
+    let isMounted = true;
+
     const initializeService = async () => {
+      if (!pid) return;
+
       setIsLoading(true);
       setError(null);
+      setFetchError(null);
 
       try {
-        if (pid) {
-          await realOntologyService.initialize(pid);
+        // First, check if the API is reachable before initializing the service
+        // This catches connection errors that initialize() swallows internally
+        const statusResponse = await ontologyApi.getStatus(pid);
 
-          // Check for pending questions
-          const nextQuestionResponse = await ontologyApi.getNextQuestion(pid);
-          if (nextQuestionResponse.all_complete) {
-            setHasPendingQuestions(false);
-            setAllQuestionsComplete(true);
-          } else if (nextQuestionResponse.question) {
-            setHasPendingQuestions(true);
-            setAllQuestionsComplete(false);
-          }
+        if (!isMounted) return;
+
+        // API is reachable, now initialize the service
+        await ontologyService.initialize(pid);
+
+        if (!isMounted) return;
+
+        // Check for pending questions
+        const nextQuestionResponse = await ontologyApi.getNextQuestion(pid);
+
+        if (!isMounted) return;
+
+        // Only show "all complete" if ontology is actually ready
+        const ontologyIsReady = statusResponse.ontology_ready ?? false;
+
+        if (nextQuestionResponse.all_complete && ontologyIsReady) {
+          setHasPendingQuestions(false);
+          setAllQuestionsComplete(true);
+        } else if (nextQuestionResponse.question) {
+          setHasPendingQuestions(true);
+          setAllQuestionsComplete(false);
+        } else {
+          // No questions yet, and ontology not ready - we're still building
+          setHasPendingQuestions(false);
+          setAllQuestionsComplete(false);
         }
       } catch (e) {
+        if (!isMounted) return;
         console.error('Failed to initialize ontology service:', e);
-        // Don't show error - service will show idle state
+        const errorMessage = e instanceof Error && e.message.includes('Failed to fetch')
+          ? 'Service is currently down.'
+          : 'Unable to connect to the ontology service.';
+        setFetchError(errorMessage);
       } finally {
-        setIsLoading(false);
+        if (isMounted) {
+          setIsLoading(false);
+        }
       }
     };
 
     void initializeService();
 
     // Subscribe to status updates
-    const unsubscribe = realOntologyService.subscribe((newStatus) => {
-      setStatus(newStatus);
+    const unsubscribe = ontologyService.subscribe((newStatus) => {
+      if (isMounted) {
+        setStatus(newStatus);
+      }
     });
 
     return () => {
+      isMounted = false;
       unsubscribe();
-      realOntologyService.stop();
+      ontologyService.stop();
     };
   }, [pid]);
 
   const handleStart = useCallback(async () => {
     setError(null);
+
     try {
-      await realOntologyService.startExtraction();
+      await ontologyService.startExtraction(projectDescription);
     } catch (e) {
       console.error('Failed to start extraction:', e);
-      setError('Failed to start extraction. Please try again.');
+      // Handle the "no_datasource_configured" error specially
+      const error = e as Error & { data?: { error?: string } };
+      if (error.data?.error === 'no_datasource_configured') {
+        setError('No datasource configured. Please set up a database connection first.');
+      } else {
+        setError('Failed to start extraction. Please try again.');
+      }
+    }
+  }, [projectDescription]);
+
+  const handleCancel = useCallback(() => {
+    setShowCancelConfirm(true);
+  }, []);
+
+  const handleCancelConfirm = useCallback(async () => {
+    try {
+      await ontologyService.cancel();
+      setShowCancelConfirm(false);
+    } catch (e) {
+      console.error('Failed to cancel:', e);
+      setShowCancelConfirm(false);
+      setError('Failed to cancel extraction. Please try again.');
     }
   }, []);
 
-  const handlePause = useCallback(async () => {
+  const handleDeleteOntology = useCallback(async () => {
     try {
-      await realOntologyService.cancel();
+      await ontologyService.deleteOntology();
+      setShowDeleteConfirm(false);
+      setHasPendingQuestions(false);
+      setAllQuestionsComplete(false);
     } catch (e) {
-      console.error('Failed to pause:', e);
+      console.error('Failed to delete ontology:', e);
     }
   }, []);
 
-  const handleResume = useCallback(async () => {
-    try {
-      await realOntologyService.startExtraction();
-    } catch (e) {
-      console.error('Failed to resume:', e);
-    }
-  }, []);
-
-  const handleRestart = useCallback(async () => {
-    setError(null);
-    try {
-      await realOntologyService.restart();
-    } catch (e) {
-      console.error('Failed to restart:', e);
-      setError('Failed to restart extraction. Please try again.');
-    }
-  }, []);
+  // TODO: handleRefresh removed - refresh button hidden until incremental refresh is implemented
+  // Workaround: Delete and rebuild from scratch
 
   // Handlers for real-time ontology updates from chat
   const handleOntologyUpdate = useCallback((update: { entity: string; field: string; summary: string }) => {
@@ -125,15 +170,118 @@ const OntologyPage = () => {
     console.log('Question answered:', questionId, actionsSummary);
   }, []);
 
+  // Handler for retrying after fetch error
+  const handleRetry = useCallback(async () => {
+    if (!pid) return;
+
+    setIsLoading(true);
+    setFetchError(null);
+
+    try {
+      // First check if API is reachable
+      const statusResponse = await ontologyApi.getStatus(pid);
+
+      // API is reachable, initialize the service
+      await ontologyService.initialize(pid);
+
+      // Check for pending questions
+      const nextQuestionResponse = await ontologyApi.getNextQuestion(pid);
+
+      const ontologyIsReady = statusResponse.ontology_ready ?? false;
+
+      if (nextQuestionResponse.all_complete && ontologyIsReady) {
+        setHasPendingQuestions(false);
+        setAllQuestionsComplete(true);
+      } else if (nextQuestionResponse.question) {
+        setHasPendingQuestions(true);
+        setAllQuestionsComplete(false);
+      } else {
+        setHasPendingQuestions(false);
+        setAllQuestionsComplete(false);
+      }
+    } catch (e) {
+      console.error('Retry failed:', e);
+      const errorMessage = e instanceof Error && e.message.includes('Failed to fetch')
+        ? 'Service is currently down.'
+        : 'Unable to connect to the ontology service.';
+      setFetchError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [pid]);
+
   const isIdle = status?.progress.state === 'idle';
+  const isError = status?.progress.state === 'error';
+  const isComplete = status?.progress.state === 'complete';
   const isRunning =
     status?.progress.state === 'building' || status?.progress.state === 'initializing';
+  const isOntologyReady = status?.ontologyReady ?? false;
+
+  // Re-check for pending questions when workflow completes
+  useEffect(() => {
+    if (!pid || !isComplete || !isOntologyReady) return;
+
+    const checkPendingQuestions = async () => {
+      try {
+        const nextQuestionResponse = await ontologyApi.getNextQuestion(pid);
+        if (nextQuestionResponse.question) {
+          setHasPendingQuestions(true);
+          setAllQuestionsComplete(false);
+        } else if (nextQuestionResponse.all_complete) {
+          setHasPendingQuestions(false);
+          setAllQuestionsComplete(true);
+        }
+      } catch (e) {
+        console.error('Failed to check pending questions:', e);
+      }
+    };
+
+    void checkPendingQuestions();
+  }, [pid, isComplete, isOntologyReady]);
 
   if (isLoading) {
     return (
       <div className="mx-auto max-w-7xl">
         <div className="flex items-center justify-center h-64">
           <div className="text-text-secondary">Loading...</div>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state - unable to fetch ontology status (initial load or polling error)
+  if (fetchError || isError) {
+    const errorMessage = fetchError ?? status?.lastError ?? 'Unable to connect to the ontology service.';
+    return (
+      <div className="mx-auto max-w-7xl">
+        <div className="mb-6">
+          <Button
+            variant="ghost"
+            onClick={() => navigate(`/projects/${pid}`)}
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Dashboard
+          </Button>
+        </div>
+
+        <div className="rounded-lg border border-border-light bg-surface-primary shadow-sm p-12">
+          <AlertTriangle className="h-16 w-16 text-red-400 mx-auto mb-4" />
+          <h2 className="text-xl font-semibold text-text-primary mb-2 text-center">
+            Unable to Get Ontology
+          </h2>
+          <p className="text-text-secondary max-w-md mx-auto mb-6 text-center">
+            {errorMessage}
+          </p>
+          <div className="text-center">
+            <Button
+              onClick={() => void handleRetry()}
+              variant="outline"
+              className="gap-2"
+            >
+              <RefreshCw className="h-4 w-4" />
+              Retry
+            </Button>
+          </div>
         </div>
       </div>
     );
@@ -163,17 +311,6 @@ const OntologyPage = () => {
               Extract business knowledge from your database schema
             </p>
           </div>
-
-          {/* Start button when idle */}
-          {isIdle && (
-            <Button
-              onClick={handleStart}
-              className="bg-purple-600 hover:bg-purple-700 text-white"
-            >
-              <Play className="mr-2 h-4 w-4" />
-              Start Extraction
-            </Button>
-          )}
         </div>
 
         {/* Error banner - client-side errors */}
@@ -197,9 +334,9 @@ const OntologyPage = () => {
         <div className="mb-6">
           <OntologyStatus
             progress={status.progress}
-            onPause={handlePause}
-            onResume={handleResume}
-            onRestart={handleRestart}
+            pendingQuestionCount={status.pendingQuestionCount}
+            onCancel={handleCancel}
+            onDelete={() => setShowDeleteConfirm(true)}
           />
         </div>
       )}
@@ -218,17 +355,17 @@ const OntologyPage = () => {
 
           {/* Right column (2/3 width) - Question Panel or Chat */}
           <div className="lg:col-span-2">
-            {/* Show QuestionPanel when there are pending questions */}
-            {hasPendingQuestions && (
-              <QuestionPanel
-                projectId={pid ?? ''}
-                onAllComplete={handleAllQuestionsComplete}
-                onQuestionAnswered={handleQuestionAnswered}
-              />
-            )}
+            {/* Always show QuestionPanel - it handles its own disabled/enabled state */}
+            <QuestionPanel
+              projectId={pid ?? ''}
+              onAllComplete={handleAllQuestionsComplete}
+              onQuestionAnswered={handleQuestionAnswered}
+              pollForQuestions={isRunning}
+              workflowComplete={isComplete || isOntologyReady}
+            />
 
-            {/* Show completion banner + Chat when all questions are done */}
-            {allQuestionsComplete && (
+            {/* Show completion banner + Chat when all questions are done AND ontology is ready */}
+            {allQuestionsComplete && isOntologyReady && (
               <>
                 <div className="mb-6 rounded-lg border border-green-200 bg-green-50 p-4 flex items-center gap-3">
                   <CheckCircle className="h-6 w-6 text-green-600 flex-shrink-0" />
@@ -247,8 +384,8 @@ const OntologyPage = () => {
               </>
             )}
 
-            {/* Show Chat only when no questions exist at all (legacy behavior) */}
-            {!hasPendingQuestions && !allQuestionsComplete && (
+            {/* Show Chat only when ontology is ready and no questions exist */}
+            {isOntologyReady && !hasPendingQuestions && !allQuestionsComplete && (
               <ChatPane
                 projectId={pid ?? ''}
                 onOntologyUpdate={handleOntologyUpdate}
@@ -259,33 +396,120 @@ const OntologyPage = () => {
         </div>
       ) : (
         /* Empty state when idle */
-        <div className="rounded-lg border border-border-light bg-surface-primary shadow-sm p-12 text-center">
+        <div className="rounded-lg border border-border-light bg-surface-primary shadow-sm p-12">
           <Brain className="h-16 w-16 text-purple-300 mx-auto mb-4" />
-          <h2 className="text-xl font-semibold text-text-primary mb-2">
+          <h2 className="text-xl font-semibold text-text-primary mb-2 text-center">
             Ready to Extract Ontology
           </h2>
-          <p className="text-text-secondary max-w-md mx-auto mb-6">
-            The extraction process will analyze your database schema and build a comprehensive
-            business ontology. You may be asked questions to clarify business rules along the way.
+          <p className="text-text-secondary max-w-3xl mx-auto mb-6 text-center">
+            Before we analyze your schema, tell us about your application. Who uses it and what do
+            they do with this data? This context helps us build a more accurate business ontology.
           </p>
-          <Button
-            onClick={handleStart}
-            size="lg"
-            className="bg-purple-600 hover:bg-purple-700 text-white"
-          >
-            <Play className="mr-2 h-5 w-5" />
-            Start Extraction
-          </Button>
+
+          {/* Description textarea */}
+          <div className="max-w-3xl mx-auto mb-6">
+            <label className="block text-sm font-medium text-text-primary mb-2">
+              Describe your application
+            </label>
+            <textarea
+              value={projectDescription}
+              onChange={(e) => setProjectDescription(e.target.value.slice(0, 500))}
+              placeholder="Example: This is our e-commerce platform for B2B wholesale. Customers are businesses that purchase products in bulk, while Users are employee accounts that manage orders. We track inventory levels, pricing tiers, and order fulfillment status..."
+              className="w-full h-32 p-3 border border-border-light rounded-lg bg-surface-secondary text-text-primary placeholder:text-text-tertiary resize-none focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+              maxLength={500}
+            />
+            <div className="flex justify-between mt-1 text-sm text-text-tertiary">
+              <span>
+                {projectDescription.length < 20
+                  ? `${20 - projectDescription.length} more characters required`
+                  : 'Ready to start'}
+              </span>
+              <span>{projectDescription.length}/500</span>
+            </div>
+          </div>
+
+          <div className="text-center">
+            <Button
+              onClick={handleStart}
+              size="lg"
+              disabled={projectDescription.length < 20}
+              className="bg-purple-600 hover:bg-purple-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <Play className="mr-2 h-5 w-5" />
+              Start Extraction
+            </Button>
+          </div>
         </div>
       )}
 
-      {/* Info panel when running - chat is available */}
-      {isRunning && (
+      {/* Info panel when ontology is ready - chat is available */}
+      {isOntologyReady && (
         <div className="mt-6 rounded-lg border border-purple-200 bg-purple-50 p-4">
           <p className="text-purple-800 text-sm">
             <strong>Chat available:</strong> Use the chat panel to answer questions about your data.
             The AI assistant will help clarify business rules and update the ontology in real-time.
           </p>
+        </div>
+      )}
+
+      {/* Cancel Extraction Confirmation Modal */}
+      {showCancelConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-surface-primary rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
+            <h3 className="text-lg font-semibold text-text-primary">Cancel Extraction?</h3>
+            <p className="text-text-secondary mt-2">
+              The workflow will be stopped. Any entities already analyzed will be preserved.
+            </p>
+            <div className="flex justify-end gap-3 mt-6">
+              <Button
+                variant="outline"
+                onClick={() => setShowCancelConfirm(false)}
+              >
+                Keep Running
+              </Button>
+              <Button
+                onClick={() => void handleCancelConfirm()}
+                className="bg-red-600 hover:bg-red-700 text-white"
+              >
+                Cancel Extraction
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Ontology Confirmation Modal */}
+      {showDeleteConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-surface-primary rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold text-text-primary">Delete Ontology?</h3>
+              <button
+                onClick={() => setShowDeleteConfirm(false)}
+                className="text-text-tertiary hover:text-text-primary"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <p className="text-text-secondary mb-6">
+              This will delete all ontology data, workflows, and questions for this project.
+              You&apos;ll need to start extraction from scratch. This action cannot be undone.
+            </p>
+            <div className="flex justify-end gap-3">
+              <Button
+                variant="outline"
+                onClick={() => setShowDeleteConfirm(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleDeleteOntology}
+                className="bg-red-600 hover:bg-red-700 text-white"
+              >
+                Delete Ontology
+              </Button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/ui/src/pages/ProjectDashboard.tsx
+++ b/ui/src/pages/ProjectDashboard.tsx
@@ -25,7 +25,7 @@ import {
 } from '../components/ui/Dialog';
 import { useDatasourceConnection } from '../contexts/DatasourceConnectionContext';
 import { fetchWithAuth } from '../lib/api';
-import { realOntologyService } from '../services/realOntologyService';
+import { ontologyService } from '../services/ontologyService';
 import type { OntologyWorkflowStatus } from '../types';
 
 type TileColor = 'blue' | 'green' | 'purple' | 'orange' | 'gray' | 'indigo';
@@ -157,7 +157,7 @@ const ProjectDashboard = () => {
 
   // Subscribe to ontology status for badge display
   useEffect(() => {
-    const unsubscribe = realOntologyService.subscribe((status) => {
+    const unsubscribe = ontologyService.subscribe((status) => {
       setOntologyStatus(status);
     });
     return () => {

--- a/ui/src/pages/SchemaPage.tsx
+++ b/ui/src/pages/SchemaPage.tsx
@@ -22,10 +22,7 @@ import { useDatasourceConnection } from "../contexts/DatasourceConnectionContext
 import { useToast } from "../hooks/useToast";
 import engineApi from "../services/engineApi";
 import type { SchemaTable as ApiSchemaTable } from "../types";
-import {
-  buildSelectionPayloads,
-  buildTableNameToQualified,
-} from "../utils/schemaUtils";
+import { buildSelectionPayloads } from "../utils/schemaUtils";
 
 interface Column {
   name: string;
@@ -270,12 +267,10 @@ const SchemaPage = () => {
     try {
       setIsStartingExtraction(true);
 
-      // Build schema-qualified table name lookup and selection payloads
-      const tableNameToQualified = buildTableNameToQualified(apiTables);
+      // Build selection payloads using table and column IDs
       const { tableSelections, columnSelections } = buildSelectionPayloads(
-        schemaData.tables,
-        selectionState,
-        tableNameToQualified
+        apiTables,
+        selectionState
       );
 
       // Save schema selections to database

--- a/ui/src/services/engineApi.ts
+++ b/ui/src/services/engineApi.ts
@@ -253,6 +253,8 @@ class EngineApiService {
   /**
    * Save schema selections (tables and columns) for a datasource
    * POST /api/projects/{projectId}/datasources/{datasourceId}/schema/selections
+   * @param tableSelections - Map of table ID (UUID) to selection status
+   * @param columnSelections - Map of table ID (UUID) to array of selected column IDs (UUIDs)
    */
   async saveSchemaSelections(
     projectId: string,

--- a/ui/src/services/ontologyService.ts
+++ b/ui/src/services/ontologyService.ts
@@ -1,0 +1,512 @@
+/**
+ * Ontology Service
+ * Communicates with the backend ontology extraction API
+ * Transforms backend responses to UI types for the work queue display
+ */
+
+import type {
+  EntityProgressResponse,
+  EntityStatus,
+  ExtractionQuestion,
+  OntologyWorkflowStatus,
+  TaskProgressResponse,
+  TaskStatus,
+  WorkflowProgress,
+  WorkflowQuestion,
+  WorkflowState,
+  WorkflowStatusResponse,
+  WorkItem,
+  WorkQueueTaskItem,
+} from '../types';
+
+import ontologyApi from './ontologyApi';
+
+type StatusUpdateCallback = (status: OntologyWorkflowStatus) => void;
+
+/**
+ * Transform backend entity_queue to UI WorkItem[] (LEGACY)
+ */
+function transformEntityQueue(entityQueue?: EntityProgressResponse[]): WorkItem[] {
+  if (!entityQueue) return [];
+
+  return entityQueue.map((entity) => {
+    const item: WorkItem = {
+      entityName: entity.entity_name,
+      status: entity.status as EntityStatus,
+    };
+    if (entity.token_count !== undefined) {
+      item.tokenCount = entity.token_count;
+    }
+    if (entity.last_updated !== undefined) {
+      item.lastUpdated = entity.last_updated;
+    }
+    if (entity.error_message !== undefined) {
+      item.errorMessage = entity.error_message;
+    }
+    return item;
+  });
+}
+
+/**
+ * Transform backend task_queue to UI WorkQueueTaskItem[] (NEW)
+ */
+function transformTaskQueue(taskQueue?: TaskProgressResponse[]): WorkQueueTaskItem[] {
+  if (!taskQueue) return [];
+
+  return taskQueue.map((task) => {
+    const item: WorkQueueTaskItem = {
+      id: task.id,
+      name: task.name,
+      status: task.status as TaskStatus,
+      requiresLlm: task.requires_llm,
+    };
+    if (task.started_at !== undefined) {
+      item.startedAt = task.started_at;
+    }
+    if (task.completed_at !== undefined) {
+      item.completedAt = task.completed_at;
+    }
+    if (task.error_message !== undefined) {
+      item.errorMessage = task.error_message;
+    }
+    return item;
+  });
+}
+
+/**
+ * Transform backend questions to UI ExtractionQuestion[]
+ */
+function transformQuestions(questions: WorkflowQuestion[]): ExtractionQuestion[] {
+  return questions.map((q) => {
+    const question: ExtractionQuestion = {
+      id: q.id,
+      text: q.text,
+      affects: q.affects ?? [],
+      isSubmitted: q.answered_at !== undefined && q.answered_at !== null,
+    };
+    // Note: answer is not set from backend - it's populated locally when user submits
+    return question;
+  });
+}
+
+/**
+ * Derive UI workflow state from backend status
+ */
+function deriveWorkflowState(status: WorkflowStatusResponse): WorkflowState {
+  // Check for awaiting_input state (questions need answers)
+  if (status.current_phase === 'awaiting_input' || status.status_label === 'Awaiting Input') {
+    return 'awaiting_input';
+  }
+
+  if (status.is_complete) {
+    return 'complete';
+  }
+
+  // Ontology data exists without active workflow = complete state
+  if (status.ontology_ready || status.has_result) {
+    return 'complete';
+  }
+
+  switch (status.current_phase) {
+    case 'initialized':
+      return 'initializing';
+    case 'schema_analysis':
+    case 'data_profiling':
+    case 'tier1_generation':
+    case 'tiered_ontology_generation':
+    case 'confidence_loop':
+      return 'building';
+    default:
+      if (status.status_type === 'processing') {
+        return 'building';
+      }
+      return 'idle';
+  }
+}
+
+/**
+ * Transform backend status response to UI status format
+ */
+function transformStatusToUI(
+  statusResponse: WorkflowStatusResponse,
+  questions: ExtractionQuestion[]
+): OntologyWorkflowStatus {
+  const workQueue = transformEntityQueue(statusResponse.entity_queue);
+  const taskQueue = transformTaskQueue(statusResponse.task_queue);
+  const pendingQuestions = questions.filter((q) => !q.isSubmitted);
+
+  // Use server-provided entity counts (from workflow progress)
+  // Never fall back to task counts - they measure different things
+  const progress: WorkflowProgress = {
+    state: deriveWorkflowState(statusResponse),
+    current: statusResponse.current_entity ?? 0,
+    total: statusResponse.total_entities ?? 0,
+    // Note: tokensPerSecond and timeRemainingMs not provided by backend yet
+  };
+
+  const result: OntologyWorkflowStatus = {
+    progress,
+    workQueue,
+    taskQueue,
+    questions,
+    pendingQuestionCount: pendingQuestions.length,
+    // UX improvement fields
+    ontologyReady: statusResponse.ontology_ready ?? false,
+  };
+
+  // Only set progressMessage if defined
+  if (statusResponse.progress_message !== undefined) {
+    result.progressMessage = statusResponse.progress_message;
+  }
+
+  if (statusResponse.errors !== undefined) {
+    result.errors = statusResponse.errors;
+  }
+  if (statusResponse.last_error !== undefined) {
+    result.lastError = statusResponse.last_error;
+  }
+
+  return result;
+}
+
+class OntologyService {
+  private projectId: string | null = null;
+  private status: OntologyWorkflowStatus;
+  private onStatusUpdate: StatusUpdateCallback | null = null;
+  private pollingInterval: ReturnType<typeof setInterval> | null = null;
+  private pollIntervalMs: number = 2000; // Poll every 2 seconds
+
+  constructor() {
+    this.status = this.createIdleStatus();
+  }
+
+  private createIdleStatus(): OntologyWorkflowStatus {
+    return {
+      progress: {
+        state: 'idle',
+        current: 0,
+        total: 0,
+      },
+      workQueue: [],
+      taskQueue: [],
+      questions: [],
+      pendingQuestionCount: 0,
+    };
+  }
+
+  /**
+   * Set the project ID for API calls
+   */
+  setProjectId(projectId: string): void {
+    this.projectId = projectId;
+  }
+
+  /**
+   * Subscribe to status updates
+   */
+  subscribe(callback: StatusUpdateCallback): () => void {
+    this.onStatusUpdate = callback;
+    // Immediately emit current status
+    callback(this.status);
+    return () => {
+      this.onStatusUpdate = null;
+    };
+  }
+
+  private emitUpdate(): void {
+    if (this.onStatusUpdate) {
+      this.onStatusUpdate({ ...this.status });
+    }
+  }
+
+  /**
+   * Get current status (for one-time reads)
+   */
+  getStatus(): OntologyWorkflowStatus {
+    return { ...this.status };
+  }
+
+  /**
+   * Fetch status from backend and update UI
+   */
+  private async fetchAndUpdateStatus(): Promise<void> {
+    if (!this.projectId) {
+      console.warn('RealOntologyService: projectId not set');
+      return;
+    }
+
+    try {
+      // Fetch status
+      const statusResponse = await ontologyApi.getStatus(this.projectId);
+
+      // Fetch questions if workflow is active or has pending questions
+      let questions: ExtractionQuestion[] = [];
+      if (!statusResponse.is_complete || (statusResponse.pending_questions_count ?? 0) > 0) {
+        try {
+          const questionsResponse = await ontologyApi.getQuestions(this.projectId);
+          // Flatten questions from priority groups
+          const allQuestions: WorkflowQuestion[] = [
+            ...(questionsResponse.questions.critical ?? []),
+            ...(questionsResponse.questions.high ?? []),
+            ...(questionsResponse.questions.medium ?? []),
+            ...(questionsResponse.questions.low ?? []),
+          ];
+          questions = transformQuestions(allQuestions);
+        } catch (e) {
+          // Questions endpoint may fail if no active workflow
+          console.debug('Could not fetch questions:', e);
+        }
+      }
+
+      // Transform to UI format
+      this.status = transformStatusToUI(statusResponse, questions);
+      this.emitUpdate();
+
+      // Stop polling if workflow is in a terminal state (not awaiting_input)
+      // Keep polling for awaiting_input since answers may come in
+      if (statusResponse.is_complete && this.status.progress.state !== 'awaiting_input') {
+        this.stopPolling();
+      }
+    } catch (error) {
+      console.error('Error fetching ontology status:', error);
+      // On error, set error state so UI can show error screen
+      const errorMessage = error instanceof Error && error.message.includes('Failed to fetch')
+        ? 'Service is currently down.'
+        : 'Unable to connect to the ontology service.';
+      this.status = {
+        ...this.status,
+        progress: {
+          ...this.status.progress,
+          state: 'error',
+        },
+        lastError: errorMessage,
+      };
+      this.emitUpdate();
+      // Stop polling on connection error - user will need to retry
+      this.stopPolling();
+    }
+  }
+
+  /**
+   * Start polling for status updates
+   */
+  private startPolling(): void {
+    if (this.pollingInterval) {
+      clearInterval(this.pollingInterval);
+    }
+
+    // Fetch immediately
+    void this.fetchAndUpdateStatus();
+
+    // Then poll at interval
+    this.pollingInterval = setInterval(() => {
+      void this.fetchAndUpdateStatus();
+    }, this.pollIntervalMs);
+  }
+
+  /**
+   * Stop polling
+   */
+  private stopPolling(): void {
+    if (this.pollingInterval) {
+      clearInterval(this.pollingInterval);
+      this.pollingInterval = null;
+    }
+  }
+
+  /**
+   * Start the extraction workflow
+   * Note: Datasource is configured at project level, not passed per-request
+   */
+  async startExtraction(projectDescription?: string): Promise<void> {
+    if (!this.projectId) {
+      throw new Error('Project ID not set');
+    }
+
+    // Update status to initializing
+    this.status = {
+      ...this.createIdleStatus(),
+      progress: {
+        state: 'initializing',
+        current: 0,
+        total: 0,
+        startedAt: new Date().toISOString(),
+      },
+    };
+    this.emitUpdate();
+
+    try {
+      // Call backend to start extraction - datasource comes from project config
+      await ontologyApi.extractOntology(
+        this.projectId,
+        projectDescription ? { projectDescription } : undefined
+      );
+
+      // Start polling for status updates
+      this.startPolling();
+    } catch (error) {
+      console.error('Failed to start extraction:', error);
+      this.status = this.createIdleStatus();
+      this.emitUpdate();
+      throw error;
+    }
+  }
+
+  /**
+   * Cancel the extraction (equivalent to pause/stop)
+   */
+  async cancel(): Promise<void> {
+    if (!this.projectId) {
+      throw new Error('Project ID not set');
+    }
+
+    try {
+      await ontologyApi.cancelWorkflow(this.projectId);
+      this.stopPolling();
+
+      // Update status to idle
+      this.status = this.createIdleStatus();
+      this.emitUpdate();
+    } catch (error) {
+      console.error('Failed to cancel workflow:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Refresh the extraction (cancel + start)
+   * Used to continue building ontology from existing state
+   */
+  async refresh(): Promise<void> {
+    if (!this.projectId) {
+      throw new Error('Project ID not set');
+    }
+
+    try {
+      // Try to cancel any existing workflow
+      try {
+        await ontologyApi.cancelWorkflow(this.projectId);
+      } catch {
+        // Ignore cancel errors (workflow may not exist)
+      }
+
+      // Start new extraction
+      await this.startExtraction();
+    } catch (error) {
+      console.error('Failed to refresh extraction:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Delete all ontology data for the project
+   */
+  async deleteOntology(): Promise<void> {
+    if (!this.projectId) {
+      throw new Error('Project ID not set');
+    }
+
+    try {
+      await ontologyApi.deleteOntology(this.projectId);
+      this.stopPolling();
+
+      // Reset to idle state
+      this.status = this.createIdleStatus();
+      this.emitUpdate();
+    } catch (error) {
+      console.error('Failed to delete ontology:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Submit an answer to a question
+   */
+  async submitAnswer(questionId: string, answer: string, _file?: File): Promise<void> {
+    if (!this.projectId) {
+      throw new Error('Project ID not set');
+    }
+
+    try {
+      await ontologyApi.submitProjectAnswers(this.projectId, {
+        answers: [{ question_id: questionId, answer }],
+      });
+
+      // Mark question as submitted locally
+      const questionIndex = this.status.questions.findIndex((q) => q.id === questionId);
+      if (questionIndex >= 0 && this.status.questions[questionIndex]) {
+        this.status.questions[questionIndex].isSubmitted = true;
+        this.status.questions[questionIndex].answer = answer;
+        this.status.pendingQuestionCount = Math.max(0, this.status.pendingQuestionCount - 1);
+
+        // Mark affected entities as updating
+        const question = this.status.questions[questionIndex];
+        if (question.affects) {
+          for (const entityName of question.affects) {
+            const entityIndex = this.status.workQueue.findIndex(
+              (w) => w.entityName === entityName
+            );
+            if (entityIndex >= 0 && this.status.workQueue[entityIndex]) {
+              const entity = this.status.workQueue[entityIndex];
+              if (entity.status === 'complete') {
+                entity.status = 'updating';
+              }
+            }
+          }
+        }
+
+        this.emitUpdate();
+      }
+
+      // Continue polling to get updated status
+      this.startPolling();
+    } catch (error) {
+      console.error('Failed to submit answer:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Stop and clean up
+   */
+  stop(): void {
+    this.stopPolling();
+    this.status = this.createIdleStatus();
+    this.emitUpdate();
+  }
+
+  /**
+   * Initialize service for a project and check for existing workflow
+   */
+  async initialize(projectId: string): Promise<void> {
+    this.setProjectId(projectId);
+
+    try {
+      // Check if there's an existing workflow
+      const statusResponse = await ontologyApi.getStatus(projectId);
+
+      // If workflow exists and is not complete, start polling
+      if (statusResponse.workflow_id && !statusResponse.is_complete) {
+        this.startPolling();
+      } else if (statusResponse.workflow_id || statusResponse.ontology_ready || statusResponse.has_result) {
+        // Workflow complete OR no workflow but ontology data exists - fetch status once
+        await this.fetchAndUpdateStatus();
+      }
+    } catch {
+      // No existing workflow, stay in idle state
+      this.status = this.createIdleStatus();
+      this.emitUpdate();
+    }
+  }
+
+  /**
+   * Get pending question count (for dashboard badge)
+   */
+  getPendingQuestionCount(): number {
+    return this.status.pendingQuestionCount;
+  }
+}
+
+// Export singleton instance
+export const ontologyService = new OntologyService();
+export default ontologyService;


### PR DESCRIPTION
## Summary
- Implement complete LLM-powered ontology extraction workflow
- Add parallel work queue with configurable concurrency for entity processing
- Create chat interface for ontology refinement with knowledge persistence
- Add comprehensive question system for user clarification during extraction
- Build workflow orchestration with state tracking per entity

## Key Components

### Backend
- **Workflow Orchestrator**: Manages extraction lifecycle with parallel processing
- **Work Queue**: Priority-based task queue with configurable parallelism
- **Ontology Builder**: LLM integration for entity analysis and summary generation
- **Chat Service**: SSE streaming chat with tool execution for ontology refinement
- **Question System**: Decoupled question management for user clarification
- **Knowledge Repository**: Persistent storage for project-level facts

### Frontend
- **Ontology Page**: Real-time workflow status and progress tracking
- **Question Panel**: Interactive Q&A interface during extraction
- **Work Queue Visualization**: Live view of parallel processing tasks

### Database
- New tables: `engine_ontology_workflows`, `engine_ontologies`, `engine_ontology_chat_messages`, `engine_workflow_state`, `engine_ontology_questions`, `engine_project_knowledge`, `engine_llm_conversations`

## Testing
- Comprehensive unit tests for all new services and repositories
- Integration tests using testcontainers for database operations
- All existing tests pass (`make check` and `make test-integration`)

## Notes
- Test container Dockerfile updated to fix race condition during PostgreSQL initialization
- The test image needs to be pushed with `make push-test-image` for CI/CD

🤖 Generated with [Claude Code](https://claude.com/claude-code)