### PR TITLE
Add comprehensive MCP interface plans for text-to-SQL

### DIFF
--- a/PLAN-mcp-auditing.md
+++ b/PLAN-mcp-auditing.md
@@ -1,0 +1,449 @@
+# PLAN: MCP Auditing & Governance
+
+## Purpose
+
+Provide administrators with complete visibility into MCP access and queries for governance, compliance, and security purposes. This creates an audit trail of all AI-assisted database access.
+
+**Key Stakeholders:**
+- Security teams: Who accessed what data and when
+- Compliance officers: Audit trails for SOC2, HIPAA, etc.
+- Project admins: Understanding usage patterns and preventing abuse
+
+---
+
+## Audit Events to Capture
+
+### Connection Events
+| Event | Data Captured |
+|-------|--------------|
+| `mcp_session_start` | User ID, client info, timestamp, project |
+| `mcp_session_end` | Duration, total queries, errors encountered |
+| `mcp_auth_failure` | Attempted user, reason, client IP |
+
+### Tool Invocations
+| Event | Data Captured |
+|-------|--------------|
+| `tool_call` | Tool name, parameters (sanitized), user, timestamp |
+| `tool_success` | Tool name, duration, result summary |
+| `tool_error` | Tool name, error type, error message |
+
+### Query Events
+| Event | Data Captured |
+|-------|--------------|
+| `query_generated` | Natural language, generated SQL, tables accessed |
+| `query_executed` | SQL, execution time, row count, success/failure |
+| `query_blocked` | SQL, reason (policy violation, rate limit, etc.) |
+| `approved_query_executed` | Query ID, parameters, result summary |
+
+### Security Events
+| Event | Data Captured |
+|-------|--------------|
+| `sql_injection_attempt` | Detected pattern, parameter values, user |
+| `rate_limit_hit` | User, limit type, window |
+| `unauthorized_table_access` | Table name, user, query |
+| `sensitive_data_access` | Column flagged as sensitive, query context |
+
+---
+
+## Data Model
+
+### New Table: `engine_mcp_audit_log`
+
+```sql
+CREATE TABLE engine_mcp_audit_log (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES engine_projects(id),
+
+    -- Who
+    user_id VARCHAR(255) NOT NULL,
+    user_email VARCHAR(255),
+    session_id VARCHAR(255),  -- Groups events in same session
+
+    -- What
+    event_type VARCHAR(50) NOT NULL,  -- See events above
+    tool_name VARCHAR(100),
+
+    -- Request details
+    request_params JSONB,  -- Sanitized parameters
+    natural_language TEXT,  -- If query-related
+    sql_query TEXT,  -- If query-related (sanitized)
+
+    -- Response details
+    was_successful BOOLEAN NOT NULL DEFAULT true,
+    error_message TEXT,
+    result_summary JSONB,  -- {"row_count": 100, "tables_accessed": ["users"]}
+
+    -- Performance
+    duration_ms INTEGER,
+
+    -- Security classification
+    security_level VARCHAR(20) DEFAULT 'normal',  -- 'normal', 'warning', 'alert'
+    security_flags TEXT[],  -- ['sensitive_data', 'large_result', 'new_table']
+
+    -- Context
+    client_info JSONB,  -- User agent, IP (if available), MCP client version
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Partitioning support
+    partition_key DATE NOT NULL DEFAULT CURRENT_DATE
+) PARTITION BY RANGE (partition_key);
+
+-- Create monthly partitions (example)
+CREATE TABLE engine_mcp_audit_log_2025_01 PARTITION OF engine_mcp_audit_log
+    FOR VALUES FROM ('2025-01-01') TO ('2025-02-01');
+
+-- Indexes for common queries
+CREATE INDEX idx_audit_project_time ON engine_mcp_audit_log(project_id, created_at DESC);
+CREATE INDEX idx_audit_user ON engine_mcp_audit_log(project_id, user_id, created_at DESC);
+CREATE INDEX idx_audit_event_type ON engine_mcp_audit_log(project_id, event_type, created_at DESC);
+CREATE INDEX idx_audit_security ON engine_mcp_audit_log(project_id, security_level, created_at DESC)
+    WHERE security_level != 'normal';
+```
+
+### Supporting Table: `engine_mcp_audit_alerts`
+
+```sql
+CREATE TABLE engine_mcp_audit_alerts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES engine_projects(id),
+
+    alert_type VARCHAR(50) NOT NULL,  -- 'sql_injection', 'rate_limit', 'unusual_access'
+    severity VARCHAR(20) NOT NULL,  -- 'info', 'warning', 'critical'
+
+    -- Alert details
+    title VARCHAR(255) NOT NULL,
+    description TEXT,
+    affected_user_id VARCHAR(255),
+    related_audit_ids UUID[],  -- References to audit_log entries
+
+    -- Resolution
+    status VARCHAR(20) NOT NULL DEFAULT 'open',  -- 'open', 'acknowledged', 'resolved', 'dismissed'
+    resolved_by VARCHAR(255),
+    resolved_at TIMESTAMPTZ,
+    resolution_notes TEXT,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+---
+
+## UI: Audit Tile on Project Dashboard
+
+### Dashboard Tile Design
+
+```
+┌─────────────────────────────────────────┐
+│ 🔍 Audit                                │
+│                                         │
+│ 1,234 queries (last 7 days)             │
+│ 12 users active                         │
+│                                         │
+│ ⚠️ 2 alerts require attention           │
+└─────────────────────────────────────────┘
+```
+
+Tile shows:
+- Query count in recent period
+- Active user count
+- Alert badge if unresolved alerts exist
+
+### Audit Page Layout
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Audit Log                                                    [Export CSV]   │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ Filters:                                                                    │
+│ [Date Range ▼] [User ▼] [Event Type ▼] [Security Level ▼] [Search...]      │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│ ┌─ Summary Cards ────────────────────────────────────────────────────────┐ │
+│ │ [Queries: 1,234] [Users: 12] [Errors: 23] [Avg Response: 145ms]       │ │
+│ └────────────────────────────────────────────────────────────────────────┘ │
+│                                                                             │
+│ ┌─ Alert Banner (if any) ────────────────────────────────────────────────┐ │
+│ │ ⚠️ 2 security alerts require attention                    [View All]  │ │
+│ └────────────────────────────────────────────────────────────────────────┘ │
+│                                                                             │
+│ Event Log:                                                                  │
+│ ┌────────────────────────────────────────────────────────────────────────┐ │
+│ │ 10:45:23  john@example.com  query_executed  ✓                          │ │
+│ │           SELECT u.name FROM users u WHERE...  (145ms, 50 rows)        │ │
+│ ├────────────────────────────────────────────────────────────────────────┤ │
+│ │ 10:44:12  john@example.com  tool_call: ontology_context  ✓             │ │
+│ │           (23ms)                                                        │ │
+│ ├────────────────────────────────────────────────────────────────────────┤ │
+│ │ 10:43:01  jane@example.com  query_blocked  ⚠️                          │ │
+│ │           Attempted access to restricted table 'salary_data'            │ │
+│ └────────────────────────────────────────────────────────────────────────┘ │
+│                                                                             │
+│ [Load More...]                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Event Detail Modal
+
+Clicking an event shows full details:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Event Details                                              [×]  │
+├─────────────────────────────────────────────────────────────────┤
+│ Event Type:    query_executed                                   │
+│ Timestamp:     2024-12-15 10:45:23 UTC                          │
+│ User:          john@example.com                                 │
+│ Session ID:    abc123...                                        │
+│ Duration:      145ms                                            │
+│ Status:        ✓ Success                                        │
+│                                                                 │
+│ Natural Language Query:                                         │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ "Show me all users who signed up last week"                 │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+│                                                                 │
+│ Generated SQL:                                                  │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ SELECT u.id, u.name, u.email, u.created_at                  │ │
+│ │ FROM users u                                                │ │
+│ │ WHERE u.created_at >= '2024-12-08'                          │ │
+│ │   AND u.created_at < '2024-12-15'                           │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+│                                                                 │
+│ Result Summary:                                                 │
+│   Rows Returned: 47                                             │
+│   Tables Accessed: users                                        │
+│                                                                 │
+│ [Copy SQL] [Re-run Query] [View User Activity]                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Alert System
+
+### Alert Types
+
+| Alert Type | Trigger | Severity |
+|------------|---------|----------|
+| `sql_injection_detected` | Injection pattern found in input | Critical |
+| `unusual_query_volume` | User exceeds normal query rate by 5x | Warning |
+| `sensitive_table_access` | Query touches flagged sensitive table | Warning |
+| `large_data_export` | Query returns > 10K rows | Info |
+| `after_hours_access` | Access outside business hours | Info |
+| `new_user_high_volume` | New user runs many queries quickly | Warning |
+| `repeated_errors` | Same error > 5 times in 10 min | Warning |
+
+### Alert Configuration (Project Settings)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Audit Alert Settings                                            │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│ ☑ SQL Injection Detection              [Critical]              │
+│   Alert on any detected injection attempt                       │
+│                                                                 │
+│ ☑ Unusual Query Volume                 [Warning]               │
+│   Threshold: [5x] normal rate within [10 min] window            │
+│                                                                 │
+│ ☐ Sensitive Table Access               [Warning]               │
+│   Tables: [Select tables...]                                    │
+│                                                                 │
+│ ☑ Large Data Export                    [Info]                  │
+│   Threshold: [10000] rows                                       │
+│                                                                 │
+│ ☐ After Hours Access                   [Info]                  │
+│   Business hours: [9:00 AM] to [6:00 PM] [America/New_York]    │
+│                                                                 │
+│ Email notifications:                                            │
+│   ☑ Critical alerts → [admin@company.com]                      │
+│   ☐ Warning alerts → [                   ]                     │
+│                                                                 │
+│                                               [Save Settings]   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## API Endpoints
+
+### List Audit Events
+```
+GET /api/projects/{pid}/audit/events
+Query params:
+  - start_date, end_date
+  - user_id
+  - event_type
+  - security_level
+  - limit, offset
+```
+
+### Get Audit Summary
+```
+GET /api/projects/{pid}/audit/summary
+Query params:
+  - start_date, end_date
+
+Response:
+{
+  "query_count": 1234,
+  "unique_users": 12,
+  "error_count": 23,
+  "avg_response_ms": 145,
+  "top_tables": [{"table": "orders", "query_count": 456}],
+  "hourly_distribution": [...]
+}
+```
+
+### List Alerts
+```
+GET /api/projects/{pid}/audit/alerts
+Query params:
+  - status: open, resolved, all
+  - severity
+```
+
+### Resolve Alert
+```
+POST /api/projects/{pid}/audit/alerts/{alert_id}/resolve
+Body:
+{
+  "resolution": "dismissed",  // or "resolved"
+  "notes": "Legitimate access by approved user"
+}
+```
+
+### Export Audit Log
+```
+GET /api/projects/{pid}/audit/export
+Query params:
+  - format: csv, json
+  - start_date, end_date
+  - event_type
+```
+
+---
+
+## Recording Implementation
+
+### Middleware Approach
+
+Create audit middleware that wraps MCP tool handlers:
+
+```go
+func AuditMiddleware(next ToolHandler, logger AuditLogger) ToolHandler {
+    return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+        start := time.Now()
+
+        // Record start
+        auditEntry := &AuditEntry{
+            EventType:     "tool_call",
+            ToolName:      req.Tool,
+            RequestParams: sanitizeParams(req.Params),
+            StartedAt:     start,
+        }
+
+        // Execute
+        result, err := next(ctx, req)
+
+        // Record completion
+        auditEntry.Duration = time.Since(start)
+        auditEntry.WasSuccessful = err == nil
+        if err != nil {
+            auditEntry.ErrorMessage = err.Error()
+        }
+
+        // Async write (don't block response)
+        go logger.Record(ctx, auditEntry)
+
+        return result, err
+    }
+}
+```
+
+### Sanitization Rules
+
+Before storing in audit log:
+1. Truncate SQL > 10KB
+2. Redact string literals if configured
+3. Preserve structure but hide values in parameters
+4. Hash user-provided values if sensitive
+
+---
+
+## Retention & Archival
+
+### Default Retention
+- Hot storage (queryable): 90 days
+- Cold storage (archived): 2 years
+- Configurable per project
+
+### Archival Process
+- Daily job moves old partitions to cold storage
+- Cold storage is compressed, read-only
+- Export available for compliance requests
+
+### GDPR Considerations
+- User deletion request: Anonymize user_id in audit logs
+- Right to access: Export endpoint includes user's audit history
+- Configurable: Option to not log certain fields
+
+---
+
+## Performance Considerations
+
+### Write Optimization
+- Async writes via channel/queue
+- Batch inserts every 100ms or 100 records
+- Don't block MCP responses on audit writes
+
+### Read Optimization
+- Partitioned by date for efficient range queries
+- Appropriate indexes for common filters
+- Consider materialized views for dashboard summaries
+
+### Storage Estimation
+- ~500 bytes per event (compressed)
+- 1M queries/month = ~500MB/month
+- Plan for growth with partitioning
+
+---
+
+## Implementation Phases
+
+### Phase 1: Core Logging
+- Create tables and migrations
+- Add audit middleware to MCP tools
+- Basic event recording (tool calls, queries)
+
+### Phase 2: UI & Viewing
+- Audit tile on dashboard
+- Audit log page with filtering
+- Event detail views
+
+### Phase 3: Alerts
+- Alert detection logic
+- Alert table and management
+- Email notifications
+
+### Phase 4: Advanced
+- Usage analytics dashboards
+- Anomaly detection
+- Export/compliance features
+
+---
+
+## File Changes Summary
+
+| Area | Changes |
+|------|---------|
+| `migrations/` | New tables for audit_log, audit_alerts |
+| `pkg/models/` | `audit.go` with event types and models |
+| `pkg/repositories/` | `audit_repository.go` |
+| `pkg/services/` | `audit_service.go` with recording logic |
+| `pkg/mcp/` | Audit middleware for tool handlers |
+| `pkg/handlers/` | `audit.go` API endpoints |
+| `ui/src/pages/` | `AuditPage.tsx` |
+| `ui/src/components/` | Audit-related components |

--- a/PLAN-mcp-data-engineering.md
+++ b/PLAN-mcp-data-engineering.md
@@ -1,0 +1,774 @@
+# PLAN: MCP Data Engineering Tools
+
+## Purpose
+
+Provide a comprehensive toolkit for Data Engineers who need full database access via MCP. This persona knows what they're doing and needs power tools, not guardrails.
+
+**Target Users:**
+- Data Engineers building ETL pipelines
+- DBAs managing schema changes
+- Analytics Engineers creating transformations
+- DevOps running migrations
+
+**Design Philosophy:** Trust but verify. Enable powerful operations with comprehensive audit logging, not with friction.
+
+---
+
+## Capabilities Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│               Data Engineering MCP Tool Suite                    │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  Schema Operations                                               │
+│  ├── CREATE TABLE/VIEW/INDEX                                     │
+│  ├── ALTER TABLE (add/drop columns, constraints)                 │
+│  ├── DROP TABLE/VIEW (with safety checks)                        │
+│  └── Schema diff and comparison                                  │
+│                                                                  │
+│  Migration Operations                                            │
+│  ├── List pending migrations                                     │
+│  ├── Run specific migration                                      │
+│  ├── Rollback migration                                          │
+│  └── Migration status and history                                │
+│                                                                  │
+│  Ontology Operations                                             │
+│  ├── Export current ontology                                     │
+│  ├── Import/install ontology                                     │
+│  ├── Validate ontology against schema                            │
+│  └── Refresh ontology from schema changes                        │
+│                                                                  │
+│  Schema Discovery                                                │
+│  ├── Full schema discovery (all tables, not just selected)       │
+│  ├── Table statistics and health                                 │
+│  ├── Foreign key analysis                                        │
+│  └── Index usage and recommendations                             │
+│                                                                  │
+│  Bulk Operations                                                 │
+│  ├── COPY data import/export                                     │
+│  ├── Bulk INSERT                                                 │
+│  ├── Table TRUNCATE                                              │
+│  └── Batch UPDATE/DELETE                                         │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Tool Group: data_engineering
+
+### Enablement
+
+This is a separate tool group with strict controls:
+
+```go
+type DataEngineeringConfig struct {
+    Enabled              bool     // Must be explicitly enabled
+    AllowedUsers         []string // Optional: restrict to specific users
+    RequireConfirmation  bool     // Require confirm_destructive for risky ops
+    AuditMode            string   // "full" (log SQL) or "summary" (log action only)
+}
+```
+
+**Enable via MCP Server page:**
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Data Engineering Tools                                          │
+├─────────────────────────────────────────────────────────────────┤
+│ ⚠️ These tools provide full database access for data engineers. │
+│    Enable only for trusted technical users.                     │
+│                                                                 │
+│ ● Enable Data Engineering Tools                          [OFF] │
+│                                                                 │
+│ ○ Require confirmation for destructive operations        [ON]  │
+│                                                                 │
+│ ○ Restrict to specific users (comma-separated emails)          │
+│   [                                                        ]    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Schema Operations
+
+### Tool: schema_discover
+
+**Purpose:** Full schema discovery without filtering
+
+```
+Input:
+{
+  "schema": "public",  // Optional: filter to schema
+  "include_system": false  // Include pg_* tables
+}
+
+Output:
+{
+  "schemas": ["public", "staging", "archive"],
+  "tables": [
+    {
+      "schema": "public",
+      "name": "users",
+      "type": "table",  // table, view, materialized_view
+      "row_count": 50000,
+      "size_bytes": 15728640,
+      "is_selected": true,  // In admin-approved schema
+      "columns": [...],
+      "indexes": [
+        {"name": "users_pkey", "columns": ["id"], "unique": true},
+        {"name": "users_email_idx", "columns": ["email"], "unique": true}
+      ],
+      "constraints": [
+        {"name": "users_pkey", "type": "primary_key", "columns": ["id"]},
+        {"name": "users_email_key", "type": "unique", "columns": ["email"]}
+      ]
+    }
+  ],
+  "foreign_keys": [
+    {
+      "name": "orders_customer_fkey",
+      "source_table": "orders",
+      "source_columns": ["customer_id"],
+      "target_table": "users",
+      "target_columns": ["id"],
+      "on_delete": "CASCADE",
+      "on_update": "NO ACTION"
+    }
+  ]
+}
+```
+
+---
+
+### Tool: schema_diff
+
+**Purpose:** Compare current schema to a reference
+
+```
+Input:
+{
+  "reference": "file",  // "file" or "snapshot"
+  "reference_id": "schema_v1.sql",  // File name or snapshot ID
+  "schemas": ["public"]  // Optional filter
+}
+
+Output:
+{
+  "changes": [
+    {
+      "type": "table_added",
+      "object": "public.new_table",
+      "details": "Table exists in current but not in reference"
+    },
+    {
+      "type": "column_added",
+      "object": "public.users.phone",
+      "details": "Column added: phone VARCHAR(20)"
+    },
+    {
+      "type": "column_modified",
+      "object": "public.users.email",
+      "details": "Type changed: VARCHAR(100) → VARCHAR(255)"
+    },
+    {
+      "type": "index_dropped",
+      "object": "public.users_name_idx",
+      "details": "Index no longer exists"
+    }
+  ],
+  "summary": {
+    "tables_added": 1,
+    "tables_dropped": 0,
+    "columns_added": 2,
+    "columns_modified": 1,
+    "indexes_changed": 1
+  }
+}
+```
+
+---
+
+### Tool: create_table
+
+**Purpose:** Create a new table with validation
+
+```
+Input:
+{
+  "schema": "staging",
+  "name": "temp_import",
+  "columns": [
+    {"name": "id", "type": "UUID", "primary_key": true, "default": "gen_random_uuid()"},
+    {"name": "data", "type": "JSONB", "nullable": true},
+    {"name": "created_at", "type": "TIMESTAMPTZ", "default": "NOW()"}
+  ],
+  "if_not_exists": true
+}
+
+Output:
+{
+  "created": true,
+  "table": "staging.temp_import",
+  "sql_executed": "CREATE TABLE IF NOT EXISTS staging.temp_import (...)"
+}
+```
+
+---
+
+### Tool: alter_table
+
+**Purpose:** Modify table structure
+
+```
+Input:
+{
+  "table": "public.users",
+  "operations": [
+    {"action": "add_column", "column": "phone", "type": "VARCHAR(20)"},
+    {"action": "drop_column", "column": "legacy_id"},
+    {"action": "rename_column", "old_name": "name", "new_name": "full_name"},
+    {"action": "add_index", "columns": ["email", "created_at"], "name": "users_email_created_idx"},
+    {"action": "add_constraint", "type": "unique", "columns": ["phone"], "name": "users_phone_key"}
+  ],
+  "confirm_destructive": true  // Required for drop operations
+}
+
+Output:
+{
+  "executed": true,
+  "operations_completed": 5,
+  "sql_executed": [
+    "ALTER TABLE public.users ADD COLUMN phone VARCHAR(20)",
+    "ALTER TABLE public.users DROP COLUMN legacy_id",
+    ...
+  ]
+}
+```
+
+---
+
+### Tool: drop_table
+
+**Purpose:** Drop tables with safety checks
+
+```
+Input:
+{
+  "table": "staging.temp_import",
+  "cascade": false,
+  "confirm_destructive": true  // Required
+}
+
+Output:
+{
+  "dropped": true,
+  "table": "staging.temp_import",
+  "cascade_dropped": [],  // Empty unless cascade: true
+  "warning": null
+}
+
+// If table has dependents and cascade: false
+Output:
+{
+  "dropped": false,
+  "error": "Table has dependent objects",
+  "dependents": [
+    {"type": "view", "name": "reports.user_summary"},
+    {"type": "foreign_key", "name": "orders_temp_fkey"}
+  ],
+  "hint": "Use cascade: true to drop dependents, or drop them first"
+}
+```
+
+---
+
+## Migration Operations
+
+### Tool: migrations_status
+
+**Purpose:** Show migration status
+
+```
+Input: {}
+
+Output:
+{
+  "current_version": "20241215_001",
+  "migrations": [
+    {
+      "version": "20241201_001",
+      "name": "add_phone_to_users",
+      "applied_at": "2024-12-01T10:00:00Z",
+      "status": "applied"
+    },
+    {
+      "version": "20241215_001",
+      "name": "create_audit_tables",
+      "applied_at": "2024-12-15T10:00:00Z",
+      "status": "applied"
+    },
+    {
+      "version": "20241220_001",
+      "name": "add_indexes_for_search",
+      "status": "pending",
+      "up_sql_preview": "CREATE INDEX CONCURRENTLY..."
+    }
+  ],
+  "pending_count": 1
+}
+```
+
+---
+
+### Tool: migrations_run
+
+**Purpose:** Apply pending migrations
+
+```
+Input:
+{
+  "target_version": "20241220_001",  // Optional: stop at this version
+  "dry_run": false,
+  "confirm": true
+}
+
+Output:
+{
+  "applied": [
+    {
+      "version": "20241220_001",
+      "name": "add_indexes_for_search",
+      "duration_ms": 5432,
+      "sql_executed": "CREATE INDEX CONCURRENTLY..."
+    }
+  ],
+  "new_version": "20241220_001"
+}
+
+// Dry run output
+{
+  "dry_run": true,
+  "would_apply": [
+    {
+      "version": "20241220_001",
+      "name": "add_indexes_for_search",
+      "up_sql": "CREATE INDEX CONCURRENTLY idx_users_search ON users USING gin(name gin_trgm_ops)"
+    }
+  ]
+}
+```
+
+---
+
+### Tool: migrations_rollback
+
+**Purpose:** Revert applied migrations
+
+```
+Input:
+{
+  "target_version": "20241215_001",  // Roll back to this version
+  "confirm_destructive": true
+}
+
+Output:
+{
+  "rolled_back": [
+    {
+      "version": "20241220_001",
+      "name": "add_indexes_for_search",
+      "down_sql_executed": "DROP INDEX CONCURRENTLY idx_users_search"
+    }
+  ],
+  "new_version": "20241215_001"
+}
+```
+
+---
+
+## Ontology Operations
+
+### Tool: ontology_export
+
+**Purpose:** Export current ontology as JSON
+
+```
+Input:
+{
+  "format": "json",  // "json" or "yaml"
+  "include_workflow_state": false
+}
+
+Output:
+{
+  "ontology": {
+    "version": 3,
+    "domain_summary": {...},
+    "entity_summaries": {...},
+    "column_details": {...}
+  },
+  "entities": [
+    {"name": "user", "primary_table": "users", "occurrences": [...]},
+    ...
+  ],
+  "relationships": [...],
+  "exported_at": "2024-12-15T10:00:00Z"
+}
+```
+
+---
+
+### Tool: ontology_import
+
+**Purpose:** Import/install ontology definitions
+
+```
+Input:
+{
+  "ontology": {
+    "domain_summary": {...},
+    "entity_summaries": {...},
+    "column_details": {...}
+  },
+  "merge_strategy": "replace",  // "replace", "merge", "validate_only"
+  "backup_current": true
+}
+
+Output:
+{
+  "imported": true,
+  "backup_id": "ontology_backup_20241215_100000",
+  "changes": {
+    "entities_added": 2,
+    "entities_updated": 5,
+    "columns_enriched": 45
+  }
+}
+```
+
+---
+
+### Tool: ontology_validate
+
+**Purpose:** Check ontology against current schema
+
+```
+Input: {}
+
+Output:
+{
+  "valid": false,
+  "issues": [
+    {
+      "severity": "error",
+      "type": "missing_table",
+      "message": "Entity 'product' references table 'products' which doesn't exist"
+    },
+    {
+      "severity": "warning",
+      "type": "column_mismatch",
+      "message": "Column 'users.status' has enum values but column type is TEXT not enum"
+    },
+    {
+      "severity": "info",
+      "type": "unmatched_table",
+      "message": "Table 'audit_logs' exists in schema but has no entity mapping"
+    }
+  ],
+  "summary": {
+    "errors": 1,
+    "warnings": 3,
+    "info": 5
+  }
+}
+```
+
+---
+
+### Tool: ontology_refresh
+
+**Purpose:** Trigger ontology refresh from schema changes
+
+```
+Input:
+{
+  "scope": "incremental",  // "full" or "incremental"
+  "tables": ["new_table"]  // Optional: limit to specific tables
+}
+
+Output:
+{
+  "workflow_id": "uuid",
+  "status": "started",
+  "message": "Ontology refresh started. Use workflow status to monitor progress."
+}
+```
+
+---
+
+## Bulk Operations
+
+### Tool: bulk_insert
+
+**Purpose:** Efficient bulk data loading
+
+```
+Input:
+{
+  "table": "staging.imports",
+  "columns": ["id", "name", "value"],
+  "data": [
+    ["uuid1", "Item 1", 100],
+    ["uuid2", "Item 2", 200],
+    ...
+  ],
+  "on_conflict": "ignore"  // "error", "ignore", "update"
+}
+
+Output:
+{
+  "inserted": 950,
+  "ignored": 50,
+  "execution_time_ms": 1234
+}
+```
+
+---
+
+### Tool: bulk_copy
+
+**Purpose:** High-performance COPY operations
+
+```
+Input:
+{
+  "direction": "export",  // "export" or "import"
+  "table": "public.orders",
+  "format": "csv",
+  "options": {
+    "header": true,
+    "delimiter": ","
+  },
+  // For export:
+  "query": "SELECT * FROM orders WHERE created_at > '2024-01-01'",
+  // For import:
+  "data": "id,name,value\nuuid1,Item1,100\n..."
+}
+
+Output (export):
+{
+  "row_count": 10000,
+  "data": "id,name,value\n...",  // or truncated with download link
+  "size_bytes": 1048576,
+  "truncated": false
+}
+
+Output (import):
+{
+  "rows_imported": 10000,
+  "execution_time_ms": 5432
+}
+```
+
+---
+
+## Raw SQL Access
+
+### Tool: raw_query
+
+**Purpose:** Execute any SQL without restrictions
+
+```
+Input:
+{
+  "sql": "SELECT pg_size_pretty(pg_total_relation_size('users'))",
+  "timeout_seconds": 60
+}
+
+Output:
+{
+  "columns": ["pg_size_pretty"],
+  "rows": [{"pg_size_pretty": "15 MB"}],
+  "row_count": 1,
+  "execution_time_ms": 12
+}
+```
+
+**No restrictions on SQL type** - the user is trusted.
+
+---
+
+### Tool: raw_execute
+
+**Purpose:** Execute any DDL/DML without restrictions
+
+```
+Input:
+{
+  "sql": "VACUUM ANALYZE users",
+  "timeout_seconds": 300,
+  "confirm_destructive": true  // Still required for safety
+}
+
+Output:
+{
+  "executed": true,
+  "message": "VACUUM",
+  "execution_time_ms": 45000
+}
+```
+
+---
+
+## Database Admin Operations
+
+### Tool: table_stats
+
+**Purpose:** Get detailed table statistics
+
+```
+Input:
+{
+  "table": "public.orders"
+}
+
+Output:
+{
+  "table": "public.orders",
+  "row_count": 1000000,
+  "dead_tuples": 15000,
+  "size": {
+    "total": "256 MB",
+    "table": "200 MB",
+    "indexes": "56 MB"
+  },
+  "last_vacuum": "2024-12-14T10:00:00Z",
+  "last_analyze": "2024-12-14T10:00:00Z",
+  "seq_scans": 145,
+  "idx_scans": 50000,
+  "hot_update_ratio": 0.85,
+  "indexes": [
+    {
+      "name": "orders_pkey",
+      "size": "20 MB",
+      "scans": 45000,
+      "rows_fetched": 45000
+    },
+    {
+      "name": "orders_customer_idx",
+      "size": "18 MB",
+      "scans": 5000,
+      "rows_fetched": 25000
+    }
+  ],
+  "recommendations": [
+    "Consider VACUUM to reclaim 15000 dead tuples",
+    "Index orders_created_idx has low usage (50 scans) - consider dropping"
+  ]
+}
+```
+
+---
+
+### Tool: index_recommendations
+
+**Purpose:** Suggest index improvements
+
+```
+Input:
+{
+  "table": "public.orders",  // Optional: all tables if not specified
+  "analyze_queries": true  // Check pg_stat_statements if available
+}
+
+Output:
+{
+  "missing_indexes": [
+    {
+      "table": "orders",
+      "columns": ["status", "created_at"],
+      "reason": "Sequential scan on 1M rows with WHERE status = X AND created_at > Y",
+      "suggested_sql": "CREATE INDEX CONCURRENTLY idx_orders_status_created ON orders(status, created_at)",
+      "estimated_improvement": "10x faster for common queries"
+    }
+  ],
+  "unused_indexes": [
+    {
+      "name": "orders_legacy_idx",
+      "table": "orders",
+      "size": "50 MB",
+      "last_used": null,
+      "suggestion": "DROP INDEX orders_legacy_idx"
+    }
+  ],
+  "duplicate_indexes": [
+    {
+      "indexes": ["orders_customer_id_idx", "orders_customer_fkey"],
+      "table": "orders",
+      "suggestion": "Foreign key constraint already creates implicit index"
+    }
+  ]
+}
+```
+
+---
+
+## Tool Registration
+
+All data engineering tools are registered under a single group:
+
+```go
+const dataEngineeringToolGroup = "data_engineering"
+
+var dataEngineeringToolNames = map[string]bool{
+    "schema_discover":        true,
+    "schema_diff":            true,
+    "create_table":           true,
+    "alter_table":            true,
+    "drop_table":             true,
+    "migrations_status":      true,
+    "migrations_run":         true,
+    "migrations_rollback":    true,
+    "ontology_export":        true,
+    "ontology_import":        true,
+    "ontology_validate":      true,
+    "ontology_refresh":       true,
+    "bulk_insert":            true,
+    "bulk_copy":              true,
+    "raw_query":              true,
+    "raw_execute":            true,
+    "table_stats":            true,
+    "index_recommendations":  true,
+}
+```
+
+---
+
+## Audit Integration
+
+All data engineering operations are logged with:
+- Full SQL (no sanitization - these are trusted users)
+- Execution time
+- Rows affected
+- Success/failure
+- User identity
+
+Special event types:
+- `de_schema_change` - DDL operations
+- `de_migration` - Migration runs
+- `de_ontology_change` - Ontology modifications
+- `de_bulk_operation` - Bulk data operations
+
+---
+
+## File Changes Summary
+
+| Area | Changes |
+|------|---------|
+| `pkg/mcp/tools/` | New `data_engineering.go` with all tools |
+| `pkg/services/` | Extend schema service for discovery, add migration service |
+| `pkg/models/mcp_config.go` | Add data_engineering tool group |
+| `ui/src/pages/MCPServerPage.tsx` | Add Data Engineering section |
+| `migrations/` | If new tables needed for migration tracking |

--- a/PLAN-mcp-ontology.md
+++ b/PLAN-mcp-ontology.md
@@ -1,0 +1,578 @@
+# PLAN: MCP Ontology Interface for SQL Generation
+
+## Purpose
+
+Design the MCP tools that enable an LLM (Claude Code or similar) to understand the database schema and ontology well enough to generate accurate SQL from natural language. This is the foundation for text-to-SQL capabilities.
+
+**Design Philosophy:** Progressive disclosure. Don't dump the entire schema at once. Provide tiered access that allows the LLM to start with domain understanding, then drill down to specifics as needed.
+
+---
+
+## Current State
+
+The existing MCP server provides:
+
+| Tool | Purpose | Limitation |
+|------|---------|------------|
+| `schema` | Raw schema (tables, columns, types) | No business context, no semantics |
+| `get_schema_context` | Schema with entity/role annotations | Prompt-formatted string, not structured for programmatic use |
+| `list_approved_queries` | Pre-approved queries | Pre-written SQL only, not generative |
+
+**Gap:** No tools for semantic understanding, entity resolution, join path discovery, or column meaning lookup.
+
+---
+
+## Proposed Tool Architecture
+
+### Tier 0: Domain Context (Call Once Per Session)
+
+```
+Tool: ontology_context
+Purpose: Provide high-level domain understanding before any specific query
+
+Input: (none - uses default datasource)
+
+Output:
+{
+  "domain": {
+    "description": "E-commerce platform for B2B wholesale transactions...",
+    "key_concepts": ["customer", "order", "product", "invoice", "shipment"],
+    "common_query_patterns": [
+      "aggregations by time period",
+      "customer segmentation",
+      "order fulfillment tracking"
+    ]
+  },
+  "entities": [
+    {
+      "name": "user",
+      "description": "Platform users including customers and internal staff",
+      "primary_table": "users",
+      "synonyms": ["customer", "account", "member"],
+      "occurrence_count": 15  // appears in 15 columns across schema
+    },
+    {
+      "name": "order",
+      "description": "Customer purchase orders",
+      "primary_table": "orders",
+      "synonyms": ["purchase", "transaction"],
+      "occurrence_count": 8
+    }
+  ],
+  "relationship_graph": [
+    {"from": "user", "to": "order", "type": "has_many"},
+    {"from": "order", "to": "product", "type": "has_many_through", "via": "order_items"}
+  ],
+  "table_count": 45,
+  "dialect": "postgres"
+}
+
+MCP Annotations:
+- read_only_hint: true
+- idempotent_hint: true
+- open_world_hint: false
+```
+
+**When to use:** Call once at the start of a session or when switching projects. This gives the LLM the "mental model" of the database.
+
+---
+
+### Tier 1: Entity Resolution
+
+```
+Tool: resolve_entity
+Purpose: Map business terms from user's question to actual tables/columns
+
+Input:
+{
+  "term": "customers",           // Required: the word from user's query
+  "context": "orders from customers in Q4"  // Optional: surrounding context for disambiguation
+}
+
+Output:
+{
+  "primary_match": {
+    "entity_name": "user",
+    "confidence": 0.95,
+    "primary_table": "users",
+    "description": "Platform users including customers and internal staff",
+    "match_reason": "synonym_match"  // synonym_match, alias_match, entity_name_match
+  },
+  "occurrences": [
+    {
+      "table": "users",
+      "column": "id",
+      "role": null,
+      "is_primary": true
+    },
+    {
+      "table": "orders",
+      "column": "customer_id",
+      "role": "customer",
+      "is_primary": false
+    },
+    {
+      "table": "invoices",
+      "column": "billed_to_user_id",
+      "role": "billed_to",
+      "is_primary": false
+    }
+  ],
+  "alternative_entities": [
+    {
+      "entity_name": "account",
+      "confidence": 0.3,
+      "reason": "Sometimes 'customer' refers to account, not user"
+    }
+  ]
+}
+
+MCP Annotations:
+- read_only_hint: true
+- idempotent_hint: true
+```
+
+**When to use:** When parsing natural language and encountering business terms that need mapping to technical names.
+
+---
+
+### Tier 2: Table Details
+
+```
+Tool: get_table_details
+Purpose: Get detailed information about specific tables needed for a query
+
+Input:
+{
+  "tables": ["orders", "users"],  // Required: 1-5 table names
+  "include_sample_values": true   // Optional: include sample data (default: false)
+}
+
+Output:
+{
+  "tables": [
+    {
+      "name": "orders",
+      "schema": "public",
+      "business_name": "Customer Orders",
+      "description": "Records of customer purchases with order details and status",
+      "row_count": 1234567,
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "semantic_type": "identifier",
+          "role": "primary_key",
+          "description": "Unique order identifier",
+          "nullable": false,
+          "is_primary_key": true,
+          "synonyms": ["order_id", "order_number"]
+        },
+        {
+          "name": "customer_id",
+          "type": "uuid",
+          "semantic_type": "identifier",
+          "role": "foreign_key",
+          "description": "Reference to the customer who placed the order",
+          "nullable": false,
+          "entity": "user",
+          "entity_role": "customer",
+          "foreign_table": "users",
+          "foreign_column": "id"
+        },
+        {
+          "name": "status",
+          "type": "varchar",
+          "semantic_type": "category",
+          "role": "dimension",
+          "description": "Current order status",
+          "nullable": false,
+          "enum_values": [
+            {"value": "pending", "label": "Pending", "description": "Order placed, awaiting processing"},
+            {"value": "confirmed", "label": "Confirmed", "description": "Order confirmed by seller"},
+            {"value": "shipped", "label": "Shipped", "description": "Order has been shipped"},
+            {"value": "delivered", "label": "Delivered", "description": "Order delivered to customer"},
+            {"value": "cancelled", "label": "Cancelled", "description": "Order was cancelled"}
+          ]
+        },
+        {
+          "name": "total_amount",
+          "type": "decimal(10,2)",
+          "semantic_type": "currency",
+          "role": "measure",
+          "description": "Total order value including tax",
+          "nullable": false,
+          "synonyms": ["order_total", "amount", "revenue"]
+        },
+        {
+          "name": "created_at",
+          "type": "timestamptz",
+          "semantic_type": "timestamp",
+          "role": "dimension",
+          "description": "When the order was placed",
+          "nullable": false,
+          "synonyms": ["order_date", "placed_at"]
+        }
+      ],
+      "sample_values": {  // Only if include_sample_values: true
+        "status": ["pending", "confirmed", "shipped", "delivered"],
+        "total_amount": [150.00, 299.99, 1250.00]
+      }
+    }
+  ],
+  "relationships_between_tables": [
+    {
+      "from_table": "orders",
+      "from_column": "customer_id",
+      "to_table": "users",
+      "to_column": "id",
+      "cardinality": "N:1",
+      "description": "Orders belong to users"
+    }
+  ]
+}
+
+MCP Annotations:
+- read_only_hint: true
+- idempotent_hint: true
+```
+
+**When to use:** After resolving entities, get detailed information about the specific tables you'll query.
+
+---
+
+### Tier 3: Column Search
+
+```
+Tool: search_columns
+Purpose: Find columns by semantic meaning, name pattern, or type
+
+Input:
+{
+  "query": "revenue",              // Required: search term
+  "semantic_type": "measure",      // Optional: filter by type (identifier, category, measure, temporal)
+  "tables": ["orders", "invoices"] // Optional: limit to specific tables
+}
+
+Output:
+{
+  "matches": [
+    {
+      "table": "orders",
+      "column": "total_amount",
+      "score": 0.95,
+      "match_reason": "synonym",
+      "data_type": "decimal(10,2)",
+      "semantic_type": "currency",
+      "role": "measure",
+      "description": "Total order value including tax",
+      "synonyms": ["order_total", "amount", "revenue"]
+    },
+    {
+      "table": "order_items",
+      "column": "line_total",
+      "score": 0.75,
+      "match_reason": "description",
+      "data_type": "decimal(10,2)",
+      "semantic_type": "currency",
+      "role": "measure",
+      "description": "Total for this line item (qty * unit_price)"
+    },
+    {
+      "table": "invoices",
+      "column": "amount",
+      "score": 0.70,
+      "match_reason": "name",
+      "data_type": "decimal(10,2)",
+      "semantic_type": "currency",
+      "role": "measure"
+    }
+  ]
+}
+
+MCP Annotations:
+- read_only_hint: true
+- idempotent_hint: true
+```
+
+**When to use:** When the user mentions a concept (like "revenue", "date", "status") and you need to find which column represents it.
+
+---
+
+### Tier 4: Join Path Discovery
+
+```
+Tool: find_join_path
+Purpose: Discover how to connect tables for a query
+
+Input:
+{
+  "source_table": "orders",
+  "target_table": "products",
+  "max_hops": 3  // Optional: default 3
+}
+
+Output:
+{
+  "paths": [
+    {
+      "hops": [
+        {
+          "from_table": "orders",
+          "from_column": "id",
+          "to_table": "order_items",
+          "to_column": "order_id",
+          "join_type": "LEFT"
+        },
+        {
+          "from_table": "order_items",
+          "from_column": "product_id",
+          "to_table": "products",
+          "to_column": "id",
+          "join_type": "INNER"
+        }
+      ],
+      "total_hops": 2,
+      "cardinality": "1:N:1",
+      "description": "Orders → Order Items → Products (one order has many items, each item references one product)"
+    }
+  ],
+  "recommended_path_index": 0,
+  "warning": null  // Or: "Multiple paths exist, verify business intent"
+}
+
+MCP Annotations:
+- read_only_hint: true
+- idempotent_hint: true
+```
+
+**When to use:** When a query involves multiple tables and you need to know how to JOIN them.
+
+---
+
+### Tier 5: Multi-Table Join Planning
+
+```
+Tool: plan_joins
+Purpose: Given multiple tables, return the optimal join plan
+
+Input:
+{
+  "tables": ["orders", "users", "products", "order_items"]
+}
+
+Output:
+{
+  "join_plan": {
+    "base_table": "orders",
+    "joins": [
+      {
+        "table": "users",
+        "alias": "u",
+        "join_type": "INNER",
+        "on": "orders.customer_id = u.id",
+        "order": 1
+      },
+      {
+        "table": "order_items",
+        "alias": "oi",
+        "join_type": "LEFT",
+        "on": "orders.id = oi.order_id",
+        "order": 2
+      },
+      {
+        "table": "products",
+        "alias": "p",
+        "join_type": "INNER",
+        "on": "oi.product_id = p.id",
+        "order": 3
+      }
+    ]
+  },
+  "sql_fragment": "FROM orders\nINNER JOIN users u ON orders.customer_id = u.id\nLEFT JOIN order_items oi ON orders.id = oi.order_id\nINNER JOIN products p ON oi.product_id = p.id",
+  "warnings": [
+    "LEFT JOIN to order_items may produce NULL values for orders without items"
+  ]
+}
+
+MCP Annotations:
+- read_only_hint: true
+- idempotent_hint: true
+```
+
+**When to use:** When you know which tables are needed and want to generate the FROM/JOIN clause.
+
+---
+
+### Tier 6: SQL Validation
+
+```
+Tool: validate_sql
+Purpose: Check SQL syntax and semantics before execution
+
+Input:
+{
+  "sql": "SELECT u.name, COUNT(o.id) FROM users u JOIN orders o ON o.customer_id = u.id GROUP BY u.name"
+}
+
+Output:
+{
+  "is_valid": true,
+  "errors": [],
+  "warnings": [
+    {
+      "type": "missing_where",
+      "message": "Query has no WHERE clause and may return large result set",
+      "severity": "info"
+    }
+  ],
+  "tables_used": ["users", "orders"],
+  "estimated_rows": 50000,  // From EXPLAIN if available
+  "query_type": "SELECT"
+}
+
+// Error case:
+{
+  "is_valid": false,
+  "errors": [
+    {
+      "type": "column_not_found",
+      "message": "Column 'usres.name' not found - did you mean 'users.name'?",
+      "position": 7,
+      "suggestion": "users.name"
+    }
+  ],
+  "warnings": []
+}
+
+MCP Annotations:
+- read_only_hint: true
+- idempotent_hint: true
+```
+
+**When to use:** Before executing any generated SQL to catch errors early.
+
+---
+
+## Complete Workflow Example
+
+User asks: "Show me the top 10 customers by total order value last quarter"
+
+```
+1. LLM calls: ontology_context
+   → Learns domain is e-commerce, "customer" maps to "user" entity, orders exist
+
+2. LLM calls: resolve_entity("customers")
+   → Confirms user entity, primary table "users", also appears in orders.customer_id
+
+3. LLM calls: resolve_entity("order value")
+   → Matches to orders.total_amount as the measure
+
+4. LLM calls: get_table_details(["users", "orders"])
+   → Gets full column details, confirms created_at for date filtering
+
+5. LLM calls: plan_joins(["users", "orders"])
+   → Gets: FROM users u INNER JOIN orders o ON o.customer_id = u.id
+
+6. LLM generates SQL:
+   SELECT u.id, u.name, SUM(o.total_amount) as total_value
+   FROM users u
+   INNER JOIN orders o ON o.customer_id = u.id
+   WHERE o.created_at >= '2024-10-01' AND o.created_at < '2025-01-01'
+   GROUP BY u.id, u.name
+   ORDER BY total_value DESC
+   LIMIT 10
+
+7. LLM calls: validate_sql(sql)
+   → Confirms valid, no errors
+
+8. LLM calls: query(sql)  [existing tool]
+   → Executes and returns results
+```
+
+---
+
+## Data Sources for Each Tool
+
+| Tool | Primary Data Source |
+|------|---------------------|
+| `ontology_context` | `engine_ontologies.domain_summary`, `engine_ontology_entities` |
+| `resolve_entity` | `engine_ontology_entities`, `engine_ontology_entity_occurrences`, `engine_ontology_entity_aliases` |
+| `get_table_details` | `engine_schema_tables`, `engine_schema_columns`, `engine_ontologies.entity_summaries`, `engine_ontologies.column_details` |
+| `search_columns` | `engine_schema_columns`, `engine_ontologies.column_details` (synonyms, descriptions) |
+| `find_join_path` | `engine_schema_relationships`, `engine_entity_relationships` |
+| `plan_joins` | `engine_schema_relationships`, `engine_entity_relationships` |
+| `validate_sql` | Query executor's EXPLAIN + column/table existence checks |
+
+---
+
+## Implementation Notes
+
+### Tool Registration
+
+All ontology tools should be registered as a new tool group `ontology` that is:
+- Enabled by default when approved_queries is enabled
+- Enabled by default when developer tools is enabled
+- Can be independently disabled if admin wants queries-only mode
+
+### Error Handling
+
+All tools should return structured errors that help the LLM self-correct:
+
+```json
+{
+  "error": true,
+  "error_type": "entity_not_found",
+  "message": "No entity matching 'custmer' found",
+  "suggestions": ["customer", "user"],
+  "hint": "Did you mean 'customer'? Try resolve_entity('customer')"
+}
+```
+
+### Caching Considerations
+
+- `ontology_context` results can be cached per project/version
+- Table details can be cached with invalidation on schema refresh
+- Entity resolution should be fast (indexed lookups)
+
+### Token Efficiency
+
+Each tool response should be:
+- Minimal but complete for the use case
+- Avoid redundant information
+- Use concise field names
+
+---
+
+## File Changes Required
+
+| Area | Changes |
+|------|---------|
+| `pkg/mcp/tools/` | New `ontology.go` file with all tools |
+| `pkg/services/` | New `ontology_context.go` for data assembly |
+| `pkg/repositories/` | May need new queries for join path discovery |
+| `pkg/models/mcp_config.go` | Add `ontology` tool group |
+
+---
+
+## Testing Strategy
+
+1. **Unit tests** for each tool handler
+2. **Integration tests** with real ontology data from test_data
+3. **Workflow tests** simulating complete query generation flows
+4. **Error case tests** for malformed inputs, missing data
+
+---
+
+## Open Questions
+
+1. **Should `ontology_context` be automatically called on connection?**
+   - Pro: LLM always has context
+   - Con: Adds latency to first request
+
+2. **Should we combine `find_join_path` and `plan_joins`?**
+   - Could be a single tool with different modes
+
+3. **How to handle multi-datasource projects?**
+   - Currently uses default datasource
+   - May need datasource_id parameter on all tools

--- a/PLAN-mcp-server-queries-config.md
+++ b/PLAN-mcp-server-queries-config.md
@@ -9,6 +9,30 @@ Add a "Queries" configuration section to the MCP Server page that allows adminis
 
 ---
 
+## V1 Scope Clarification
+
+**For V1, the full ontology is ALWAYS exposed** regardless of whether suggestions are enabled:
+- Entity summaries, column details, enum values are all available
+- This enables the MCP client to understand the domain and explain queries
+- The `allow_suggestions` toggle only controls:
+  - Whether `suggest_query()` tool is available
+  - Whether SQL of pre-approved queries is shown (if OFF, only name/description/parameters)
+
+**Mode Matrix (V1):**
+
+| FORCE Mode | Suggestions | Ontology | Query SQL | suggest_query | Developer Tools |
+|------------|-------------|----------|-----------|---------------|-----------------|
+| OFF | OFF | ✅ Full | ❌ Hidden | ❌ | Depends on dev toggle |
+| OFF | ON | ✅ Full | ✅ Shown | ✅ | Depends on dev toggle |
+| ON | OFF | ✅ Full | ❌ Hidden | ❌ | ❌ Disabled |
+| ON | ON | ✅ Full | ✅ Shown | ✅ | ❌ Disabled |
+
+**Key Insight:** Hiding ontology doesn't add security - the MCP client can infer from query names. The real security is:
+1. FORCE mode limits to pre-approved queries only
+2. Database permissions are the ultimate enforcement
+
+---
+
 ## Part 1: UI Changes - MCP Server Page
 
 ### 1.0 Update MCP Server Logo

--- a/PLAN-mcp-sql-execution.md
+++ b/PLAN-mcp-sql-execution.md
@@ -1,0 +1,481 @@
+# PLAN: MCP SQL Execution Layer
+
+## Purpose
+
+Define how SQL queries are executed through the MCP interface, including permissions, limits, timeouts, and result formatting. This layer sits between the LLM's generated SQL and the actual database execution.
+
+**Scope:** This plan covers the execution mechanics. Query generation is covered in PLAN-mcp-ontology.md.
+
+---
+
+## Current State
+
+The existing MCP server provides:
+
+| Tool | SQL Type | Limits | Current Behavior |
+|------|----------|--------|------------------|
+| `query` | SELECT only | 1000 rows | Direct execution, read-only |
+| `execute` | DDL/DML | None | Requires explicit enablement |
+| `execute_approved_query` | Any (pre-approved) | 1000 rows | Parameter substitution |
+
+---
+
+## Execution Model
+
+### Query Types
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    SQL Execution Categories                      │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  READ (query tool)                                               │
+│  ├── SELECT statements                                           │
+│  ├── WITH (CTE) that ends in SELECT                              │
+│  └── EXPLAIN/EXPLAIN ANALYZE                                     │
+│                                                                  │
+│  WRITE (execute tool - requires explicit enablement)             │
+│  ├── INSERT, UPDATE, DELETE                                      │
+│  ├── MERGE/UPSERT                                                │
+│  └── TRUNCATE                                                    │
+│                                                                  │
+│  DDL (execute tool - requires explicit enablement)               │
+│  ├── CREATE TABLE/VIEW/INDEX                                     │
+│  ├── ALTER TABLE                                                 │
+│  ├── DROP (dangerous!)                                           │
+│  └── GRANT/REVOKE                                                │
+│                                                                  │
+│  APPROVED (execute_approved_query)                               │
+│  └── Any SQL that admin has pre-approved                         │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Tool Specifications
+
+### Tool: query
+
+**Purpose:** Execute read-only SELECT statements
+
+```
+Input:
+{
+  "sql": "SELECT * FROM users WHERE created_at > '2024-01-01'",
+  "limit": 100,  // Optional: default 100, max 1000
+  "explain": false,  // Optional: return query plan instead of results
+  "natural_language_context": "users created this year"  // Optional: for history
+}
+
+Output (success):
+{
+  "columns": [
+    {"name": "id", "type": "uuid"},
+    {"name": "name", "type": "text"},
+    {"name": "created_at", "type": "timestamptz"}
+  ],
+  "rows": [
+    {"id": "abc123", "name": "John", "created_at": "2024-03-15T10:00:00Z"},
+    ...
+  ],
+  "row_count": 47,
+  "truncated": false,
+  "execution_time_ms": 145,
+  "query_id": "uuid"  // For feedback/history
+}
+
+Output (explain mode):
+{
+  "plan": [
+    "Seq Scan on users  (cost=0.00..25.00 rows=500 width=64)",
+    "  Filter: (created_at > '2024-01-01'::date)"
+  ],
+  "estimated_rows": 500,
+  "execution_time_ms": 12
+}
+
+Output (error):
+{
+  "error": true,
+  "error_type": "syntax_error",
+  "message": "syntax error at or near 'SELEC'",
+  "position": 1,
+  "hint": "Did you mean 'SELECT'?",
+  "sql_state": "42601"
+}
+```
+
+**Validation Rules:**
+- Must start with SELECT or WITH
+- No data-modifying CTEs (WITH ... INSERT/UPDATE/DELETE)
+- No function calls that modify data
+
+---
+
+### Tool: execute
+
+**Purpose:** Execute DDL/DML statements (when enabled)
+
+```
+Input:
+{
+  "sql": "INSERT INTO orders (customer_id, total) VALUES ('abc', 100.00) RETURNING id",
+  "confirm_destructive": false  // Required true for DROP/TRUNCATE/DELETE without WHERE
+}
+
+Output (success with RETURNING):
+{
+  "columns": [{"name": "id", "type": "uuid"}],
+  "rows": [{"id": "new-uuid-123"}],
+  "rows_affected": 1,
+  "execution_time_ms": 45
+}
+
+Output (success without RETURNING):
+{
+  "rows_affected": 1,
+  "message": "1 row inserted",
+  "execution_time_ms": 45
+}
+
+Output (blocked - destructive):
+{
+  "error": true,
+  "error_type": "confirmation_required",
+  "message": "DELETE without WHERE clause affects all rows. Set confirm_destructive: true to proceed.",
+  "estimated_affected_rows": 50000
+}
+```
+
+**Safety Rules:**
+- DROP TABLE/DATABASE requires `confirm_destructive: true`
+- DELETE/TRUNCATE without WHERE requires `confirm_destructive: true`
+- All executions logged to audit trail
+- 30-second timeout (configurable)
+
+---
+
+### Tool: execute_approved_query
+
+**Purpose:** Execute pre-approved parameterized queries
+
+```
+Input:
+{
+  "query_id": "uuid",
+  "parameters": {
+    "customer_id": "abc123",
+    "start_date": "2024-01-01"
+  },
+  "limit": 100  // Optional
+}
+
+Output:
+{
+  "columns": [...],
+  "rows": [...],
+  "row_count": 47,
+  "truncated": false,
+  "execution_time_ms": 145,
+  "query_name": "Customer Orders Report",
+  "parameters_used": {
+    "customer_id": "abc123",
+    "start_date": "2024-01-01"
+  }
+}
+```
+
+**Security:**
+- SQL is not exposed to MCP client (unless allow_suggestions is on)
+- Parameters are type-checked and sanitized
+- SQL injection attempts are detected and logged
+
+---
+
+## Limits & Quotas
+
+### Row Limits
+
+| Context | Default | Max | Configurable |
+|---------|---------|-----|--------------|
+| query tool | 100 | 1000 | Per project |
+| approved queries | 100 | 1000 | Per project |
+| execute with RETURNING | 100 | 1000 | Per project |
+
+### Timeout Limits
+
+| Operation | Default | Max | Configurable |
+|-----------|---------|-----|--------------|
+| SELECT queries | 30s | 120s | Per project |
+| DDL/DML | 30s | 60s | Per project |
+| Approved queries | 60s | 120s | Per project |
+
+### Rate Limits (Future)
+
+| Limit | Default | Window |
+|-------|---------|--------|
+| Queries per minute | 60 | 1 minute |
+| Total rows per hour | 100,000 | 1 hour |
+| Concurrent queries | 5 | N/A |
+
+---
+
+## Error Handling
+
+### Error Categories
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Error Type           │ User-Facing Message                     │
+├──────────────────────┼─────────────────────────────────────────┤
+│ syntax_error         │ SQL syntax error with position          │
+│ column_not_found     │ Column X doesn't exist, suggest similar │
+│ table_not_found      │ Table X doesn't exist, suggest similar  │
+│ permission_denied    │ User doesn't have access to this table  │
+│ timeout              │ Query exceeded time limit               │
+│ row_limit_exceeded   │ Results truncated to limit              │
+│ rate_limit_exceeded  │ Too many queries, try again later       │
+│ connection_error     │ Database connection failed              │
+│ validation_failed    │ Query failed pre-execution validation   │
+└──────────────────────┴─────────────────────────────────────────┘
+```
+
+### Error Response Format
+
+```json
+{
+  "error": true,
+  "error_type": "column_not_found",
+  "message": "Column 'usres.name' does not exist",
+  "sql_state": "42703",
+  "position": 7,
+  "suggestions": [
+    {"correction": "users.name", "reason": "Likely typo in table alias"}
+  ],
+  "context": {
+    "available_columns": ["users.id", "users.name", "users.email"],
+    "similar_columns": ["users.name"]
+  }
+}
+```
+
+**LLM-Friendly Errors:**
+- Include suggestions for common mistakes
+- Provide context for self-correction
+- Reference available columns/tables when relevant
+
+---
+
+## Permission Model
+
+### Table-Level Permissions
+
+Permissions are derived from the admin-approved schema:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Permission Hierarchy                          │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  Admin selects tables in Schema view                             │
+│            ↓                                                     │
+│  Selected tables → engine_schema_tables.is_selected = true       │
+│            ↓                                                     │
+│  MCP queries can only access selected tables                     │
+│            ↓                                                     │
+│  Database-level permissions are final enforcement                │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Query Validation Pipeline
+
+```
+1. Parse SQL (syntax check)
+        ↓
+2. Extract referenced tables
+        ↓
+3. Check tables against is_selected
+        ↓
+4. If approved_queries_only mode:
+   - Reject dynamic SQL
+   - Only allow execute_approved_query
+        ↓
+5. Pass to database with connection credentials
+        ↓
+6. Database enforces final permissions
+```
+
+---
+
+## Result Formatting
+
+### Data Type Handling
+
+| Database Type | JSON Representation | Notes |
+|--------------|---------------------|-------|
+| uuid | string | As-is |
+| integer/bigint | number | Safe for JavaScript |
+| numeric/decimal | string | Preserve precision |
+| text/varchar | string | As-is |
+| boolean | boolean | true/false |
+| date | string | ISO 8601 (YYYY-MM-DD) |
+| timestamp/timestamptz | string | ISO 8601 with timezone |
+| json/jsonb | object/array | Parsed JSON |
+| bytea | string | Base64 encoded |
+| array | array | Native JSON array |
+| NULL | null | JSON null |
+
+### Large Value Handling
+
+| Scenario | Handling |
+|----------|----------|
+| Text > 10KB | Truncate with "...[truncated]" marker |
+| Binary data | Base64 encode, include size |
+| Very wide tables (>50 cols) | Include all, warn about size |
+
+---
+
+## Execution Context
+
+### Connection Management
+
+```go
+type ExecutionContext struct {
+    ProjectID     uuid.UUID
+    UserID        string
+    DatasourceID  uuid.UUID
+    SessionID     string
+
+    // Limits
+    RowLimit      int
+    TimeoutMS     int
+
+    // Audit
+    NaturalLanguageContext string
+    ToolName      string
+}
+```
+
+### Connection Pooling
+
+- Use existing datasource connection pools
+- Acquire connection with project context
+- Set statement timeout before execution
+- Return connection to pool after use
+
+---
+
+## Transaction Handling
+
+### Default Behavior
+- Each query/execute runs in auto-commit mode
+- No multi-statement transactions via MCP (for now)
+
+### Future: Explicit Transactions
+```
+begin_transaction() → returns transaction_id
+query(sql, transaction_id) → uses same transaction
+commit_transaction(transaction_id)
+rollback_transaction(transaction_id)
+```
+
+**Considerations:**
+- Transaction timeout (prevent stuck connections)
+- Maximum transaction duration
+- Audit logging for transaction boundaries
+
+---
+
+## Query Cancellation (Future)
+
+### Cancel Long-Running Query
+
+```
+Tool: cancel_query
+Input:
+{
+  "query_id": "uuid"  // From query response
+}
+
+Output:
+{
+  "cancelled": true,
+  "message": "Query cancelled after 15.3 seconds"
+}
+```
+
+**Implementation:**
+- Map query_id to backend PID
+- Send pg_cancel_backend()
+- Clean up resources
+
+---
+
+## Implementation Notes
+
+### Refactoring Existing Code
+
+The current `query` and `execute` tools in `pkg/mcp/tools/developer.go` should be:
+
+1. Extracted to a shared execution layer
+2. Enhanced with better error formatting
+3. Integrated with audit logging
+4. Made configurable via project settings
+
+### Execution Flow
+
+```
+MCP Tool Handler
+       ↓
+Validation Layer (syntax, permissions)
+       ↓
+Audit Logger (pre-execution)
+       ↓
+Query Executor
+       ↓
+Result Formatter
+       ↓
+Audit Logger (post-execution)
+       ↓
+Return to MCP Client
+```
+
+---
+
+## Configuration Options
+
+### Project-Level Settings
+
+```go
+type QueryExecutionConfig struct {
+    // Limits
+    DefaultRowLimit     int  // Default: 100
+    MaxRowLimit         int  // Default: 1000
+    QueryTimeoutSeconds int  // Default: 30
+    ExecuteTimeoutSeconds int // Default: 30
+
+    // Features
+    AllowExplain        bool // Default: true
+    AllowDynamicSQL     bool // Default: true (false = approved only)
+    AllowDDL            bool // Default: false
+    AllowDML            bool // Default: false
+
+    // Safety
+    RequireConfirmDestructive bool // Default: true
+    LogAllQueries       bool       // Default: true
+}
+```
+
+---
+
+## File Changes Summary
+
+| Area | Changes |
+|------|---------|
+| `pkg/mcp/tools/` | Refactor query/execute into execution layer |
+| `pkg/adapters/datasource/` | Enhance error formatting, timeout handling |
+| `pkg/models/` | Query execution config model |
+| `pkg/services/` | Execution service with validation pipeline |
+| `pkg/repositories/` | Config storage for execution settings |

