### PR TITLE
Consolidate to single PostgreSQL driver (pgx)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/gorilla/sessions v1.4.0
 	github.com/ilyakaznacheev/cleanenv v1.5.0
 	github.com/jackc/pgx/v5 v5.7.6
-	github.com/lib/pq v1.10.9
 	github.com/liushuangls/go-anthropic/v2 v2.17.0
 	github.com/mark3labs/mcp-go v0.43.2
 	github.com/microsoft/go-mssqldb v1.9.5
@@ -61,6 +60,7 @@ require (
 	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/lib/pq v1.10.9 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ import (
 	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
 	"github.com/ekaya-inc/ekaya-engine/pkg/services"
 	"github.com/ekaya-inc/ekaya-engine/ui"
-	_ "github.com/lib/pq" // PostgreSQL driver for migrations
+	_ "github.com/jackc/pgx/v5/stdlib" // PostgreSQL driver for database/sql (migrations)
 )
 
 // Version is set at build time via ldflags
@@ -627,7 +627,7 @@ func runMigrations(databaseURL string, logger *zap.Logger) error {
 	}
 	migrationURL := fmt.Sprintf("%s%sstatement_timeout=%d", databaseURL, separator, timeoutMS)
 
-	db, err := sql.Open("postgres", migrationURL)
+	db, err := sql.Open("pgx", migrationURL)
 	if err != nil {
 		return formatMigrationError(fmt.Errorf("failed to open migration connection: %w", err))
 	}

--- a/pkg/database/migrations_permissions_test.go
+++ b/pkg/database/migrations_permissions_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
-	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -84,7 +83,7 @@ func Test_Migrations_InsufficientPermissions(t *testing.T) {
 	connStr := "postgres://" + testUser + ":" + testPassword + "@" + host + ":" + port.Port() + "/" + testDBName + "?sslmode=disable"
 
 	// Open connection as the restricted user
-	restrictedDB, err := sql.Open("postgres", connStr)
+	restrictedDB, err := sql.Open("pgx", connStr)
 	require.NoError(t, err, "Failed to open connection as restricted user")
 	defer restrictedDB.Close()
 
@@ -156,7 +155,7 @@ func Test_Migrations_SuccessWithProperPermissions(t *testing.T) {
 
 	// Connect as superuser to the new database to grant schema permissions
 	superConnStr := "postgres://ekaya:test_password@" + host + ":" + port.Port() + "/" + testDBName + "?sslmode=disable"
-	superDB, err := sql.Open("postgres", superConnStr)
+	superDB, err := sql.Open("pgx", superConnStr)
 	require.NoError(t, err)
 	defer superDB.Close()
 
@@ -183,7 +182,7 @@ func Test_Migrations_SuccessWithProperPermissions(t *testing.T) {
 	connStr := "postgres://" + testUser + ":" + testPassword + "@" + host + ":" + port.Port() + "/" + testDBName + "?sslmode=disable"
 
 	// Open connection
-	userDB, err := sql.Open("postgres", connStr)
+	userDB, err := sql.Open("pgx", connStr)
 	require.NoError(t, err, "Failed to open connection")
 	defer userDB.Close()
 
@@ -206,7 +205,7 @@ func Test_Migrations_SuccessWithProperPermissions(t *testing.T) {
 
 	// Verify migrations actually ran by checking for a table
 	// Note: RunMigrations closes the connection, so we need a fresh one for verification
-	verifyDB, err := sql.Open("postgres", connStr)
+	verifyDB, err := sql.Open("pgx", connStr)
 	require.NoError(t, err, "Failed to open verification connection")
 	defer verifyDB.Close()
 
@@ -252,7 +251,7 @@ func Test_Migrations_ConcurrentAccessBlocking(t *testing.T) {
 
 	// Connect as superuser to grant schema permissions
 	superConnStr := "postgres://ekaya:test_password@" + host + ":" + port.Port() + "/" + testDBName + "?sslmode=disable"
-	superDB, err := sql.Open("postgres", superConnStr)
+	superDB, err := sql.Open("pgx", superConnStr)
 	require.NoError(t, err)
 	defer superDB.Close()
 
@@ -276,7 +275,7 @@ func Test_Migrations_ConcurrentAccessBlocking(t *testing.T) {
 	connStr := "postgres://" + testUser + ":" + testPassword + "@" + host + ":" + port.Port() + "/" + testDBName + "?sslmode=disable"
 
 	// First, run migrations successfully to create schema_migrations table
-	firstDB, err := sql.Open("postgres", connStr)
+	firstDB, err := sql.Open("pgx", connStr)
 	require.NoError(t, err)
 	defer firstDB.Close()
 
@@ -284,7 +283,7 @@ func Test_Migrations_ConcurrentAccessBlocking(t *testing.T) {
 	require.NoError(t, err, "First migration run should succeed")
 
 	// Now open a connection and lock the schema_migrations table
-	lockDB, err := sql.Open("postgres", connStr)
+	lockDB, err := sql.Open("pgx", connStr)
 	require.NoError(t, err)
 	defer lockDB.Close()
 
@@ -299,7 +298,7 @@ func Test_Migrations_ConcurrentAccessBlocking(t *testing.T) {
 
 	// Now try to run migrations from another connection
 	// This should block waiting for the lock
-	secondDB, err := sql.Open("postgres", connStr)
+	secondDB, err := sql.Open("pgx", connStr)
 	require.NoError(t, err)
 	defer secondDB.Close()
 
@@ -461,7 +460,7 @@ func Test_Migrations_InsufficientSchemaPermissions_AppPath(t *testing.T) {
 	timeoutMS := int(migrationTimeout.Milliseconds())
 	migrationURL := fmt.Sprintf("%s&statement_timeout=%d", databaseURL, timeoutMS)
 
-	migrationDB, err := sql.Open("postgres", migrationURL)
+	migrationDB, err := sql.Open("pgx", migrationURL)
 	require.NoError(t, err, "Should be able to open migration connection")
 	defer migrationDB.Close()
 

--- a/pkg/testhelpers/containers.go
+++ b/pkg/testhelpers/containers.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	_ "github.com/lib/pq" // PostgreSQL driver for database/sql (used by migrations)
+	_ "github.com/jackc/pgx/v5/stdlib" // PostgreSQL driver for database/sql (migrations)
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"go.uber.org/zap"


### PR DESCRIPTION
## Summary
- Remove direct `lib/pq` imports from all code
- Use `pgx/v5/stdlib` for all `database/sql` connections (including migrations)
- Consistent driver usage across engine DB, datasources, and migrations

Note: `lib/pq` remains as an indirect dependency through `golang-migrate`, but our code now consistently uses pgx.

## Test plan
- [x] `make test-short` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)