--- a/PLAN-mcp-user-history.md
+++ b/PLAN-mcp-user-history.md
@@ -1,0 +1,355 @@
+# PLAN: MCP User Query History
+
+## Purpose
+
+Enable the MCP client to learn from past queries - both the user's own history and successful patterns across the project. This creates a feedback loop where the system gets smarter over time.
+
+**Core Insight:** The best query for a new question is often an adaptation of a query that worked before.
+
+---
+
+## Use Cases
+
+### 1. Query Reuse
+User asks: "Show me top customers by revenue"
+System finds: Previous query "top 10 customers by order value" with 95% similarity
+LLM adapts: Reuses the query structure, adjusts column names if needed
+
+### 2. Error Avoidance
+User asks: "Orders by region"
+System finds: Previous query failed because "region" column doesn't exist, user clarified they meant "shipping_state"
+LLM learns: Suggest clarification before generating SQL
+
+### 3. Pattern Discovery
+User frequently queries: "X by month for last year"
+System learns: This user prefers monthly aggregations with 12-month lookback
+
+---
+
+## Data Model
+
+### New Table: `engine_mcp_query_history`
+
+```sql
+CREATE TABLE engine_mcp_query_history (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES engine_projects(id),
+    user_id VARCHAR(255) NOT NULL,  -- From auth claims
+
+    -- The query itself
+    natural_language TEXT NOT NULL,
+    generated_sql TEXT NOT NULL,
+    final_sql TEXT,  -- May differ if user edited
+
+    -- Execution details
+    executed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    execution_duration_ms INTEGER,
+    row_count INTEGER,
+    was_successful BOOLEAN NOT NULL,
+    error_message TEXT,
+
+    -- Learning signals
+    user_feedback VARCHAR(20),  -- 'helpful', 'not_helpful', 'edited', NULL
+    feedback_comment TEXT,
+
+    -- Query classification (for similarity search)
+    query_type VARCHAR(50),  -- 'aggregation', 'lookup', 'report', 'exploration'
+    tables_used TEXT[],  -- ['users', 'orders']
+    aggregations_used TEXT[],  -- ['SUM', 'COUNT', 'AVG']
+    time_filters JSONB,  -- {"type": "relative", "period": "last_quarter"}
+
+    -- Embedding for similarity search (optional, for advanced similarity)
+    question_embedding VECTOR(1536),  -- If using pgvector
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_project FOREIGN KEY (project_id) REFERENCES engine_projects(id)
+);
+
+-- Indexes
+CREATE INDEX idx_query_history_user ON engine_mcp_query_history(project_id, user_id, created_at DESC);
+CREATE INDEX idx_query_history_tables ON engine_mcp_query_history USING GIN(tables_used);
+CREATE INDEX idx_query_history_success ON engine_mcp_query_history(project_id, was_successful, created_at DESC);
+```
+
+---
+
+## MCP Tools
+
+### Tool: get_query_history
+
+```
+Purpose: Retrieve the user's recent query history
+
+Input:
+{
+  "limit": 20,                    // Optional: default 20, max 100
+  "filter": "all",                // Optional: "all", "successful", "failed"
+  "tables": ["orders"],           // Optional: filter by tables used
+  "since": "2024-01-01"           // Optional: filter by date
+}
+
+Output:
+{
+  "queries": [
+    {
+      "id": "uuid",
+      "natural_language": "Show me top 10 customers by total orders",
+      "sql": "SELECT u.name, COUNT(o.id) as order_count FROM users u JOIN orders o ON o.customer_id = u.id GROUP BY u.id, u.name ORDER BY order_count DESC LIMIT 10",
+      "executed_at": "2024-12-15T10:30:00Z",
+      "was_successful": true,
+      "row_count": 10,
+      "execution_duration_ms": 145,
+      "tables_used": ["users", "orders"],
+      "query_type": "aggregation",
+      "user_feedback": "helpful"
+    },
+    {
+      "id": "uuid",
+      "natural_language": "Orders by region last month",
+      "sql": "SELECT region, COUNT(*) FROM orders WHERE created_at >= '2024-11-01' GROUP BY region",
+      "executed_at": "2024-12-14T15:00:00Z",
+      "was_successful": false,
+      "error_message": "column \"region\" does not exist",
+      "tables_used": ["orders"],
+      "query_type": "aggregation"
+    }
+  ],
+  "total_count": 156,
+  "has_more": true
+}
+
+MCP Annotations:
+- read_only_hint: true
+- idempotent_hint: true
+```
+
+---
+
+### Tool: find_similar_queries
+
+```
+Purpose: Find past queries semantically similar to a new question
+
+Input:
+{
+  "natural_language": "Who are our biggest customers?",
+  "limit": 5  // Optional: default 5
+}
+
+Output:
+{
+  "similar_queries": [
+    {
+      "id": "uuid",
+      "original_question": "Show me top 10 customers by total orders",
+      "sql": "SELECT u.name, COUNT(o.id) as order_count FROM users u JOIN orders o ON o.customer_id = u.id GROUP BY u.id, u.name ORDER BY order_count DESC LIMIT 10",
+      "similarity_score": 0.92,
+      "was_successful": true,
+      "tables_used": ["users", "orders"],
+      "can_reuse": true,
+      "adaptation_hint": "Consider changing metric from order count to revenue if 'biggest' means by value"
+    },
+    {
+      "id": "uuid",
+      "original_question": "Top customers by revenue last year",
+      "sql": "SELECT u.name, SUM(o.total_amount) as revenue FROM users u JOIN orders o ON o.customer_id = u.id WHERE o.created_at >= '2024-01-01' GROUP BY u.id, u.name ORDER BY revenue DESC LIMIT 10",
+      "similarity_score": 0.88,
+      "was_successful": true,
+      "tables_used": ["users", "orders"],
+      "can_reuse": true,
+      "adaptation_hint": "Remove date filter if all-time is desired"
+    }
+  ],
+  "recommendation": {
+    "suggested_action": "adapt",
+    "base_query_id": "uuid",
+    "reasoning": "Previous query for 'top customers by revenue' is highly similar and was successful. Consider adapting this query."
+  }
+}
+
+MCP Annotations:
+- read_only_hint: true
+- idempotent_hint: true
+```
+
+**Similarity Calculation Options:**
+
+1. **Simple (V1):** TF-IDF or keyword matching on natural language
+2. **Advanced (V2):** Embedding similarity using pgvector
+3. **Structural:** Compare tables_used, aggregations_used, query patterns
+
+---
+
+### Tool: record_query_feedback
+
+```
+Purpose: Record whether a generated query was helpful
+
+Input:
+{
+  "query_id": "uuid",             // Required: from query history
+  "feedback": "helpful",          // Required: "helpful", "not_helpful", "edited"
+  "comment": "Had to add date filter"  // Optional
+}
+
+Output:
+{
+  "recorded": true,
+  "message": "Feedback recorded. Thank you for helping improve query suggestions."
+}
+
+MCP Annotations:
+- read_only_hint: false
+- destructive_hint: false
+- idempotent_hint: true
+```
+
+---
+
+### Tool: get_query_patterns
+
+```
+Purpose: Get common query patterns for this project/user
+
+Input:
+{
+  "scope": "user"  // "user" or "project"
+}
+
+Output:
+{
+  "patterns": [
+    {
+      "pattern": "time_series_aggregation",
+      "description": "Aggregations grouped by time period",
+      "frequency": 45,  // Used 45 times
+      "example_sql": "SELECT DATE_TRUNC('month', created_at), SUM(amount) FROM orders GROUP BY 1",
+      "common_tables": ["orders", "invoices"],
+      "common_metrics": ["SUM", "COUNT"]
+    },
+    {
+      "pattern": "top_n_ranking",
+      "description": "Top N items by some metric",
+      "frequency": 32,
+      "example_sql": "SELECT name, COUNT(*) as cnt FROM ... GROUP BY name ORDER BY cnt DESC LIMIT 10",
+      "common_tables": ["users", "products"],
+      "common_metrics": ["COUNT", "SUM"]
+    }
+  ],
+  "preferences": {
+    "default_limit": 10,
+    "preferred_date_format": "relative",  // "relative" or "absolute"
+    "common_time_ranges": ["last_month", "last_quarter", "ytd"]
+  }
+}
+
+MCP Annotations:
+- read_only_hint: true
+- idempotent_hint: true
+```
+
+---
+
+## Query Recording Flow
+
+When a query is executed via MCP tools, automatically record it:
+
+```
+1. User sends natural language question
+2. LLM generates SQL using ontology tools
+3. LLM calls query() or execute_approved_query()
+4. System intercepts and records:
+   - Natural language (from conversation context or explicit parameter)
+   - Generated SQL
+   - Execution result
+   - Tables used (parsed from SQL or from query plan)
+5. Query ID returned in response for later feedback
+```
+
+### Recording Integration Point
+
+Modify the `query` tool to optionally accept natural language context:
+
+```go
+// query tool input
+{
+  "sql": "SELECT ...",
+  "limit": 100,
+  "natural_language_context": "top customers by revenue"  // Optional
+}
+```
+
+If provided, automatically creates a history entry.
+
+---
+
+## Privacy & Security Considerations
+
+### Data Isolation
+- Query history is scoped by `project_id` and `user_id`
+- Users can only see their own history
+- Project admins may see aggregated patterns (not individual queries) - future feature
+
+### Retention Policy
+- Default: 90 days retention
+- Configurable per project
+- Option to disable history recording entirely
+
+### Sensitive Data
+- SQL queries may contain literals (dates, IDs, etc.)
+- Consider: Option to strip literals before storing
+- Consider: Parameterize queries before storing
+
+---
+
+## UI Considerations (Future)
+
+While this PLAN focuses on the MCP interface, the history data enables:
+
+1. **Query History Panel** - View/rerun past queries
+2. **"Did you mean?" Suggestions** - During query building
+3. **Query Templates** - Save and share successful queries
+4. **Usage Analytics** - Most queried tables, common patterns
+
+---
+
+## Implementation Phases
+
+### Phase 1: Core History
+- Create table and migration
+- Implement `get_query_history` tool
+- Auto-record queries from `query` tool
+
+### Phase 2: Similarity Search
+- Implement `find_similar_queries` with keyword matching
+- Add `record_query_feedback` tool
+- Parse and store query metadata (tables, aggregations)
+
+### Phase 3: Advanced Matching
+- Add vector embeddings for semantic similarity
+- Implement `get_query_patterns`
+- Add pattern detection algorithms
+
+---
+
+## Open Questions
+
+1. **Should failed queries be recorded?**
+   - Pro: Learn from mistakes
+   - Con: Noise in similarity search
+   - Recommendation: Record with flag, filter by default
+
+2. **How to handle edited queries?**
+   - Record both generated and final SQL?
+   - Track diffs for learning?
+
+3. **Cross-user learning?**
+   - Should one user's successful queries help another?
+   - Privacy implications
+   - Recommendation: Aggregate patterns only, not specific queries
+
+4. **Embedding model for similarity?**
+   - Use OpenAI embeddings?
+   - Use local model?
+   - Start with keyword matching, add embeddings later


### PR DESCRIPTION
## Summary
- Add 5 new PLAN files defining the MCP tool architecture for natural language to SQL
- Update existing PLAN-mcp-server-queries-config.md with V1 mode matrix

## Plans Added

| Plan | Purpose |
|------|---------|
| **PLAN-mcp-ontology.md** | Core tools for entity resolution, join discovery, column semantics |
| **PLAN-mcp-user-history.md** | Per-user query history and similarity search |
| **PLAN-mcp-auditing.md** | Governance audit tile with event logging and alerts |
| **PLAN-mcp-sql-execution.md** | Execution layer (limits, timeouts, permissions, errors) |
| **PLAN-mcp-data-engineering.md** | Power tools for DDL, migrations, ontology management |

## Motivation
These plans define the MCP interface that will enable LLMs (Claude Code) to:
1. Understand database schema and ontology progressively
2. Resolve business terms to technical names
3. Discover join paths between tables
4. Generate and validate SQL
5. Learn from query history

## Key Design Decisions
- **Ontology always exposed in V1** - Full entity/column/enum information regardless of mode
- **Progressive disclosure** - Tiered tools from domain → table → column level
- **LLM-friendly errors** - Include suggestions and context for self-correction
- **Audit-first** - All operations logged before execution

## Testing
- Documentation/planning only - no code changes
- All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)