### PR TITLE
feat: add ontology import and export bundle flow

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -148,6 +148,7 @@ func Run(version string) error {
 	pendingChangeRepo := repositories.NewPendingChangeRepository()
 	columnMetadataRepo := repositories.NewColumnMetadataRepository()
 	tableMetadataRepo := repositories.NewTableMetadataRepository()
+	glossaryRepo := repositories.NewGlossaryRepository()
 
 	// Create connection manager with config-driven settings
 	connManagerCfg := datasource.ConnectionManagerConfig{
@@ -209,6 +210,19 @@ func Run(version string) error {
 		projectRepo, schemaRepo, columnMetadataRepo, convRepo, llmFactory, getTenantCtx, logger)
 	ontologyContextService := services.NewOntologyContextService(
 		schemaRepo, columnMetadataRepo, tableMetadataRepo, projectService, logger)
+	ontologyExportService := services.NewOntologyExportService(
+		projectRepo,
+		datasourceService,
+		schemaRepo,
+		tableMetadataRepo,
+		columnMetadataRepo,
+		ontologyQuestionRepo,
+		knowledgeRepo,
+		glossaryRepo,
+		queryRepo,
+		agentRepo,
+		logger,
+	)
 
 	// Create worker pool for parallel LLM calls
 	workerPoolConfig := llm.DefaultWorkerPoolConfig()
@@ -221,7 +235,6 @@ func Run(version string) error {
 	columnEnrichmentService := services.NewColumnEnrichmentService(
 		schemaRepo, columnMetadataRepo, convRepo, projectRepo, ontologyQuestionService,
 		datasourceService, adapterFactory, llmFactory, llmWorkerPool, llmCircuitBreaker, getTenantCtx, logger)
-	glossaryRepo := repositories.NewGlossaryRepository()
 	glossaryService := services.NewGlossaryService(glossaryRepo, columnMetadataRepo, knowledgeRepo, schemaRepo, projectService, datasourceService, adapterFactory, llmFactory, getTenantCtx, logger, cfg.Env)
 
 	// Ontology DAG service for orchestrated workflow execution
@@ -446,6 +459,10 @@ func Run(version string) error {
 	// Register ontology DAG handler (protected) - unified workflow execution
 	ontologyDAGHandler := handlers.NewOntologyDAGHandler(ontologyDAGService, projectService, logger)
 	ontologyDAGHandler.RegisterRoutes(mux, authMiddleware, tenantMiddleware)
+
+	// Register ontology export handler (protected) - raw export bundle download
+	ontologyExportHandler := handlers.NewOntologyExportHandler(ontologyExportService, logger)
+	ontologyExportHandler.RegisterRoutes(mux, authMiddleware, tenantMiddleware)
 
 	// Register ontology enrichment handler (protected) - read-only tiered ontology for UI
 	ontologyEnrichmentHandler := handlers.NewOntologyEnrichmentHandler(schemaService, projectService, logger)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -220,7 +220,6 @@ func Run(version string) error {
 		knowledgeRepo,
 		glossaryRepo,
 		queryRepo,
-		agentRepo,
 		logger,
 	)
 	ontologyImportService := services.NewOntologyImportService(
@@ -229,7 +228,6 @@ func Run(version string) error {
 		schemaRepo,
 		ontologyDAGRepo,
 		installedAppService,
-		credentialEncryptor,
 		logger,
 	)
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -223,6 +223,15 @@ func Run(version string) error {
 		agentRepo,
 		logger,
 	)
+	ontologyImportService := services.NewOntologyImportService(
+		projectRepo,
+		datasourceService,
+		schemaRepo,
+		ontologyDAGRepo,
+		installedAppService,
+		credentialEncryptor,
+		logger,
+	)
 
 	// Create worker pool for parallel LLM calls
 	workerPoolConfig := llm.DefaultWorkerPoolConfig()
@@ -463,6 +472,10 @@ func Run(version string) error {
 	// Register ontology export handler (protected) - raw export bundle download
 	ontologyExportHandler := handlers.NewOntologyExportHandler(ontologyExportService, logger)
 	ontologyExportHandler.RegisterRoutes(mux, authMiddleware, tenantMiddleware)
+
+	// Register ontology import handler (protected) - raw bundle upload for manual/provisioning reuse
+	ontologyImportHandler := handlers.NewOntologyImportHandler(ontologyImportService, logger)
+	ontologyImportHandler.RegisterRoutes(mux, authMiddleware, tenantMiddleware)
 
 	// Register ontology enrichment handler (protected) - read-only tiered ontology for UI
 	ontologyEnrichmentHandler := handlers.NewOntologyEnrichmentHandler(schemaService, projectService, logger)

--- a/pkg/handlers/ontology_export_handler.go
+++ b/pkg/handlers/ontology_export_handler.go
@@ -1,0 +1,76 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/auth"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/services"
+)
+
+// OntologyExportHandler handles ontology bundle export requests.
+type OntologyExportHandler struct {
+	exportService services.OntologyExportService
+	logger        *zap.Logger
+}
+
+// NewOntologyExportHandler creates a new ontology export handler.
+func NewOntologyExportHandler(exportService services.OntologyExportService, logger *zap.Logger) *OntologyExportHandler {
+	return &OntologyExportHandler{
+		exportService: exportService,
+		logger:        logger,
+	}
+}
+
+// RegisterRoutes registers ontology export routes.
+func (h *OntologyExportHandler) RegisterRoutes(mux *http.ServeMux, authMiddleware *auth.Middleware, tenantMiddleware TenantMiddleware) {
+	base := "/api/projects/{pid}/datasources/{dsid}/ontology"
+
+	mux.HandleFunc("GET "+base+"/export",
+		authMiddleware.RequireAuthWithPathValidation("pid")(
+			auth.RequireRole(models.RoleAdmin, models.RoleData)(tenantMiddleware(h.Export))))
+}
+
+// Export handles GET /api/projects/{pid}/datasources/{dsid}/ontology/export.
+func (h *OntologyExportHandler) Export(w http.ResponseWriter, r *http.Request) {
+	projectID, datasourceID, ok := ParseProjectAndDatasourceIDs(w, r, h.logger)
+	if !ok {
+		return
+	}
+
+	bundle, err := h.exportService.BuildBundle(r.Context(), projectID, datasourceID)
+	if err != nil {
+		h.logger.Error("Failed to build ontology export bundle",
+			zap.String("project_id", projectID.String()),
+			zap.String("datasource_id", datasourceID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "export_failed", "Failed to export ontology bundle"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	payload, err := h.exportService.MarshalBundle(bundle)
+	if err != nil {
+		h.logger.Error("Failed to marshal ontology export bundle",
+			zap.String("project_id", projectID.String()),
+			zap.String("datasource_id", datasourceID.String()),
+			zap.Error(err))
+		if err := ErrorResponse(w, http.StatusInternalServerError, "export_failed", "Failed to serialize ontology bundle"); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	filename := h.exportService.SuggestedFilename(bundle)
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
+	w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(payload); err != nil {
+		h.logger.Error("Failed to write ontology export bundle", zap.Error(err))
+	}
+}

--- a/pkg/handlers/ontology_export_handler_test.go
+++ b/pkg/handlers/ontology_export_handler_test.go
@@ -1,0 +1,119 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+)
+
+type mockOntologyExportService struct {
+	buildBundleFn       func(ctx context.Context, projectID, datasourceID uuid.UUID) (*models.OntologyExportBundle, error)
+	marshalBundleFn     func(bundle *models.OntologyExportBundle) ([]byte, error)
+	suggestedFilenameFn func(bundle *models.OntologyExportBundle) string
+}
+
+func (m *mockOntologyExportService) BuildBundle(ctx context.Context, projectID, datasourceID uuid.UUID) (*models.OntologyExportBundle, error) {
+	return m.buildBundleFn(ctx, projectID, datasourceID)
+}
+
+func (m *mockOntologyExportService) MarshalBundle(bundle *models.OntologyExportBundle) ([]byte, error) {
+	return m.marshalBundleFn(bundle)
+}
+
+func (m *mockOntologyExportService) SuggestedFilename(bundle *models.OntologyExportBundle) string {
+	if m.suggestedFilenameFn != nil {
+		return m.suggestedFilenameFn(bundle)
+	}
+	return "ontology-export.json"
+}
+
+func TestOntologyExportHandler_Export_Success(t *testing.T) {
+	projectID := uuid.New()
+	datasourceID := uuid.New()
+	bundle := &models.OntologyExportBundle{
+		Format:     models.OntologyExportFormat,
+		Version:    models.OntologyExportVersion,
+		ExportedAt: time.Date(2026, time.March, 24, 10, 0, 0, 0, time.UTC),
+		Project: models.OntologyExportProject{
+			Name: "The Look Demo",
+		},
+	}
+	payload := []byte("{\n  \"format\": \"ekaya-ontology-export\"\n}")
+
+	handler := NewOntologyExportHandler(&mockOntologyExportService{
+		buildBundleFn: func(ctx context.Context, gotProjectID, gotDatasourceID uuid.UUID) (*models.OntologyExportBundle, error) {
+			if gotProjectID != projectID {
+				t.Fatalf("unexpected project id: %s", gotProjectID)
+			}
+			if gotDatasourceID != datasourceID {
+				t.Fatalf("unexpected datasource id: %s", gotDatasourceID)
+			}
+			return bundle, nil
+		},
+		marshalBundleFn: func(gotBundle *models.OntologyExportBundle) ([]byte, error) {
+			if gotBundle != bundle {
+				t.Fatal("marshal received unexpected bundle")
+			}
+			return payload, nil
+		},
+		suggestedFilenameFn: func(gotBundle *models.OntologyExportBundle) string {
+			if gotBundle != bundle {
+				t.Fatal("filename received unexpected bundle")
+			}
+			return "the-look-demo-export.json"
+		},
+	}, zap.NewNop())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/projects/"+projectID.String()+"/datasources/"+datasourceID.String()+"/ontology/export", nil)
+	req.SetPathValue("pid", projectID.String())
+	req.SetPathValue("dsid", datasourceID.String())
+	rec := httptest.NewRecorder()
+
+	handler.Export(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("expected application/json content type, got %q", got)
+	}
+	if got := rec.Header().Get("Content-Disposition"); got != `attachment; filename="the-look-demo-export.json"` {
+		t.Fatalf("unexpected content disposition: %q", got)
+	}
+	if body := rec.Body.String(); body != string(payload) {
+		t.Fatalf("unexpected body: %q", body)
+	}
+}
+
+func TestOntologyExportHandler_Export_BuildError(t *testing.T) {
+	projectID := uuid.New()
+	datasourceID := uuid.New()
+
+	handler := NewOntologyExportHandler(&mockOntologyExportService{
+		buildBundleFn: func(ctx context.Context, gotProjectID, gotDatasourceID uuid.UUID) (*models.OntologyExportBundle, error) {
+			return nil, context.DeadlineExceeded
+		},
+		marshalBundleFn: func(bundle *models.OntologyExportBundle) ([]byte, error) {
+			t.Fatal("marshal should not be called on build error")
+			return nil, nil
+		},
+	}, zap.NewNop())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/projects/"+projectID.String()+"/datasources/"+datasourceID.String()+"/ontology/export", nil)
+	req.SetPathValue("pid", projectID.String())
+	req.SetPathValue("dsid", datasourceID.String())
+	rec := httptest.NewRecorder()
+
+	handler.Export(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rec.Code)
+	}
+}

--- a/pkg/handlers/ontology_import_handler.go
+++ b/pkg/handlers/ontology_import_handler.go
@@ -1,0 +1,147 @@
+package handlers
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/auth"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/services"
+)
+
+// OntologyImportHandler handles ontology bundle import requests.
+type OntologyImportHandler struct {
+	importService services.OntologyImportService
+	logger        *zap.Logger
+}
+
+// NewOntologyImportHandler creates a new ontology import handler.
+func NewOntologyImportHandler(importService services.OntologyImportService, logger *zap.Logger) *OntologyImportHandler {
+	return &OntologyImportHandler{
+		importService: importService,
+		logger:        logger,
+	}
+}
+
+// RegisterRoutes registers ontology import routes.
+func (h *OntologyImportHandler) RegisterRoutes(mux *http.ServeMux, authMiddleware *auth.Middleware, tenantMiddleware TenantMiddleware) {
+	base := "/api/projects/{pid}/datasources/{dsid}/ontology"
+
+	mux.HandleFunc("POST "+base+"/import",
+		authMiddleware.RequireAuthWithPathValidation("pid")(
+			auth.RequireRole(models.RoleAdmin)(tenantMiddleware(h.Import))))
+}
+
+// Import handles POST /api/projects/{pid}/datasources/{dsid}/ontology/import.
+func (h *OntologyImportHandler) Import(w http.ResponseWriter, r *http.Request) {
+	projectID, datasourceID, ok := ParseProjectAndDatasourceIDs(w, r, h.logger)
+	if !ok {
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, models.OntologyImportMaxBytes)
+	if err := r.ParseMultipartForm(models.OntologyImportMaxBytes); err != nil {
+		if err := WriteJSON(w, http.StatusBadRequest, ApiResponse{
+			Success: false,
+			Error:   "file_too_large",
+			Message: "Ontology bundle exceeds the 5 MB maximum size",
+			Data: models.OntologyImportValidationReport{
+				Problems: []models.OntologyImportProblem{{
+					Code:    "file_too_large",
+					Message: "Ontology bundle exceeds the 5 MB maximum size.",
+				}},
+			},
+		}); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		if err := WriteJSON(w, http.StatusBadRequest, ApiResponse{
+			Success: false,
+			Error:   "invalid_file",
+			Message: "No ontology bundle file was provided",
+			Data: models.OntologyImportValidationReport{
+				Problems: []models.OntologyImportProblem{{
+					Code:    "invalid_file",
+					Message: "Select a local .json ontology bundle to import.",
+				}},
+			},
+		}); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+	defer file.Close()
+
+	if !strings.HasSuffix(strings.ToLower(header.Filename), ".json") {
+		if err := WriteJSON(w, http.StatusBadRequest, ApiResponse{
+			Success: false,
+			Error:   "invalid_file",
+			Message: "Ontology bundle must be a .json file",
+			Data: models.OntologyImportValidationReport{
+				Problems: []models.OntologyImportProblem{{
+					Code:    "invalid_file",
+					Message: "Ontology bundle must use the .json file extension.",
+				}},
+			},
+		}); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	payload, err := io.ReadAll(file)
+	if err != nil {
+		if err := WriteJSON(w, http.StatusBadRequest, ApiResponse{
+			Success: false,
+			Error:   "read_error",
+			Message: "Failed to read the ontology bundle file",
+		}); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	result, err := h.importService.ImportBundle(r.Context(), projectID, datasourceID, payload)
+	if err != nil {
+		var validationErr *services.OntologyImportValidationError
+		if errors.As(err, &validationErr) {
+			if err := WriteJSON(w, validationErr.StatusCode, ApiResponse{
+				Success: false,
+				Error:   validationErr.Code,
+				Message: validationErr.Message,
+				Data:    validationErr.Report,
+			}); err != nil {
+				h.logger.Error("Failed to write validation response", zap.Error(err))
+			}
+			return
+		}
+
+		h.logger.Error("Failed to import ontology bundle",
+			zap.String("project_id", projectID.String()),
+			zap.String("datasource_id", datasourceID.String()),
+			zap.Error(err))
+		if err := WriteJSON(w, http.StatusInternalServerError, ApiResponse{
+			Success: false,
+			Error:   "ontology_import_failed",
+			Message: "Failed to import ontology bundle",
+		}); err != nil {
+			h.logger.Error("Failed to write error response", zap.Error(err))
+		}
+		return
+	}
+
+	if err := WriteJSON(w, http.StatusOK, ApiResponse{
+		Success: true,
+		Data:    result,
+	}); err != nil {
+		h.logger.Error("Failed to write response", zap.Error(err))
+	}
+}

--- a/pkg/handlers/ontology_import_handler_test.go
+++ b/pkg/handlers/ontology_import_handler_test.go
@@ -1,0 +1,144 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/services"
+)
+
+type mockOntologyImportService struct {
+	importBundleFn func(ctx context.Context, projectID, datasourceID uuid.UUID, bundleBytes []byte) (*models.OntologyImportResult, error)
+}
+
+func (m *mockOntologyImportService) ImportBundle(ctx context.Context, projectID, datasourceID uuid.UUID, bundleBytes []byte) (*models.OntologyImportResult, error) {
+	return m.importBundleFn(ctx, projectID, datasourceID, bundleBytes)
+}
+
+func TestOntologyImportHandler_Import_Success(t *testing.T) {
+	projectID := uuid.New()
+	datasourceID := uuid.New()
+	payload := []byte(`{"format":"ekaya-ontology-export","version":1}`)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", "bundle.json")
+	require.NoError(t, err)
+	_, err = part.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	handler := NewOntologyImportHandler(&mockOntologyImportService{
+		importBundleFn: func(ctx context.Context, gotProjectID, gotDatasourceID uuid.UUID, bundleBytes []byte) (*models.OntologyImportResult, error) {
+			require.Equal(t, projectID, gotProjectID)
+			require.Equal(t, datasourceID, gotDatasourceID)
+			require.Equal(t, payload, bundleBytes)
+			return &models.OntologyImportResult{
+				ImportedAt:           time.Date(2026, time.March, 24, 10, 0, 0, 0, time.UTC),
+				CompletionProvenance: models.OntologyCompletionProvenanceImported,
+			}, nil
+		},
+	}, zap.NewNop())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID.String()+"/datasources/"+datasourceID.String()+"/ontology/import", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.SetPathValue("pid", projectID.String())
+	req.SetPathValue("dsid", datasourceID.String())
+	rec := httptest.NewRecorder()
+
+	handler.Import(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var response ApiResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.True(t, response.Success)
+
+	dataMap, ok := response.Data.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "imported", dataMap["completion_provenance"])
+	require.Equal(t, "2026-03-24T10:00:00Z", dataMap["imported_at"])
+}
+
+func TestOntologyImportHandler_Import_ValidationError(t *testing.T) {
+	projectID := uuid.New()
+	datasourceID := uuid.New()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", "bundle.json")
+	require.NoError(t, err)
+	_, err = part.Write([]byte(`{"format":"ekaya-ontology-export","version":1}`))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	handler := NewOntologyImportHandler(&mockOntologyImportService{
+		importBundleFn: func(ctx context.Context, projectID, datasourceID uuid.UUID, bundleBytes []byte) (*models.OntologyImportResult, error) {
+			return nil, &services.OntologyImportValidationError{
+				StatusCode: http.StatusBadRequest,
+				Code:       "schema_validation_failed",
+				Message:    "Ontology bundle does not match the selected datasource schema",
+				Report: models.OntologyImportValidationReport{
+					MissingTables: []models.OntologyExportTableRef{{
+						SchemaName: "public",
+						TableName:  "orders",
+					}},
+				},
+			}
+		},
+	}, zap.NewNop())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID.String()+"/datasources/"+datasourceID.String()+"/ontology/import", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.SetPathValue("pid", projectID.String())
+	req.SetPathValue("dsid", datasourceID.String())
+	rec := httptest.NewRecorder()
+
+	handler.Import(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), `"error":"schema_validation_failed"`)
+	require.Contains(t, rec.Body.String(), `"missing_tables":[{"schema_name":"public","table_name":"orders"}]`)
+}
+
+func TestOntologyImportHandler_Import_RejectsNonJSONFiles(t *testing.T) {
+	projectID := uuid.New()
+	datasourceID := uuid.New()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", "bundle.txt")
+	require.NoError(t, err)
+	_, err = part.Write([]byte(`not-json`))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	handler := NewOntologyImportHandler(&mockOntologyImportService{
+		importBundleFn: func(ctx context.Context, projectID, datasourceID uuid.UUID, bundleBytes []byte) (*models.OntologyImportResult, error) {
+			t.Fatal("import service should not be called for non-json files")
+			return nil, nil
+		},
+	}, zap.NewNop())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/projects/"+projectID.String()+"/datasources/"+datasourceID.String()+"/ontology/import", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.SetPathValue("pid", projectID.String())
+	req.SetPathValue("dsid", datasourceID.String())
+	rec := httptest.NewRecorder()
+
+	handler.Import(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), `"error":"invalid_file"`)
+}

--- a/pkg/handlers/rbac_test.go
+++ b/pkg/handlers/rbac_test.go
@@ -611,6 +611,35 @@ func (m *mockOntologyDAGServiceForRBAC) GetOntologyStatus(ctx context.Context, p
 }
 func (m *mockOntologyDAGServiceForRBAC) Shutdown(ctx context.Context) error { return nil }
 
+// mockOntologyExportServiceForRBAC implements services.OntologyExportService.
+type mockOntologyExportServiceForRBAC struct{}
+
+func (m *mockOntologyExportServiceForRBAC) BuildBundle(ctx context.Context, projectID, datasourceID uuid.UUID) (*models.OntologyExportBundle, error) {
+	return &models.OntologyExportBundle{
+		Format:       models.OntologyExportFormat,
+		Version:      models.OntologyExportVersion,
+		RequiredApps: []string{},
+		Datasources:  []models.OntologyExportDatasource{},
+		Ontology: models.OntologyExportOntology{
+			TableMetadata:    []models.OntologyExportTableMetadata{},
+			ColumnMetadata:   []models.OntologyExportColumnMetadata{},
+			Questions:        []models.OntologyExportQuestion{},
+			ProjectKnowledge: []models.OntologyExportKnowledgeFact{},
+			GlossaryTerms:    []models.OntologyExportGlossaryTerm{},
+		},
+		ApprovedQueries: []models.OntologyExportApprovedQuery{},
+		Agents:          []models.OntologyExportAgent{},
+	}, nil
+}
+
+func (m *mockOntologyExportServiceForRBAC) MarshalBundle(bundle *models.OntologyExportBundle) ([]byte, error) {
+	return []byte(`{"format":"ekaya-ontology-export"}`), nil
+}
+
+func (m *mockOntologyExportServiceForRBAC) SuggestedFilename(bundle *models.OntologyExportBundle) string {
+	return "ontology-export.json"
+}
+
 // mockOntologyChatServiceForRBAC implements services.OntologyChatService.
 type mockOntologyChatServiceForRBAC struct{}
 
@@ -930,6 +959,26 @@ func TestRBAC_OntologyDAGHandler(t *testing.T) {
 		{name: "DELETE_admin_allowed", method: http.MethodDelete, path: base, roles: []string{models.RoleAdmin}, expectedStatus: http.StatusOK},
 		{name: "DELETE_data_allowed", method: http.MethodDelete, path: base, roles: []string{models.RoleData}, expectedStatus: http.StatusOK},
 		{name: "DELETE_user_denied", method: http.MethodDelete, path: base, roles: []string{models.RoleUser}, expectedStatus: http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runRBACTest(t, projectID, handler.RegisterRoutes, tc)
+		})
+	}
+}
+
+func TestRBAC_OntologyExportHandler(t *testing.T) {
+	projectID := uuid.New()
+	dsID := uuid.New()
+	handler := NewOntologyExportHandler(&mockOntologyExportServiceForRBAC{}, zap.NewNop())
+
+	path := "/api/projects/" + projectID.String() + "/datasources/" + dsID.String() + "/ontology/export"
+
+	tests := []rbacTestCase{
+		{name: "GET_export_admin_allowed", method: http.MethodGet, path: path, roles: []string{models.RoleAdmin}, expectedStatus: http.StatusOK},
+		{name: "GET_export_data_allowed", method: http.MethodGet, path: path, roles: []string{models.RoleData}, expectedStatus: http.StatusOK},
+		{name: "GET_export_user_denied", method: http.MethodGet, path: path, roles: []string{models.RoleUser}, expectedStatus: http.StatusForbidden},
 	}
 
 	for _, tc := range tests {

--- a/pkg/handlers/rbac_test.go
+++ b/pkg/handlers/rbac_test.go
@@ -628,7 +628,6 @@ func (m *mockOntologyExportServiceForRBAC) BuildBundle(ctx context.Context, proj
 			GlossaryTerms:    []models.OntologyExportGlossaryTerm{},
 		},
 		ApprovedQueries: []models.OntologyExportApprovedQuery{},
-		Agents:          []models.OntologyExportAgent{},
 	}, nil
 }
 

--- a/pkg/handlers/rbac_test.go
+++ b/pkg/handlers/rbac_test.go
@@ -640,6 +640,15 @@ func (m *mockOntologyExportServiceForRBAC) SuggestedFilename(bundle *models.Onto
 	return "ontology-export.json"
 }
 
+// mockOntologyImportServiceForRBAC implements services.OntologyImportService.
+type mockOntologyImportServiceForRBAC struct{}
+
+func (m *mockOntologyImportServiceForRBAC) ImportBundle(ctx context.Context, projectID, datasourceID uuid.UUID, bundleBytes []byte) (*models.OntologyImportResult, error) {
+	return &models.OntologyImportResult{
+		CompletionProvenance: models.OntologyCompletionProvenanceImported,
+	}, nil
+}
+
 // mockOntologyChatServiceForRBAC implements services.OntologyChatService.
 type mockOntologyChatServiceForRBAC struct{}
 
@@ -979,6 +988,26 @@ func TestRBAC_OntologyExportHandler(t *testing.T) {
 		{name: "GET_export_admin_allowed", method: http.MethodGet, path: path, roles: []string{models.RoleAdmin}, expectedStatus: http.StatusOK},
 		{name: "GET_export_data_allowed", method: http.MethodGet, path: path, roles: []string{models.RoleData}, expectedStatus: http.StatusOK},
 		{name: "GET_export_user_denied", method: http.MethodGet, path: path, roles: []string{models.RoleUser}, expectedStatus: http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runRBACTest(t, projectID, handler.RegisterRoutes, tc)
+		})
+	}
+}
+
+func TestRBAC_OntologyImportHandler(t *testing.T) {
+	projectID := uuid.New()
+	dsID := uuid.New()
+	handler := NewOntologyImportHandler(&mockOntologyImportServiceForRBAC{}, zap.NewNop())
+
+	path := "/api/projects/" + projectID.String() + "/datasources/" + dsID.String() + "/ontology/import"
+
+	tests := []rbacTestCase{
+		{name: "POST_import_admin_allowed", method: http.MethodPost, path: path, roles: []string{models.RoleAdmin}, expectedStatus: http.StatusBadRequest},
+		{name: "POST_import_data_denied", method: http.MethodPost, path: path, roles: []string{models.RoleData}, expectedStatus: http.StatusForbidden},
+		{name: "POST_import_user_denied", method: http.MethodPost, path: path, roles: []string{models.RoleUser}, expectedStatus: http.StatusForbidden},
 	}
 
 	for _, tc := range tests {

--- a/pkg/models/ontology_dag.go
+++ b/pkg/models/ontology_dag.go
@@ -277,8 +277,9 @@ func (n *DAGNode) IsSkipped() bool {
 
 // OntologyStatusResponse represents the ontology status with change detection.
 type OntologyStatusResponse struct {
-	HasOntology             bool           `json:"has_ontology"`
-	LastBuiltAt             *time.Time     `json:"last_built_at,omitempty"`
-	SchemaChangedSinceBuild bool           `json:"schema_changed_since_build"`
-	ChangeSummary           *ChangeSummary `json:"change_summary,omitempty"`
+	HasOntology             bool                         `json:"has_ontology"`
+	LastBuiltAt             *time.Time                   `json:"last_built_at,omitempty"`
+	CompletionProvenance    OntologyCompletionProvenance `json:"completion_provenance,omitempty"`
+	SchemaChangedSinceBuild bool                         `json:"schema_changed_since_build"`
+	ChangeSummary           *ChangeSummary               `json:"change_summary,omitempty"`
 }

--- a/pkg/models/ontology_export.go
+++ b/pkg/models/ontology_export.go
@@ -1,0 +1,216 @@
+package models
+
+import "time"
+
+// OntologyExportFormat identifies the ontology export bundle format.
+const OntologyExportFormat = "ekaya-ontology-export"
+
+// OntologyExportVersion is the current export bundle version.
+const OntologyExportVersion = 1
+
+// OntologyExportBundle is a versioned, import-oriented ontology export artifact.
+type OntologyExportBundle struct {
+	Format          string                        `json:"format"`
+	Version         int                           `json:"version"`
+	ExportedAt      time.Time                     `json:"exported_at"`
+	Project         OntologyExportProject         `json:"project"`
+	RequiredApps    []string                      `json:"required_apps"`
+	Datasources     []OntologyExportDatasource    `json:"datasources"`
+	Ontology        OntologyExportOntology        `json:"ontology"`
+	ApprovedQueries []OntologyExportApprovedQuery `json:"approved_queries"`
+	Agents          []OntologyExportAgent         `json:"agents"`
+	Security        OntologyExportSecurity        `json:"security"`
+}
+
+// OntologyExportProject contains project-scoped template metadata.
+type OntologyExportProject struct {
+	Name          string         `json:"name"`
+	IndustryType  string         `json:"industry_type,omitempty"`
+	DomainSummary *DomainSummary `json:"domain_summary,omitempty"`
+}
+
+// OntologyExportDatasource contains a portable datasource definition and schema snapshot.
+type OntologyExportDatasource struct {
+	Key            string                       `json:"key"`
+	Name           string                       `json:"name"`
+	DatasourceType string                       `json:"datasource_type"`
+	Provider       string                       `json:"provider,omitempty"`
+	Config         map[string]any               `json:"config,omitempty"`
+	SelectedSchema OntologyExportSelectedSchema `json:"selected_schema"`
+}
+
+// OntologyExportSelectedSchema captures the selected schema snapshot for the datasource.
+type OntologyExportSelectedSchema struct {
+	Tables        []OntologyExportTable        `json:"tables"`
+	Relationships []OntologyExportRelationship `json:"relationships"`
+}
+
+// OntologyExportTable is a portable table definition.
+type OntologyExportTable struct {
+	SchemaName string                 `json:"schema_name"`
+	TableName  string                 `json:"table_name"`
+	RowCount   *int64                 `json:"row_count,omitempty"`
+	Columns    []OntologyExportColumn `json:"columns"`
+}
+
+// OntologyExportColumn is a portable column definition.
+type OntologyExportColumn struct {
+	ColumnName        string   `json:"column_name"`
+	DataType          string   `json:"data_type"`
+	IsNullable        bool     `json:"is_nullable"`
+	IsPrimaryKey      bool     `json:"is_primary_key"`
+	IsUnique          bool     `json:"is_unique"`
+	OrdinalPosition   int      `json:"ordinal_position"`
+	DefaultValue      *string  `json:"default_value,omitempty"`
+	DistinctCount     *int64   `json:"distinct_count,omitempty"`
+	NullCount         *int64   `json:"null_count,omitempty"`
+	MinLength         *int64   `json:"min_length,omitempty"`
+	MaxLength         *int64   `json:"max_length,omitempty"`
+	EnumValues        []string `json:"enum_values,omitempty"`
+	RowCount          *int64   `json:"row_count,omitempty"`
+	NonNullCount      *int64   `json:"non_null_count,omitempty"`
+	IsJoinable        *bool    `json:"is_joinable,omitempty"`
+	JoinabilityReason *string  `json:"joinability_reason,omitempty"`
+}
+
+// OntologyExportTableRef identifies a table by natural key.
+type OntologyExportTableRef struct {
+	SchemaName string `json:"schema_name,omitempty"`
+	TableName  string `json:"table_name"`
+}
+
+// OntologyExportColumnRef identifies a column by natural key.
+type OntologyExportColumnRef struct {
+	Table      OntologyExportTableRef `json:"table"`
+	ColumnName string                 `json:"column_name"`
+}
+
+// OntologyExportRelationship is a portable relationship definition.
+type OntologyExportRelationship struct {
+	Source           OntologyExportColumnRef `json:"source"`
+	Target           OntologyExportColumnRef `json:"target"`
+	RelationshipType string                  `json:"relationship_type"`
+	Cardinality      string                  `json:"cardinality"`
+	Confidence       float64                 `json:"confidence"`
+	InferenceMethod  *string                 `json:"inference_method,omitempty"`
+	IsValidated      bool                    `json:"is_validated"`
+	Validation       *ValidationResults      `json:"validation,omitempty"`
+	IsApproved       *bool                   `json:"is_approved,omitempty"`
+}
+
+// OntologyExportOntology contains semantic project state.
+type OntologyExportOntology struct {
+	TableMetadata    []OntologyExportTableMetadata  `json:"table_metadata"`
+	ColumnMetadata   []OntologyExportColumnMetadata `json:"column_metadata"`
+	Questions        []OntologyExportQuestion       `json:"questions"`
+	ProjectKnowledge []OntologyExportKnowledgeFact  `json:"project_knowledge"`
+	GlossaryTerms    []OntologyExportGlossaryTerm   `json:"glossary_terms"`
+}
+
+// OntologyExportTableMetadata is portable table-level semantic metadata.
+type OntologyExportTableMetadata struct {
+	Table                OntologyExportTableRef  `json:"table"`
+	TableType            *string                 `json:"table_type,omitempty"`
+	Description          *string                 `json:"description,omitempty"`
+	UsageNotes           *string                 `json:"usage_notes,omitempty"`
+	IsEphemeral          bool                    `json:"is_ephemeral"`
+	PreferredAlternative *OntologyExportTableRef `json:"preferred_alternative,omitempty"`
+	Confidence           *float64                `json:"confidence,omitempty"`
+	Features             TableMetadataFeatures   `json:"features"`
+	Source               string                  `json:"source,omitempty"`
+	LastEditSource       *string                 `json:"last_edit_source,omitempty"`
+}
+
+// OntologyExportColumnMetadata is portable column-level semantic metadata.
+type OntologyExportColumnMetadata struct {
+	Column                OntologyExportColumnRef `json:"column"`
+	ClassificationPath    *string                 `json:"classification_path,omitempty"`
+	Purpose               *string                 `json:"purpose,omitempty"`
+	SemanticType          *string                 `json:"semantic_type,omitempty"`
+	Role                  *string                 `json:"role,omitempty"`
+	Description           *string                 `json:"description,omitempty"`
+	Confidence            *float64                `json:"confidence,omitempty"`
+	Features              ColumnMetadataFeatures  `json:"features"`
+	NeedsEnumAnalysis     bool                    `json:"needs_enum_analysis"`
+	NeedsFKResolution     bool                    `json:"needs_fk_resolution"`
+	NeedsCrossColumnCheck bool                    `json:"needs_cross_column_check"`
+	NeedsClarification    bool                    `json:"needs_clarification"`
+	ClarificationQuestion *string                 `json:"clarification_question,omitempty"`
+	IsSensitive           *bool                   `json:"is_sensitive,omitempty"`
+	Source                string                  `json:"source,omitempty"`
+	LastEditSource        *string                 `json:"last_edit_source,omitempty"`
+}
+
+// OntologyExportQuestionAffects captures portable question scope.
+type OntologyExportQuestionAffects struct {
+	Tables  []OntologyExportTableRef  `json:"tables,omitempty"`
+	Columns []OntologyExportColumnRef `json:"columns,omitempty"`
+}
+
+// OntologyExportQuestion is a portable ontology question state snapshot.
+type OntologyExportQuestion struct {
+	Text            string                         `json:"text"`
+	Priority        int                            `json:"priority"`
+	IsRequired      bool                           `json:"is_required"`
+	Category        string                         `json:"category,omitempty"`
+	Reasoning       string                         `json:"reasoning,omitempty"`
+	Affects         *OntologyExportQuestionAffects `json:"affects,omitempty"`
+	DetectedPattern string                         `json:"detected_pattern,omitempty"`
+	Status          QuestionStatus                 `json:"status"`
+	StatusReason    string                         `json:"status_reason,omitempty"`
+	Answer          string                         `json:"answer,omitempty"`
+}
+
+// OntologyExportKnowledgeFact is a portable project knowledge fact.
+type OntologyExportKnowledgeFact struct {
+	FactType       string  `json:"fact_type"`
+	Value          string  `json:"value"`
+	Context        string  `json:"context,omitempty"`
+	Source         string  `json:"source,omitempty"`
+	LastEditSource *string `json:"last_edit_source,omitempty"`
+}
+
+// OntologyExportGlossaryTerm is a portable glossary term definition.
+type OntologyExportGlossaryTerm struct {
+	Term             string         `json:"term"`
+	Definition       string         `json:"definition"`
+	DefiningSQL      string         `json:"defining_sql"`
+	BaseTable        string         `json:"base_table,omitempty"`
+	OutputColumns    []OutputColumn `json:"output_columns"`
+	Aliases          []string       `json:"aliases"`
+	EnrichmentStatus string         `json:"enrichment_status,omitempty"`
+	EnrichmentError  string         `json:"enrichment_error,omitempty"`
+	NeedsReview      bool           `json:"needs_review,omitempty"`
+	ReviewReason     string         `json:"review_reason,omitempty"`
+	Source           string         `json:"source,omitempty"`
+	LastEditSource   *string        `json:"last_edit_source,omitempty"`
+}
+
+// OntologyExportApprovedQuery is a portable approved query definition.
+type OntologyExportApprovedQuery struct {
+	Key                   string           `json:"key"`
+	DatasourceKey         string           `json:"datasource_key"`
+	NaturalLanguagePrompt string           `json:"natural_language_prompt"`
+	AdditionalContext     *string          `json:"additional_context,omitempty"`
+	SQL                   string           `json:"sql"`
+	Dialect               string           `json:"dialect"`
+	Enabled               bool             `json:"enabled"`
+	Parameters            []QueryParameter `json:"parameters"`
+	OutputColumns         []OutputColumn   `json:"output_columns"`
+	Constraints           *string          `json:"constraints,omitempty"`
+	Tags                  []string         `json:"tags"`
+	AllowsModification    bool             `json:"allows_modification"`
+}
+
+// OntologyExportAgent is a portable named-agent definition.
+type OntologyExportAgent struct {
+	Name      string   `json:"name"`
+	QueryKeys []string `json:"query_keys"`
+}
+
+// OntologyExportSecurity documents secret-handling guarantees for the bundle.
+type OntologyExportSecurity struct {
+	IncludesDatasourceCredentials bool `json:"includes_datasource_credentials"`
+	IncludesAIConfig              bool `json:"includes_ai_config"`
+	IncludesAgentAPIKeys          bool `json:"includes_agent_api_keys"`
+}

--- a/pkg/models/ontology_export.go
+++ b/pkg/models/ontology_export.go
@@ -18,7 +18,6 @@ type OntologyExportBundle struct {
 	Datasources     []OntologyExportDatasource    `json:"datasources"`
 	Ontology        OntologyExportOntology        `json:"ontology"`
 	ApprovedQueries []OntologyExportApprovedQuery `json:"approved_queries"`
-	Agents          []OntologyExportAgent         `json:"agents"`
 	Security        OntologyExportSecurity        `json:"security"`
 }
 
@@ -200,12 +199,6 @@ type OntologyExportApprovedQuery struct {
 	Constraints           *string          `json:"constraints,omitempty"`
 	Tags                  []string         `json:"tags"`
 	AllowsModification    bool             `json:"allows_modification"`
-}
-
-// OntologyExportAgent is a portable named-agent definition.
-type OntologyExportAgent struct {
-	Name      string   `json:"name"`
-	QueryKeys []string `json:"query_keys"`
 }
 
 // OntologyExportSecurity documents secret-handling guarantees for the bundle.

--- a/pkg/models/ontology_import.go
+++ b/pkg/models/ontology_import.go
@@ -1,0 +1,73 @@
+package models
+
+import "time"
+
+// OntologyImportMaxBytes is the maximum accepted ontology bundle size.
+const OntologyImportMaxBytes = 5 << 20 // 5 MB
+
+// OntologyCompletionProvenance identifies how the current ontology state was produced.
+type OntologyCompletionProvenance string
+
+const (
+	OntologyCompletionProvenanceExtracted OntologyCompletionProvenance = "extracted"
+	OntologyCompletionProvenanceImported  OntologyCompletionProvenance = "imported"
+)
+
+// IsValid returns true when the provenance value is supported.
+func (p OntologyCompletionProvenance) IsValid() bool {
+	switch p {
+	case OntologyCompletionProvenanceExtracted, OntologyCompletionProvenanceImported:
+		return true
+	default:
+		return false
+	}
+}
+
+// OntologyImportResult is returned after a successful ontology bundle import.
+type OntologyImportResult struct {
+	ImportedAt           time.Time                    `json:"imported_at"`
+	CompletionProvenance OntologyCompletionProvenance `json:"completion_provenance"`
+}
+
+// OntologyImportProblem is a structured validation failure for bundle import.
+type OntologyImportProblem struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// OntologyImportDatabaseTypeMismatch describes a datasource type mismatch.
+type OntologyImportDatabaseTypeMismatch struct {
+	BundleType string `json:"bundle_type"`
+	TargetType string `json:"target_type"`
+}
+
+// OntologyImportRelationshipIssue identifies a relationship that could not be resolved.
+type OntologyImportRelationshipIssue struct {
+	Source  OntologyExportColumnRef `json:"source"`
+	Target  OntologyExportColumnRef `json:"target"`
+	Message string                  `json:"message"`
+}
+
+// OntologyImportValidationReport contains structured validation failures for UI display.
+type OntologyImportValidationReport struct {
+	Problems                []OntologyImportProblem             `json:"problems,omitempty"`
+	DatabaseTypeMismatch    *OntologyImportDatabaseTypeMismatch `json:"database_type_mismatch,omitempty"`
+	MissingTables           []OntologyExportTableRef            `json:"missing_tables,omitempty"`
+	UnexpectedTables        []OntologyExportTableRef            `json:"unexpected_tables,omitempty"`
+	MissingColumns          []OntologyExportColumnRef           `json:"missing_columns,omitempty"`
+	UnexpectedColumns       []OntologyExportColumnRef           `json:"unexpected_columns,omitempty"`
+	UnresolvedRelationships []OntologyImportRelationshipIssue   `json:"unresolved_relationships,omitempty"`
+	MissingRequiredApps     []string                            `json:"missing_required_apps,omitempty"`
+}
+
+// HasProblems returns true when the validation report contains any blocking issue.
+func (r OntologyImportValidationReport) HasProblems() bool {
+	return len(r.Problems) > 0 ||
+		r.DatabaseTypeMismatch != nil ||
+		len(r.MissingTables) > 0 ||
+		len(r.UnexpectedTables) > 0 ||
+		len(r.MissingColumns) > 0 ||
+		len(r.UnexpectedColumns) > 0 ||
+		len(r.UnresolvedRelationships) > 0 ||
+		len(r.MissingRequiredApps) > 0
+}

--- a/pkg/services/changeset_false_positive_test.go
+++ b/pkg/services/changeset_false_positive_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
 	"github.com/ekaya-inc/ekaya-engine/pkg/models"
 	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
 )
@@ -198,4 +199,60 @@ func TestComputeChangeSet_DetectsDeselectedColumn(t *testing.T) {
 	assert.False(t, changeSet.IsEmpty(), "ChangeSet should NOT be empty after deselecting a column")
 	assert.Len(t, changeSet.DeletedColumns, 1, "deselected column should appear in DeletedColumns")
 	assert.Equal(t, "email", changeSet.DeletedColumns[0].ColumnName)
+}
+
+// TestGetOntologyStatus_NoFalsePositivesImmediatelyAfterImport verifies that an imported
+// ontology does not immediately report its own selected schema rows as modified.
+func TestGetOntologyStatus_NoFalsePositivesImmediatelyAfterImport(t *testing.T) {
+	tc := setupSchemaServiceTest(t)
+	tc.cleanup()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	usersTable := tc.createTestTable(ctx, "public", "users", true)
+	tc.createTestColumn(ctx, usersTable.ID, "id", "uuid", 1, true)
+	tc.createTestColumn(ctx, usersTable.ID, "email", "text", 2, true)
+
+	time.Sleep(10 * time.Millisecond)
+	importedAt := time.Now().UTC()
+	require.NotZero(t, importedAt.Nanosecond(), "test requires sub-second precision")
+
+	scope, ok := database.GetTenantScope(ctx)
+	require.True(t, ok, "tenant scope should be present")
+
+	_, err := scope.Conn.Exec(ctx, `
+		UPDATE engine_schema_tables
+		SET updated_at = $2
+		WHERE project_id = $1
+	`, tc.projectID, importedAt)
+	require.NoError(t, err)
+
+	_, err = scope.Conn.Exec(ctx, `
+		UPDATE engine_schema_columns
+		SET updated_at = $2
+		WHERE project_id = $1
+	`, tc.projectID, importedAt)
+	require.NoError(t, err)
+
+	require.NoError(t, storeOntologyCompletionState(
+		ctx,
+		scope.Conn,
+		tc.projectID,
+		models.OntologyCompletionProvenanceImported,
+		importedAt,
+	))
+
+	dagSvc := NewOntologyDAGService(nil, repositories.NewSchemaRepository(), nil, nil, nil, nil, nil, zap.NewNop())
+	status, err := dagSvc.GetOntologyStatus(ctx, tc.projectID, tc.dsID)
+	require.NoError(t, err)
+
+	require.True(t, status.HasOntology)
+	require.Equal(t, models.OntologyCompletionProvenanceImported, status.CompletionProvenance)
+	require.NotNil(t, status.LastBuiltAt)
+	require.True(t, status.LastBuiltAt.Equal(importedAt), "stored completion time should preserve import precision")
+	assert.False(t, status.SchemaChangedSinceBuild, "import should not report its own schema selection updates as changes")
+	require.NotNil(t, status.ChangeSummary)
+	assert.Equal(t, 0, status.ChangeSummary.TablesModified)
+	assert.Equal(t, 0, status.ChangeSummary.ColumnsModified)
 }

--- a/pkg/services/changeset_false_positive_test.go
+++ b/pkg/services/changeset_false_positive_test.go
@@ -239,6 +239,7 @@ func TestGetOntologyStatus_NoFalsePositivesImmediatelyAfterImport(t *testing.T) 
 		ctx,
 		scope.Conn,
 		tc.projectID,
+		tc.dsID,
 		models.OntologyCompletionProvenanceImported,
 		importedAt,
 	))

--- a/pkg/services/ontology_completion_state.go
+++ b/pkg/services/ontology_completion_state.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	projectParamOntologyCompletionStates     = "ontology_completion_states"
 	projectParamOntologyCompletionProvenance = "ontology_completion_provenance"
 	projectParamOntologyCompletedAt          = "ontology_completed_at"
 	projectParamOntologyCompletedAtFormat    = time.RFC3339Nano
@@ -24,36 +25,45 @@ type ontologyCompletionState struct {
 	CompletedAt *time.Time
 }
 
+type ontologyCompletionStatePayload struct {
+	Provenance  string `json:"provenance,omitempty"`
+	CompletedAt string `json:"completed_at,omitempty"`
+}
+
 type projectSettingsExecer interface {
 	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 }
 
-func loadOntologyCompletionState(ctx context.Context, execer projectSettingsExecer, projectID uuid.UUID) (*ontologyCompletionState, error) {
-	var raw []byte
-	if err := execer.QueryRow(ctx, `SELECT parameters FROM engine_projects WHERE id = $1`, projectID).Scan(&raw); err != nil {
-		return nil, fmt.Errorf("load project parameters: %w", err)
+func loadOntologyCompletionState(ctx context.Context, execer projectSettingsExecer, projectID, datasourceID uuid.UUID) (*ontologyCompletionState, error) {
+	parameters, err := loadProjectParameters(ctx, execer, projectID)
+	if err != nil {
+		return nil, err
 	}
 
-	parameters := make(map[string]any)
-	if len(raw) > 0 && string(raw) != "null" {
-		if err := json.Unmarshal(raw, &parameters); err != nil {
-			return nil, fmt.Errorf("decode project parameters: %w", err)
-		}
+	states, err := loadOntologyCompletionStatePayloads(parameters)
+	if err != nil {
+		return nil, err
 	}
 
-	state := &ontologyCompletionState{}
-	if value, ok := parameters[projectParamOntologyCompletionProvenance].(string); ok {
-		state.Provenance = models.OntologyCompletionProvenance(value)
+	payload, ok := states[datasourceID.String()]
+	if !ok {
+		return &ontologyCompletionState{}, nil
 	}
-	if value, ok := parameters[projectParamOntologyCompletedAt].(string); ok && value != "" {
-		parsed, err := time.Parse(projectParamOntologyCompletedAtFormat, value)
-		if err != nil {
-			return nil, fmt.Errorf("parse ontology completion time: %w", err)
-		}
-		parsed = parsed.UTC()
-		state.CompletedAt = &parsed
+
+	state := &ontologyCompletionState{
+		Provenance: models.OntologyCompletionProvenance(payload.Provenance),
 	}
+	if payload.CompletedAt == "" {
+		return state, nil
+	}
+
+	parsed, err := time.Parse(projectParamOntologyCompletedAtFormat, payload.CompletedAt)
+	if err != nil {
+		return nil, fmt.Errorf("parse ontology completion time for datasource %s: %w", datasourceID, err)
+	}
+	parsed = parsed.UTC()
+	state.CompletedAt = &parsed
 
 	return state, nil
 }
@@ -62,6 +72,7 @@ func storeOntologyCompletionState(
 	ctx context.Context,
 	execer projectSettingsExecer,
 	projectID uuid.UUID,
+	datasourceID uuid.UUID,
 	provenance models.OntologyCompletionProvenance,
 	completedAt time.Time,
 ) error {
@@ -70,14 +81,76 @@ func storeOntologyCompletionState(
 		return err
 	}
 
-	parameters[projectParamOntologyCompletionProvenance] = string(provenance)
-	parameters[projectParamOntologyCompletedAt] = completedAt.UTC().Format(projectParamOntologyCompletedAtFormat)
+	if err := setOntologyCompletionState(parameters, datasourceID, provenance, completedAt); err != nil {
+		return err
+	}
 
 	return updateProjectParameters(ctx, execer, projectID, parameters)
 }
 
-func clearOntologyCompletionState(ctx context.Context, execer projectSettingsExecer, projectID uuid.UUID) error {
+func clearOntologyCompletionState(ctx context.Context, execer projectSettingsExecer, projectID, datasourceID uuid.UUID) error {
 	parameters, err := loadProjectParameters(ctx, execer, projectID)
+	if err != nil {
+		return err
+	}
+
+	if datasourceID == uuid.Nil {
+		delete(parameters, projectParamOntologyCompletionStates)
+		delete(parameters, projectParamOntologyCompletionProvenance)
+		delete(parameters, projectParamOntologyCompletedAt)
+		return updateProjectParameters(ctx, execer, projectID, parameters)
+	}
+
+	states, err := loadOntologyCompletionStatePayloads(parameters)
+	if err != nil {
+		return err
+	}
+	delete(states, datasourceID.String())
+	if len(states) == 0 {
+		delete(parameters, projectParamOntologyCompletionStates)
+	} else {
+		parameters[projectParamOntologyCompletionStates] = states
+	}
+
+	delete(parameters, projectParamOntologyCompletionProvenance)
+	delete(parameters, projectParamOntologyCompletedAt)
+
+	return updateProjectParameters(ctx, execer, projectID, parameters)
+}
+
+func loadOntologyCompletionStatePayloads(parameters map[string]any) (map[string]ontologyCompletionStatePayload, error) {
+	rawStates, ok := parameters[projectParamOntologyCompletionStates]
+	if !ok || rawStates == nil {
+		return map[string]ontologyCompletionStatePayload{}, nil
+	}
+
+	payload, err := json.Marshal(rawStates)
+	if err != nil {
+		return nil, fmt.Errorf("encode ontology completion states: %w", err)
+	}
+
+	var states map[string]ontologyCompletionStatePayload
+	if err := json.Unmarshal(payload, &states); err != nil {
+		return nil, fmt.Errorf("decode ontology completion states: %w", err)
+	}
+	if states == nil {
+		return map[string]ontologyCompletionStatePayload{}, nil
+	}
+
+	return states, nil
+}
+
+func setOntologyCompletionState(
+	parameters map[string]any,
+	datasourceID uuid.UUID,
+	provenance models.OntologyCompletionProvenance,
+	completedAt time.Time,
+) error {
+	if datasourceID == uuid.Nil {
+		return fmt.Errorf("datasource id is required for ontology completion state")
+	}
+
+	states, err := loadOntologyCompletionStatePayloads(parameters)
 	if err != nil {
 		return err
 	}
@@ -85,7 +158,13 @@ func clearOntologyCompletionState(ctx context.Context, execer projectSettingsExe
 	delete(parameters, projectParamOntologyCompletionProvenance)
 	delete(parameters, projectParamOntologyCompletedAt)
 
-	return updateProjectParameters(ctx, execer, projectID, parameters)
+	states[datasourceID.String()] = ontologyCompletionStatePayload{
+		Provenance:  string(provenance),
+		CompletedAt: completedAt.UTC().Format(projectParamOntologyCompletedAtFormat),
+	}
+	parameters[projectParamOntologyCompletionStates] = states
+
+	return nil
 }
 
 func loadProjectParameters(ctx context.Context, execer projectSettingsExecer, projectID uuid.UUID) (map[string]any, error) {

--- a/pkg/services/ontology_completion_state.go
+++ b/pkg/services/ontology_completion_state.go
@@ -1,0 +1,124 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+)
+
+const (
+	projectParamOntologyCompletionProvenance = "ontology_completion_provenance"
+	projectParamOntologyCompletedAt          = "ontology_completed_at"
+	projectParamOntologyCompletedAtFormat    = time.RFC3339Nano
+)
+
+type ontologyCompletionState struct {
+	Provenance  models.OntologyCompletionProvenance
+	CompletedAt *time.Time
+}
+
+type projectSettingsExecer interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+func loadOntologyCompletionState(ctx context.Context, execer projectSettingsExecer, projectID uuid.UUID) (*ontologyCompletionState, error) {
+	var raw []byte
+	if err := execer.QueryRow(ctx, `SELECT parameters FROM engine_projects WHERE id = $1`, projectID).Scan(&raw); err != nil {
+		return nil, fmt.Errorf("load project parameters: %w", err)
+	}
+
+	parameters := make(map[string]any)
+	if len(raw) > 0 && string(raw) != "null" {
+		if err := json.Unmarshal(raw, &parameters); err != nil {
+			return nil, fmt.Errorf("decode project parameters: %w", err)
+		}
+	}
+
+	state := &ontologyCompletionState{}
+	if value, ok := parameters[projectParamOntologyCompletionProvenance].(string); ok {
+		state.Provenance = models.OntologyCompletionProvenance(value)
+	}
+	if value, ok := parameters[projectParamOntologyCompletedAt].(string); ok && value != "" {
+		parsed, err := time.Parse(projectParamOntologyCompletedAtFormat, value)
+		if err != nil {
+			return nil, fmt.Errorf("parse ontology completion time: %w", err)
+		}
+		parsed = parsed.UTC()
+		state.CompletedAt = &parsed
+	}
+
+	return state, nil
+}
+
+func storeOntologyCompletionState(
+	ctx context.Context,
+	execer projectSettingsExecer,
+	projectID uuid.UUID,
+	provenance models.OntologyCompletionProvenance,
+	completedAt time.Time,
+) error {
+	parameters, err := loadProjectParameters(ctx, execer, projectID)
+	if err != nil {
+		return err
+	}
+
+	parameters[projectParamOntologyCompletionProvenance] = string(provenance)
+	parameters[projectParamOntologyCompletedAt] = completedAt.UTC().Format(projectParamOntologyCompletedAtFormat)
+
+	return updateProjectParameters(ctx, execer, projectID, parameters)
+}
+
+func clearOntologyCompletionState(ctx context.Context, execer projectSettingsExecer, projectID uuid.UUID) error {
+	parameters, err := loadProjectParameters(ctx, execer, projectID)
+	if err != nil {
+		return err
+	}
+
+	delete(parameters, projectParamOntologyCompletionProvenance)
+	delete(parameters, projectParamOntologyCompletedAt)
+
+	return updateProjectParameters(ctx, execer, projectID, parameters)
+}
+
+func loadProjectParameters(ctx context.Context, execer projectSettingsExecer, projectID uuid.UUID) (map[string]any, error) {
+	var raw []byte
+	if err := execer.QueryRow(ctx, `SELECT parameters FROM engine_projects WHERE id = $1`, projectID).Scan(&raw); err != nil {
+		return nil, fmt.Errorf("load project parameters: %w", err)
+	}
+
+	parameters := make(map[string]any)
+	if len(raw) == 0 || string(raw) == "null" {
+		return parameters, nil
+	}
+
+	if err := json.Unmarshal(raw, &parameters); err != nil {
+		return nil, fmt.Errorf("decode project parameters: %w", err)
+	}
+
+	return parameters, nil
+}
+
+func updateProjectParameters(ctx context.Context, execer projectSettingsExecer, projectID uuid.UUID, parameters map[string]any) error {
+	payload, err := json.Marshal(parameters)
+	if err != nil {
+		return fmt.Errorf("encode project parameters: %w", err)
+	}
+
+	if _, err := execer.Exec(ctx, `
+		UPDATE engine_projects
+		SET parameters = $2, updated_at = $3
+		WHERE id = $1
+	`, projectID, payload, time.Now().UTC()); err != nil {
+		return fmt.Errorf("update project parameters: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/services/ontology_dag_incremental.go
+++ b/pkg/services/ontology_dag_incremental.go
@@ -221,7 +221,7 @@ func (s *ontologyDAGService) GetOntologyStatus(ctx context.Context, projectID, d
 		return nil, fmt.Errorf("get last completed DAG: %w", err)
 	}
 
-	completionState, err := loadOntologyCompletionState(ctx, scope.Conn, projectID)
+	completionState, err := loadOntologyCompletionState(ctx, scope.Conn, projectID, datasourceID)
 	if err != nil {
 		return nil, fmt.Errorf("load ontology completion state: %w", err)
 	}

--- a/pkg/services/ontology_dag_incremental.go
+++ b/pkg/services/ontology_dag_incremental.go
@@ -210,24 +210,46 @@ func (s *ontologyDAGService) GetLastCompletedDAG(ctx context.Context, datasource
 
 // GetOntologyStatus returns the current ontology status with change detection.
 func (s *ontologyDAGService) GetOntologyStatus(ctx context.Context, projectID, datasourceID uuid.UUID) (*models.OntologyStatusResponse, error) {
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
 	// Get the latest completed DAG
 	lastDAG, err := s.GetLastCompletedDAG(ctx, datasourceID)
 	if err != nil {
 		return nil, fmt.Errorf("get last completed DAG: %w", err)
 	}
 
-	resp := &models.OntologyStatusResponse{
-		HasOntology: lastDAG != nil,
+	completionState, err := loadOntologyCompletionState(ctx, scope.Conn, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("load ontology completion state: %w", err)
 	}
 
-	if lastDAG == nil || lastDAG.CompletedAt == nil {
+	resp := &models.OntologyStatusResponse{
+		HasOntology: completionState.Provenance.IsValid() || lastDAG != nil,
+	}
+
+	switch {
+	case completionState.Provenance.IsValid():
+		resp.CompletionProvenance = completionState.Provenance
+	case lastDAG != nil:
+		resp.CompletionProvenance = models.OntologyCompletionProvenanceExtracted
+	}
+
+	switch {
+	case completionState.CompletedAt != nil:
+		resp.LastBuiltAt = completionState.CompletedAt
+	case lastDAG != nil && lastDAG.CompletedAt != nil:
+		resp.LastBuiltAt = lastDAG.CompletedAt
+	}
+
+	if resp.LastBuiltAt == nil {
 		return resp, nil
 	}
 
-	resp.LastBuiltAt = lastDAG.CompletedAt
-
 	// Compute what has changed since the last build
-	changeSet, err := s.ComputeChangeSet(ctx, projectID, *lastDAG.CompletedAt)
+	changeSet, err := s.ComputeChangeSet(ctx, projectID, *resp.LastBuiltAt)
 	if err != nil {
 		return nil, fmt.Errorf("compute change set: %w", err)
 	}

--- a/pkg/services/ontology_dag_service.go
+++ b/pkg/services/ontology_dag_service.go
@@ -449,7 +449,7 @@ func (s *ontologyDAGService) Delete(ctx context.Context, projectID uuid.UUID) er
 	if !ok {
 		return fmt.Errorf("no tenant scope in context")
 	}
-	if err := clearOntologyCompletionState(ctx, scope.Conn, projectID); err != nil {
+	if err := clearOntologyCompletionState(ctx, scope.Conn, projectID, uuid.Nil); err != nil {
 		s.logger.Error("Failed to clear ontology completion state", zap.String("project_id", projectID.String()), zap.Error(err))
 		return fmt.Errorf("clear ontology completion state: %w", err)
 	}
@@ -596,7 +596,7 @@ func (s *ontologyDAGService) executeDAG(projectID, dagID, userID uuid.UUID, chan
 	}
 
 	// All nodes completed successfully
-	s.markDAGCompleted(projectID, dagID)
+	s.markDAGCompleted(projectID, dagRecord.DatasourceID, dagID)
 }
 
 // executeNode runs a single node with retry logic.
@@ -835,7 +835,7 @@ func (s *ontologyDAGService) markDAGFailed(projectID, dagID uuid.UUID, errMsg st
 }
 
 // markDAGCompleted marks the DAG as completed.
-func (s *ontologyDAGService) markDAGCompleted(projectID, dagID uuid.UUID) {
+func (s *ontologyDAGService) markDAGCompleted(projectID, datasourceID, dagID uuid.UUID) {
 	ctx, cleanup, err := s.getTenantCtx(context.Background(), projectID)
 	if err != nil {
 		s.logger.Error("Failed to get tenant context for marking DAG completed", zap.Error(err))
@@ -852,7 +852,7 @@ func (s *ontologyDAGService) markDAGCompleted(projectID, dagID uuid.UUID) {
 		s.logger.Error("Tenant scope missing while marking DAG completed")
 		return
 	}
-	if err := storeOntologyCompletionState(ctx, scope.Conn, projectID, models.OntologyCompletionProvenanceExtracted, time.Now().UTC()); err != nil {
+	if err := storeOntologyCompletionState(ctx, scope.Conn, projectID, datasourceID, models.OntologyCompletionProvenanceExtracted, time.Now().UTC()); err != nil {
 		s.logger.Error("Failed to store ontology completion state", zap.Error(err))
 	}
 

--- a/pkg/services/ontology_dag_service.go
+++ b/pkg/services/ontology_dag_service.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ekaya-inc/ekaya-engine/pkg/auth"
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
 	"github.com/ekaya-inc/ekaya-engine/pkg/llm"
 	"github.com/ekaya-inc/ekaya-engine/pkg/models"
 	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
@@ -444,6 +445,15 @@ func (s *ontologyDAGService) Delete(ctx context.Context, projectID uuid.UUID) er
 	}
 	s.logger.Debug("Deleted inferred relationships", zap.String("project_id", projectID.String()), zap.Int64("count", deletedRels))
 
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return fmt.Errorf("no tenant scope in context")
+	}
+	if err := clearOntologyCompletionState(ctx, scope.Conn, projectID); err != nil {
+		s.logger.Error("Failed to clear ontology completion state", zap.String("project_id", projectID.String()), zap.Error(err))
+		return fmt.Errorf("clear ontology completion state: %w", err)
+	}
+
 	s.logger.Info("Successfully deleted all ontology data", zap.String("project_id", projectID.String()))
 	return nil
 }
@@ -835,6 +845,15 @@ func (s *ontologyDAGService) markDAGCompleted(projectID, dagID uuid.UUID) {
 
 	if err := s.dagRepo.UpdateStatus(ctx, dagID, models.DAGStatusCompleted, nil); err != nil {
 		s.logger.Error("Failed to mark DAG as completed", zap.Error(err))
+	}
+
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		s.logger.Error("Tenant scope missing while marking DAG completed")
+		return
+	}
+	if err := storeOntologyCompletionState(ctx, scope.Conn, projectID, models.OntologyCompletionProvenanceExtracted, time.Now().UTC()); err != nil {
+		s.logger.Error("Failed to store ontology completion state", zap.Error(err))
 	}
 
 	s.logger.Info("DAG completed successfully", zap.String("dag_id", dagID.String()))

--- a/pkg/services/ontology_export.go
+++ b/pkg/services/ontology_export.go
@@ -68,11 +68,6 @@ type ontologyExportQueryRepository interface {
 	ListByDatasource(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.Query, error)
 }
 
-type ontologyExportAgentRepository interface {
-	ListByProject(ctx context.Context, projectID uuid.UUID) ([]*models.Agent, error)
-	GetQueryAccessByAgentIDs(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID][]uuid.UUID, error)
-}
-
 type ontologyExportService struct {
 	projectRepo        ontologyExportProjectRepository
 	datasourceService  ontologyExportDatasourceService
@@ -83,7 +78,6 @@ type ontologyExportService struct {
 	knowledgeRepo      ontologyExportKnowledgeRepository
 	glossaryRepo       ontologyExportGlossaryRepository
 	queryRepo          ontologyExportQueryRepository
-	agentRepo          ontologyExportAgentRepository
 	logger             *zap.Logger
 }
 
@@ -105,7 +99,6 @@ func NewOntologyExportService(
 	knowledgeRepo ontologyExportKnowledgeRepository,
 	glossaryRepo ontologyExportGlossaryRepository,
 	queryRepo ontologyExportQueryRepository,
-	agentRepo ontologyExportAgentRepository,
 	logger *zap.Logger,
 ) OntologyExportService {
 	return &ontologyExportService{
@@ -118,7 +111,6 @@ func NewOntologyExportService(
 		knowledgeRepo:      knowledgeRepo,
 		glossaryRepo:       glossaryRepo,
 		queryRepo:          queryRepo,
-		agentRepo:          agentRepo,
 		logger:             logger,
 	}
 }
@@ -183,24 +175,13 @@ func (s *ontologyExportService) BuildBundle(ctx context.Context, projectID, data
 		return nil, fmt.Errorf("load queries: %w", err)
 	}
 
-	agents, err := s.agentRepo.ListByProject(ctx, projectID)
-	if err != nil {
-		return nil, fmt.Errorf("load agents: %w", err)
-	}
-
-	queryAccessByAgentID, err := s.loadAgentQueryAccess(ctx, agents)
-	if err != nil {
-		return nil, fmt.Errorf("load agent query access: %w", err)
-	}
-
-	exportedQueries, queryKeys := buildApprovedQueryExports(queries)
-	exportedAgents := buildExportAgents(agents, queryAccessByAgentID, queryKeys)
+	exportedQueries := buildApprovedQueryExports(queries)
 
 	bundle := &models.OntologyExportBundle{
 		Format:       models.OntologyExportFormat,
 		Version:      models.OntologyExportVersion,
 		ExportedAt:   time.Now().UTC(),
-		RequiredApps: buildRequiredApps(exportedQueries, exportedAgents),
+		RequiredApps: buildRequiredApps(exportedQueries),
 		Project: models.OntologyExportProject{
 			Name:          project.Name,
 			IndustryType:  project.IndustryType,
@@ -227,7 +208,6 @@ func (s *ontologyExportService) BuildBundle(ctx context.Context, projectID, data
 			GlossaryTerms:    buildExportGlossaryTerms(glossaryTerms),
 		},
 		ApprovedQueries: exportedQueries,
-		Agents:          exportedAgents,
 		Security: models.OntologyExportSecurity{
 			IncludesDatasourceCredentials: false,
 			IncludesAIConfig:              false,
@@ -279,19 +259,6 @@ func (s *ontologyExportService) loadAllQuestions(ctx context.Context, projectID 
 	}
 
 	return result, nil
-}
-
-func (s *ontologyExportService) loadAgentQueryAccess(ctx context.Context, agents []*models.Agent) (map[uuid.UUID][]uuid.UUID, error) {
-	if len(agents) == 0 {
-		return map[uuid.UUID][]uuid.UUID{}, nil
-	}
-
-	agentIDs := make([]uuid.UUID, 0, len(agents))
-	for _, agent := range agents {
-		agentIDs = append(agentIDs, agent.ID)
-	}
-
-	return s.agentRepo.GetQueryAccessByAgentIDs(ctx, agentIDs)
 }
 
 func filterSelectedTables(tables []*models.SchemaTable) map[uuid.UUID]*models.SchemaTable {
@@ -675,7 +642,7 @@ func buildExportGlossaryTerms(terms []*models.BusinessGlossaryTerm) []models.Ont
 	return exported
 }
 
-func buildApprovedQueryExports(queries []*models.Query) ([]models.OntologyExportApprovedQuery, map[uuid.UUID]string) {
+func buildApprovedQueryExports(queries []*models.Query) []models.OntologyExportApprovedQuery {
 	approved := make([]*models.Query, 0, len(queries))
 	for _, query := range queries {
 		if query == nil || query.Status != "approved" {
@@ -695,10 +662,8 @@ func buildApprovedQueryExports(queries []*models.Query) ([]models.OntologyExport
 	})
 
 	exported := make([]models.OntologyExportApprovedQuery, 0, len(approved))
-	keys := make(map[uuid.UUID]string, len(approved))
 	for index, query := range approved {
 		key := fmt.Sprintf("query_%03d", index+1)
-		keys[query.ID] = key
 
 		parameters := append([]models.QueryParameter(nil), query.Parameters...)
 		sort.Slice(parameters, func(i, j int) bool {
@@ -729,53 +694,13 @@ func buildApprovedQueryExports(queries []*models.Query) ([]models.OntologyExport
 		})
 	}
 
-	return exported, keys
-}
-
-func buildExportAgents(
-	agents []*models.Agent,
-	queryAccessByAgentID map[uuid.UUID][]uuid.UUID,
-	queryKeys map[uuid.UUID]string,
-) []models.OntologyExportAgent {
-	exported := make([]models.OntologyExportAgent, 0, len(agents))
-	for _, agent := range agents {
-		if agent == nil {
-			continue
-		}
-
-		queryIDs := queryAccessByAgentID[agent.ID]
-		queryKeysForAgent := make([]string, 0, len(queryIDs))
-		for _, queryID := range queryIDs {
-			if key, ok := queryKeys[queryID]; ok {
-				queryKeysForAgent = append(queryKeysForAgent, key)
-			}
-		}
-
-		if len(queryKeysForAgent) == 0 {
-			continue
-		}
-
-		sort.Strings(queryKeysForAgent)
-		exported = append(exported, models.OntologyExportAgent{
-			Name:      agent.Name,
-			QueryKeys: queryKeysForAgent,
-		})
-	}
-
-	sort.Slice(exported, func(i, j int) bool {
-		return exported[i].Name < exported[j].Name
-	})
-
 	return exported
 }
 
-func buildRequiredApps(queries []models.OntologyExportApprovedQuery, agents []models.OntologyExportAgent) []string {
+func buildRequiredApps(queries []models.OntologyExportApprovedQuery) []string {
 	apps := []string{models.AppIDOntologyForge}
 	if len(queries) > 0 {
 		apps = append(apps, models.AppIDAIDataLiaison)
-	}
-	if len(agents) > 0 {
-		apps = append(apps, models.AppIDAIAgents)
 	}
 	return apps
 }

--- a/pkg/services/ontology_export.go
+++ b/pkg/services/ontology_export.go
@@ -1,0 +1,942 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
+)
+
+const (
+	ontologyExportDatasourceKey    = "primary"
+	ontologyExportQuestionPageSize = 500
+)
+
+var nonFilenameChars = regexp.MustCompile(`[^a-z0-9]+`)
+
+// OntologyExportService assembles portable ontology export bundles.
+type OntologyExportService interface {
+	BuildBundle(ctx context.Context, projectID, datasourceID uuid.UUID) (*models.OntologyExportBundle, error)
+	MarshalBundle(bundle *models.OntologyExportBundle) ([]byte, error)
+	SuggestedFilename(bundle *models.OntologyExportBundle) string
+}
+
+type ontologyExportProjectRepository interface {
+	Get(ctx context.Context, id uuid.UUID) (*models.Project, error)
+}
+
+type ontologyExportDatasourceService interface {
+	Get(ctx context.Context, projectID, id uuid.UUID) (*models.Datasource, error)
+}
+
+type ontologyExportSchemaRepository interface {
+	ListTablesByDatasource(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.SchemaTable, error)
+	ListColumnsByDatasource(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.SchemaColumn, error)
+	ListRelationshipsByDatasource(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.SchemaRelationship, error)
+}
+
+type ontologyExportTableMetadataRepository interface {
+	List(ctx context.Context, projectID uuid.UUID) ([]*models.TableMetadata, error)
+}
+
+type ontologyExportColumnMetadataRepository interface {
+	GetByProject(ctx context.Context, projectID uuid.UUID) ([]*models.ColumnMetadata, error)
+}
+
+type ontologyExportQuestionRepository interface {
+	List(ctx context.Context, projectID uuid.UUID, filters repositories.QuestionListFilters) (*repositories.QuestionListResult, error)
+}
+
+type ontologyExportKnowledgeRepository interface {
+	GetByProject(ctx context.Context, projectID uuid.UUID) ([]*models.KnowledgeFact, error)
+}
+
+type ontologyExportGlossaryRepository interface {
+	GetByProject(ctx context.Context, projectID uuid.UUID) ([]*models.BusinessGlossaryTerm, error)
+}
+
+type ontologyExportQueryRepository interface {
+	ListByDatasource(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.Query, error)
+}
+
+type ontologyExportAgentRepository interface {
+	ListByProject(ctx context.Context, projectID uuid.UUID) ([]*models.Agent, error)
+	GetQueryAccessByAgentIDs(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID][]uuid.UUID, error)
+}
+
+type ontologyExportService struct {
+	projectRepo        ontologyExportProjectRepository
+	datasourceService  ontologyExportDatasourceService
+	schemaRepo         ontologyExportSchemaRepository
+	tableMetadataRepo  ontologyExportTableMetadataRepository
+	columnMetadataRepo ontologyExportColumnMetadataRepository
+	questionRepo       ontologyExportQuestionRepository
+	knowledgeRepo      ontologyExportKnowledgeRepository
+	glossaryRepo       ontologyExportGlossaryRepository
+	queryRepo          ontologyExportQueryRepository
+	agentRepo          ontologyExportAgentRepository
+	logger             *zap.Logger
+}
+
+type schemaRefResolver struct {
+	tableByID     map[uuid.UUID]models.OntologyExportTableRef
+	columnByID    map[uuid.UUID]models.OntologyExportColumnRef
+	tableByName   map[string][]models.OntologyExportTableRef
+	columnByValue map[string][]models.OntologyExportColumnRef
+}
+
+// NewOntologyExportService creates a new ontology export service.
+func NewOntologyExportService(
+	projectRepo ontologyExportProjectRepository,
+	datasourceService ontologyExportDatasourceService,
+	schemaRepo ontologyExportSchemaRepository,
+	tableMetadataRepo ontologyExportTableMetadataRepository,
+	columnMetadataRepo ontologyExportColumnMetadataRepository,
+	questionRepo ontologyExportQuestionRepository,
+	knowledgeRepo ontologyExportKnowledgeRepository,
+	glossaryRepo ontologyExportGlossaryRepository,
+	queryRepo ontologyExportQueryRepository,
+	agentRepo ontologyExportAgentRepository,
+	logger *zap.Logger,
+) OntologyExportService {
+	return &ontologyExportService{
+		projectRepo:        projectRepo,
+		datasourceService:  datasourceService,
+		schemaRepo:         schemaRepo,
+		tableMetadataRepo:  tableMetadataRepo,
+		columnMetadataRepo: columnMetadataRepo,
+		questionRepo:       questionRepo,
+		knowledgeRepo:      knowledgeRepo,
+		glossaryRepo:       glossaryRepo,
+		queryRepo:          queryRepo,
+		agentRepo:          agentRepo,
+		logger:             logger,
+	}
+}
+
+func (s *ontologyExportService) BuildBundle(ctx context.Context, projectID, datasourceID uuid.UUID) (*models.OntologyExportBundle, error) {
+	project, err := s.projectRepo.Get(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("load project: %w", err)
+	}
+
+	ds, err := s.datasourceService.Get(ctx, projectID, datasourceID)
+	if err != nil {
+		return nil, fmt.Errorf("load datasource: %w", err)
+	}
+
+	tables, err := s.schemaRepo.ListTablesByDatasource(ctx, projectID, datasourceID)
+	if err != nil {
+		return nil, fmt.Errorf("load schema tables: %w", err)
+	}
+
+	columns, err := s.schemaRepo.ListColumnsByDatasource(ctx, projectID, datasourceID)
+	if err != nil {
+		return nil, fmt.Errorf("load schema columns: %w", err)
+	}
+
+	relationships, err := s.schemaRepo.ListRelationshipsByDatasource(ctx, projectID, datasourceID)
+	if err != nil {
+		return nil, fmt.Errorf("load schema relationships: %w", err)
+	}
+
+	selectedTables := filterSelectedTables(tables)
+	selectedColumns := filterSelectedColumns(columns, selectedTables)
+	resolver := buildSchemaRefResolver(selectedTables, selectedColumns)
+
+	tableMetadata, err := s.tableMetadataRepo.List(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("load table metadata: %w", err)
+	}
+
+	columnMetadata, err := s.columnMetadataRepo.GetByProject(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("load column metadata: %w", err)
+	}
+
+	questions, err := s.loadAllQuestions(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("load ontology questions: %w", err)
+	}
+
+	knowledgeFacts, err := s.knowledgeRepo.GetByProject(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("load project knowledge: %w", err)
+	}
+
+	glossaryTerms, err := s.glossaryRepo.GetByProject(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("load glossary terms: %w", err)
+	}
+
+	queries, err := s.queryRepo.ListByDatasource(ctx, projectID, datasourceID)
+	if err != nil {
+		return nil, fmt.Errorf("load queries: %w", err)
+	}
+
+	agents, err := s.agentRepo.ListByProject(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("load agents: %w", err)
+	}
+
+	queryAccessByAgentID, err := s.loadAgentQueryAccess(ctx, agents)
+	if err != nil {
+		return nil, fmt.Errorf("load agent query access: %w", err)
+	}
+
+	exportedQueries, queryKeys := buildApprovedQueryExports(queries)
+	exportedAgents := buildExportAgents(agents, queryAccessByAgentID, queryKeys)
+
+	bundle := &models.OntologyExportBundle{
+		Format:       models.OntologyExportFormat,
+		Version:      models.OntologyExportVersion,
+		ExportedAt:   time.Now().UTC(),
+		RequiredApps: buildRequiredApps(exportedQueries, exportedAgents),
+		Project: models.OntologyExportProject{
+			Name:          project.Name,
+			IndustryType:  project.IndustryType,
+			DomainSummary: project.DomainSummary,
+		},
+		Datasources: []models.OntologyExportDatasource{
+			{
+				Key:            ontologyExportDatasourceKey,
+				Name:           ds.Name,
+				DatasourceType: ds.DatasourceType,
+				Provider:       ds.Provider,
+				Config:         sanitizeDatasourceConfig(ds.Config),
+				SelectedSchema: models.OntologyExportSelectedSchema{
+					Tables:        buildExportTables(selectedTables, selectedColumns),
+					Relationships: buildExportRelationships(relationships, resolver),
+				},
+			},
+		},
+		Ontology: models.OntologyExportOntology{
+			TableMetadata:    buildExportTableMetadata(tableMetadata, resolver),
+			ColumnMetadata:   buildExportColumnMetadata(columnMetadata, resolver),
+			Questions:        buildExportQuestions(questions, resolver),
+			ProjectKnowledge: buildExportKnowledge(knowledgeFacts),
+			GlossaryTerms:    buildExportGlossaryTerms(glossaryTerms),
+		},
+		ApprovedQueries: exportedQueries,
+		Agents:          exportedAgents,
+		Security: models.OntologyExportSecurity{
+			IncludesDatasourceCredentials: false,
+			IncludesAIConfig:              false,
+			IncludesAgentAPIKeys:          false,
+		},
+	}
+
+	return bundle, nil
+}
+
+func (s *ontologyExportService) MarshalBundle(bundle *models.OntologyExportBundle) ([]byte, error) {
+	if bundle == nil {
+		return nil, fmt.Errorf("bundle is required")
+	}
+	return json.MarshalIndent(bundle, "", "  ")
+}
+
+func (s *ontologyExportService) SuggestedFilename(bundle *models.OntologyExportBundle) string {
+	if bundle == nil {
+		return "ontology-export.json"
+	}
+
+	slug := slugifyFilename(bundle.Project.Name)
+	if slug == "" {
+		slug = "ontology"
+	}
+
+	return fmt.Sprintf("%s-export.json", slug)
+}
+
+func (s *ontologyExportService) loadAllQuestions(ctx context.Context, projectID uuid.UUID) ([]*models.OntologyQuestion, error) {
+	var result []*models.OntologyQuestion
+	offset := 0
+
+	for {
+		page, err := s.questionRepo.List(ctx, projectID, repositories.QuestionListFilters{
+			Limit:  ontologyExportQuestionPageSize,
+			Offset: offset,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, page.Questions...)
+		offset += len(page.Questions)
+		if offset >= page.TotalCount || len(page.Questions) == 0 {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func (s *ontologyExportService) loadAgentQueryAccess(ctx context.Context, agents []*models.Agent) (map[uuid.UUID][]uuid.UUID, error) {
+	if len(agents) == 0 {
+		return map[uuid.UUID][]uuid.UUID{}, nil
+	}
+
+	agentIDs := make([]uuid.UUID, 0, len(agents))
+	for _, agent := range agents {
+		agentIDs = append(agentIDs, agent.ID)
+	}
+
+	return s.agentRepo.GetQueryAccessByAgentIDs(ctx, agentIDs)
+}
+
+func filterSelectedTables(tables []*models.SchemaTable) map[uuid.UUID]*models.SchemaTable {
+	selected := make(map[uuid.UUID]*models.SchemaTable)
+	for _, table := range tables {
+		if table == nil || !table.IsSelected {
+			continue
+		}
+		selected[table.ID] = table
+	}
+	return selected
+}
+
+func filterSelectedColumns(columns []*models.SchemaColumn, selectedTables map[uuid.UUID]*models.SchemaTable) map[uuid.UUID]*models.SchemaColumn {
+	selected := make(map[uuid.UUID]*models.SchemaColumn)
+	for _, column := range columns {
+		if column == nil || !column.IsSelected {
+			continue
+		}
+		if _, ok := selectedTables[column.SchemaTableID]; !ok {
+			continue
+		}
+		selected[column.ID] = column
+	}
+	return selected
+}
+
+func buildSchemaRefResolver(
+	selectedTables map[uuid.UUID]*models.SchemaTable,
+	selectedColumns map[uuid.UUID]*models.SchemaColumn,
+) schemaRefResolver {
+	resolver := schemaRefResolver{
+		tableByID:     make(map[uuid.UUID]models.OntologyExportTableRef, len(selectedTables)),
+		columnByID:    make(map[uuid.UUID]models.OntologyExportColumnRef, len(selectedColumns)),
+		tableByName:   make(map[string][]models.OntologyExportTableRef),
+		columnByValue: make(map[string][]models.OntologyExportColumnRef),
+	}
+
+	for id, table := range selectedTables {
+		ref := models.OntologyExportTableRef{
+			SchemaName: table.SchemaName,
+			TableName:  table.TableName,
+		}
+		resolver.tableByID[id] = ref
+		resolver.tableByName[table.TableName] = append(resolver.tableByName[table.TableName], ref)
+	}
+
+	for id, column := range selectedColumns {
+		tableRef, ok := resolver.tableByID[column.SchemaTableID]
+		if !ok {
+			continue
+		}
+		ref := models.OntologyExportColumnRef{
+			Table:      tableRef,
+			ColumnName: column.ColumnName,
+		}
+		resolver.columnByID[id] = ref
+		key := tableRef.TableName + "." + column.ColumnName
+		resolver.columnByValue[key] = append(resolver.columnByValue[key], ref)
+	}
+
+	for name := range resolver.tableByName {
+		sort.Slice(resolver.tableByName[name], func(i, j int) bool {
+			return compareTableRefs(resolver.tableByName[name][i], resolver.tableByName[name][j]) < 0
+		})
+	}
+	for key := range resolver.columnByValue {
+		sort.Slice(resolver.columnByValue[key], func(i, j int) bool {
+			return compareColumnRefs(resolver.columnByValue[key][i], resolver.columnByValue[key][j]) < 0
+		})
+	}
+
+	return resolver
+}
+
+func buildExportTables(
+	selectedTables map[uuid.UUID]*models.SchemaTable,
+	selectedColumns map[uuid.UUID]*models.SchemaColumn,
+) []models.OntologyExportTable {
+	orderedTables := make([]*models.SchemaTable, 0, len(selectedTables))
+	for _, table := range selectedTables {
+		orderedTables = append(orderedTables, table)
+	}
+	sort.Slice(orderedTables, func(i, j int) bool {
+		if orderedTables[i].SchemaName != orderedTables[j].SchemaName {
+			return orderedTables[i].SchemaName < orderedTables[j].SchemaName
+		}
+		return orderedTables[i].TableName < orderedTables[j].TableName
+	})
+
+	columnsByTableID := make(map[uuid.UUID][]*models.SchemaColumn)
+	for _, column := range selectedColumns {
+		columnsByTableID[column.SchemaTableID] = append(columnsByTableID[column.SchemaTableID], column)
+	}
+
+	exported := make([]models.OntologyExportTable, 0, len(orderedTables))
+	for _, table := range orderedTables {
+		tableColumns := columnsByTableID[table.ID]
+		sort.Slice(tableColumns, func(i, j int) bool {
+			if tableColumns[i].OrdinalPosition != tableColumns[j].OrdinalPosition {
+				return tableColumns[i].OrdinalPosition < tableColumns[j].OrdinalPosition
+			}
+			return tableColumns[i].ColumnName < tableColumns[j].ColumnName
+		})
+
+		columns := make([]models.OntologyExportColumn, 0, len(tableColumns))
+		for _, column := range tableColumns {
+			enumValues := append([]string(nil), column.EnumValues...)
+			sort.Strings(enumValues)
+
+			columns = append(columns, models.OntologyExportColumn{
+				ColumnName:        column.ColumnName,
+				DataType:          column.DataType,
+				IsNullable:        column.IsNullable,
+				IsPrimaryKey:      column.IsPrimaryKey,
+				IsUnique:          column.IsUnique,
+				OrdinalPosition:   column.OrdinalPosition,
+				DefaultValue:      column.DefaultValue,
+				DistinctCount:     column.DistinctCount,
+				NullCount:         column.NullCount,
+				MinLength:         column.MinLength,
+				MaxLength:         column.MaxLength,
+				EnumValues:        enumValues,
+				RowCount:          column.RowCount,
+				NonNullCount:      column.NonNullCount,
+				IsJoinable:        column.IsJoinable,
+				JoinabilityReason: column.JoinabilityReason,
+			})
+		}
+
+		exported = append(exported, models.OntologyExportTable{
+			SchemaName: table.SchemaName,
+			TableName:  table.TableName,
+			RowCount:   table.RowCount,
+			Columns:    columns,
+		})
+	}
+
+	return exported
+}
+
+func buildExportRelationships(
+	relationships []*models.SchemaRelationship,
+	resolver schemaRefResolver,
+) []models.OntologyExportRelationship {
+	exported := make([]models.OntologyExportRelationship, 0)
+	for _, rel := range relationships {
+		if rel == nil {
+			continue
+		}
+
+		sourceRef, sourceOK := resolver.columnByID[rel.SourceColumnID]
+		targetRef, targetOK := resolver.columnByID[rel.TargetColumnID]
+		if !sourceOK || !targetOK {
+			continue
+		}
+
+		exported = append(exported, models.OntologyExportRelationship{
+			Source:           sourceRef,
+			Target:           targetRef,
+			RelationshipType: rel.RelationshipType,
+			Cardinality:      rel.Cardinality,
+			Confidence:       rel.Confidence,
+			InferenceMethod:  rel.InferenceMethod,
+			IsValidated:      rel.IsValidated,
+			Validation:       rel.ValidationResults,
+			IsApproved:       rel.IsApproved,
+		})
+	}
+
+	sort.Slice(exported, func(i, j int) bool {
+		if cmp := compareColumnRefs(exported[i].Source, exported[j].Source); cmp != 0 {
+			return cmp < 0
+		}
+		return compareColumnRefs(exported[i].Target, exported[j].Target) < 0
+	})
+
+	return exported
+}
+
+func buildExportTableMetadata(
+	metadata []*models.TableMetadata,
+	resolver schemaRefResolver,
+) []models.OntologyExportTableMetadata {
+	exported := make([]models.OntologyExportTableMetadata, 0)
+	for _, item := range metadata {
+		if item == nil {
+			continue
+		}
+		tableRef, ok := resolver.tableByID[item.SchemaTableID]
+		if !ok {
+			continue
+		}
+
+		exported = append(exported, models.OntologyExportTableMetadata{
+			Table:                tableRef,
+			TableType:            item.TableType,
+			Description:          item.Description,
+			UsageNotes:           item.UsageNotes,
+			IsEphemeral:          item.IsEphemeral,
+			PreferredAlternative: resolver.tableRefByName(ptrString(item.PreferredAlternative)),
+			Confidence:           item.Confidence,
+			Features:             item.Features,
+			Source:               item.Source,
+			LastEditSource:       item.LastEditSource,
+		})
+	}
+
+	sort.Slice(exported, func(i, j int) bool {
+		return compareTableRefs(exported[i].Table, exported[j].Table) < 0
+	})
+
+	return exported
+}
+
+func buildExportColumnMetadata(
+	metadata []*models.ColumnMetadata,
+	resolver schemaRefResolver,
+) []models.OntologyExportColumnMetadata {
+	exported := make([]models.OntologyExportColumnMetadata, 0)
+	for _, item := range metadata {
+		if item == nil {
+			continue
+		}
+		columnRef, ok := resolver.columnByID[item.SchemaColumnID]
+		if !ok {
+			continue
+		}
+
+		exported = append(exported, models.OntologyExportColumnMetadata{
+			Column:                columnRef,
+			ClassificationPath:    item.ClassificationPath,
+			Purpose:               item.Purpose,
+			SemanticType:          item.SemanticType,
+			Role:                  item.Role,
+			Description:           item.Description,
+			Confidence:            item.Confidence,
+			Features:              item.Features,
+			NeedsEnumAnalysis:     item.NeedsEnumAnalysis,
+			NeedsFKResolution:     item.NeedsFKResolution,
+			NeedsCrossColumnCheck: item.NeedsCrossColumnCheck,
+			NeedsClarification:    item.NeedsClarification,
+			ClarificationQuestion: item.ClarificationQuestion,
+			IsSensitive:           item.IsSensitive,
+			Source:                item.Source,
+			LastEditSource:        item.LastEditSource,
+		})
+	}
+
+	sort.Slice(exported, func(i, j int) bool {
+		return compareColumnRefs(exported[i].Column, exported[j].Column) < 0
+	})
+
+	return exported
+}
+
+func buildExportQuestions(
+	questions []*models.OntologyQuestion,
+	resolver schemaRefResolver,
+) []models.OntologyExportQuestion {
+	exported := make([]models.OntologyExportQuestion, 0, len(questions))
+	for _, question := range questions {
+		if question == nil || question.Status == models.QuestionStatusDeleted {
+			continue
+		}
+
+		var affects *models.OntologyExportQuestionAffects
+		if question.Affects != nil {
+			tableRefs := make([]models.OntologyExportTableRef, 0, len(question.Affects.Tables))
+			for _, tableName := range question.Affects.Tables {
+				if ref := resolver.tableRefByName(tableName); ref != nil {
+					tableRefs = append(tableRefs, *ref)
+				}
+			}
+			sort.Slice(tableRefs, func(i, j int) bool {
+				return compareTableRefs(tableRefs[i], tableRefs[j]) < 0
+			})
+
+			columnRefs := make([]models.OntologyExportColumnRef, 0, len(question.Affects.Columns))
+			for _, value := range question.Affects.Columns {
+				if ref := resolver.columnRefByValue(value); ref != nil {
+					columnRefs = append(columnRefs, *ref)
+				}
+			}
+			sort.Slice(columnRefs, func(i, j int) bool {
+				return compareColumnRefs(columnRefs[i], columnRefs[j]) < 0
+			})
+
+			if len(tableRefs) > 0 || len(columnRefs) > 0 {
+				affects = &models.OntologyExportQuestionAffects{
+					Tables:  tableRefs,
+					Columns: columnRefs,
+				}
+			}
+		}
+
+		exported = append(exported, models.OntologyExportQuestion{
+			Text:            question.Text,
+			Priority:        question.Priority,
+			IsRequired:      question.IsRequired,
+			Category:        question.Category,
+			Reasoning:       question.Reasoning,
+			Affects:         affects,
+			DetectedPattern: question.DetectedPattern,
+			Status:          question.Status,
+			StatusReason:    question.StatusReason,
+			Answer:          question.Answer,
+		})
+	}
+
+	sort.Slice(exported, func(i, j int) bool {
+		if exported[i].Priority != exported[j].Priority {
+			return exported[i].Priority < exported[j].Priority
+		}
+		return exported[i].Text < exported[j].Text
+	})
+
+	return exported
+}
+
+func buildExportKnowledge(facts []*models.KnowledgeFact) []models.OntologyExportKnowledgeFact {
+	exported := make([]models.OntologyExportKnowledgeFact, 0, len(facts))
+	for _, fact := range facts {
+		if fact == nil {
+			continue
+		}
+		exported = append(exported, models.OntologyExportKnowledgeFact{
+			FactType:       fact.FactType,
+			Value:          fact.Value,
+			Context:        fact.Context,
+			Source:         fact.Source,
+			LastEditSource: fact.LastEditSource,
+		})
+	}
+
+	sort.Slice(exported, func(i, j int) bool {
+		if exported[i].FactType != exported[j].FactType {
+			return exported[i].FactType < exported[j].FactType
+		}
+		return exported[i].Value < exported[j].Value
+	})
+
+	return exported
+}
+
+func buildExportGlossaryTerms(terms []*models.BusinessGlossaryTerm) []models.OntologyExportGlossaryTerm {
+	exported := make([]models.OntologyExportGlossaryTerm, 0, len(terms))
+	for _, term := range terms {
+		if term == nil {
+			continue
+		}
+
+		aliases := append([]string(nil), term.Aliases...)
+		sort.Strings(aliases)
+
+		outputColumns := append([]models.OutputColumn(nil), term.OutputColumns...)
+		sort.Slice(outputColumns, func(i, j int) bool {
+			return outputColumns[i].Name < outputColumns[j].Name
+		})
+
+		exported = append(exported, models.OntologyExportGlossaryTerm{
+			Term:             term.Term,
+			Definition:       term.Definition,
+			DefiningSQL:      term.DefiningSQL,
+			BaseTable:        term.BaseTable,
+			OutputColumns:    outputColumns,
+			Aliases:          aliases,
+			EnrichmentStatus: term.EnrichmentStatus,
+			EnrichmentError:  term.EnrichmentError,
+			NeedsReview:      term.NeedsReview,
+			ReviewReason:     term.ReviewReason,
+			Source:           term.Source,
+			LastEditSource:   term.LastEditSource,
+		})
+	}
+
+	sort.Slice(exported, func(i, j int) bool {
+		return exported[i].Term < exported[j].Term
+	})
+
+	return exported
+}
+
+func buildApprovedQueryExports(queries []*models.Query) ([]models.OntologyExportApprovedQuery, map[uuid.UUID]string) {
+	approved := make([]*models.Query, 0, len(queries))
+	for _, query := range queries {
+		if query == nil || query.Status != "approved" {
+			continue
+		}
+		approved = append(approved, query)
+	}
+
+	sort.Slice(approved, func(i, j int) bool {
+		if approved[i].NaturalLanguagePrompt != approved[j].NaturalLanguagePrompt {
+			return approved[i].NaturalLanguagePrompt < approved[j].NaturalLanguagePrompt
+		}
+		if approved[i].SQLQuery != approved[j].SQLQuery {
+			return approved[i].SQLQuery < approved[j].SQLQuery
+		}
+		return approved[i].ID.String() < approved[j].ID.String()
+	})
+
+	exported := make([]models.OntologyExportApprovedQuery, 0, len(approved))
+	keys := make(map[uuid.UUID]string, len(approved))
+	for index, query := range approved {
+		key := fmt.Sprintf("query_%03d", index+1)
+		keys[query.ID] = key
+
+		parameters := append([]models.QueryParameter(nil), query.Parameters...)
+		sort.Slice(parameters, func(i, j int) bool {
+			return parameters[i].Name < parameters[j].Name
+		})
+
+		outputColumns := append([]models.OutputColumn(nil), query.OutputColumns...)
+		sort.Slice(outputColumns, func(i, j int) bool {
+			return outputColumns[i].Name < outputColumns[j].Name
+		})
+
+		tags := append([]string(nil), query.Tags...)
+		sort.Strings(tags)
+
+		exported = append(exported, models.OntologyExportApprovedQuery{
+			Key:                   key,
+			DatasourceKey:         ontologyExportDatasourceKey,
+			NaturalLanguagePrompt: query.NaturalLanguagePrompt,
+			AdditionalContext:     query.AdditionalContext,
+			SQL:                   query.SQLQuery,
+			Dialect:               query.Dialect,
+			Enabled:               query.IsEnabled,
+			Parameters:            parameters,
+			OutputColumns:         outputColumns,
+			Constraints:           query.Constraints,
+			Tags:                  tags,
+			AllowsModification:    query.AllowsModification,
+		})
+	}
+
+	return exported, keys
+}
+
+func buildExportAgents(
+	agents []*models.Agent,
+	queryAccessByAgentID map[uuid.UUID][]uuid.UUID,
+	queryKeys map[uuid.UUID]string,
+) []models.OntologyExportAgent {
+	exported := make([]models.OntologyExportAgent, 0, len(agents))
+	for _, agent := range agents {
+		if agent == nil {
+			continue
+		}
+
+		queryIDs := queryAccessByAgentID[agent.ID]
+		queryKeysForAgent := make([]string, 0, len(queryIDs))
+		for _, queryID := range queryIDs {
+			if key, ok := queryKeys[queryID]; ok {
+				queryKeysForAgent = append(queryKeysForAgent, key)
+			}
+		}
+
+		if len(queryKeysForAgent) == 0 {
+			continue
+		}
+
+		sort.Strings(queryKeysForAgent)
+		exported = append(exported, models.OntologyExportAgent{
+			Name:      agent.Name,
+			QueryKeys: queryKeysForAgent,
+		})
+	}
+
+	sort.Slice(exported, func(i, j int) bool {
+		return exported[i].Name < exported[j].Name
+	})
+
+	return exported
+}
+
+func buildRequiredApps(queries []models.OntologyExportApprovedQuery, agents []models.OntologyExportAgent) []string {
+	apps := []string{models.AppIDOntologyForge}
+	if len(queries) > 0 {
+		apps = append(apps, models.AppIDAIDataLiaison)
+	}
+	if len(agents) > 0 {
+		apps = append(apps, models.AppIDAIAgents)
+	}
+	return apps
+}
+
+func sanitizeDatasourceConfig(config map[string]any) map[string]any {
+	if len(config) == 0 {
+		return map[string]any{}
+	}
+
+	sanitized, ok := sanitizeValue(config).(map[string]any)
+	if !ok || sanitized == nil {
+		return map[string]any{}
+	}
+	return sanitized
+}
+
+func sanitizeValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		sanitized := make(map[string]any)
+		for key, nested := range typed {
+			if isSensitiveDatasourceKey(key) {
+				continue
+			}
+			sanitizedNested := sanitizeValue(nested)
+			if shouldOmitSanitizedValue(sanitizedNested) {
+				continue
+			}
+			sanitized[key] = sanitizedNested
+		}
+		return sanitized
+	case []any:
+		items := make([]any, 0, len(typed))
+		for _, item := range typed {
+			sanitizedItem := sanitizeValue(item)
+			if shouldOmitSanitizedValue(sanitizedItem) {
+				continue
+			}
+			items = append(items, sanitizedItem)
+		}
+		return items
+	default:
+		return value
+	}
+}
+
+func shouldOmitSanitizedValue(value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return true
+	case map[string]any:
+		return len(typed) == 0
+	case []any:
+		return false
+	default:
+		return false
+	}
+}
+
+func isSensitiveDatasourceKey(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	normalized = strings.ReplaceAll(normalized, "-", "_")
+
+	switch normalized {
+	case "user", "username", "password", "pass", "passwd", "pwd",
+		"url", "uri", "dsn", "connection_string", "connectionstring",
+		"client_secret", "private_key", "service_account_json":
+		return true
+	}
+
+	sensitiveFragments := []string{
+		"password",
+		"secret",
+		"token",
+		"credential",
+		"api_key",
+		"apikey",
+		"private_key",
+		"client_secret",
+		"connection_string",
+	}
+	for _, fragment := range sensitiveFragments {
+		if strings.Contains(normalized, fragment) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func slugifyFilename(name string) string {
+	slug := strings.ToLower(strings.TrimSpace(name))
+	slug = nonFilenameChars.ReplaceAllString(slug, "-")
+	slug = strings.Trim(slug, "-")
+	return slug
+}
+
+func compareTableRefs(left, right models.OntologyExportTableRef) int {
+	if left.SchemaName != right.SchemaName {
+		if left.SchemaName < right.SchemaName {
+			return -1
+		}
+		return 1
+	}
+	if left.TableName != right.TableName {
+		if left.TableName < right.TableName {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+func compareColumnRefs(left, right models.OntologyExportColumnRef) int {
+	if cmp := compareTableRefs(left.Table, right.Table); cmp != 0 {
+		return cmp
+	}
+	if left.ColumnName < right.ColumnName {
+		return -1
+	}
+	if left.ColumnName > right.ColumnName {
+		return 1
+	}
+	return 0
+}
+
+func (r schemaRefResolver) tableRefByName(tableName string) *models.OntologyExportTableRef {
+	if tableName == "" {
+		return nil
+	}
+	refs := r.tableByName[tableName]
+	if len(refs) == 1 {
+		ref := refs[0]
+		return &ref
+	}
+	ref := models.OntologyExportTableRef{TableName: tableName}
+	return &ref
+}
+
+func (r schemaRefResolver) columnRefByValue(value string) *models.OntologyExportColumnRef {
+	tableName, columnName, found := strings.Cut(value, ".")
+	if !found {
+		return nil
+	}
+	refs := r.columnByValue[tableName+"."+columnName]
+	if len(refs) == 1 {
+		ref := refs[0]
+		return &ref
+	}
+	ref := models.OntologyExportColumnRef{
+		Table: models.OntologyExportTableRef{
+			TableName: tableName,
+		},
+		ColumnName: columnName,
+	}
+	return &ref
+}
+
+func ptrString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/pkg/services/ontology_export_test.go
+++ b/pkg/services/ontology_export_test.go
@@ -380,6 +380,122 @@ func TestOntologyExportService_BuildBundle(t *testing.T) {
 	require.NotContains(t, payloadText, "agent-secret")
 }
 
+func TestOntologyExportService_BuildBundle_DeterministicOrdering(t *testing.T) {
+	projectID := uuid.New()
+	datasourceID := uuid.New()
+	ordersTableID := uuid.New()
+	usersTableID := uuid.New()
+	ordersIDColumnID := uuid.New()
+	ordersUserIDColumnID := uuid.New()
+	ordersStatusColumnID := uuid.New()
+	usersIDColumnID := uuid.New()
+	queryAID := uuid.New()
+	queryZID := uuid.New()
+	agentAID := uuid.New()
+	agentZID := uuid.New()
+
+	service := NewOntologyExportService(
+		&mockOntologyExportProjectRepo{
+			project: &models.Project{
+				ID:   projectID,
+				Name: "The Look Demo",
+			},
+		},
+		&mockOntologyExportDatasourceService{
+			datasource: &models.Datasource{
+				ID:             datasourceID,
+				ProjectID:      projectID,
+				Name:           "The Look",
+				DatasourceType: "postgres",
+			},
+		},
+		&mockOntologyExportSchemaRepo{
+			tables: []*models.SchemaTable{
+				{ID: usersTableID, ProjectID: projectID, DatasourceID: datasourceID, SchemaName: "public", TableName: "users", IsSelected: true},
+				{ID: ordersTableID, ProjectID: projectID, DatasourceID: datasourceID, SchemaName: "public", TableName: "orders", IsSelected: true},
+			},
+			columns: []*models.SchemaColumn{
+				{ID: ordersStatusColumnID, ProjectID: projectID, SchemaTableID: ordersTableID, ColumnName: "status", DataType: "text", IsSelected: true, OrdinalPosition: 3},
+				{ID: usersIDColumnID, ProjectID: projectID, SchemaTableID: usersTableID, ColumnName: "id", DataType: "uuid", IsPrimaryKey: true, IsSelected: true, OrdinalPosition: 1},
+				{ID: ordersUserIDColumnID, ProjectID: projectID, SchemaTableID: ordersTableID, ColumnName: "user_id", DataType: "uuid", IsSelected: true, OrdinalPosition: 2},
+				{ID: ordersIDColumnID, ProjectID: projectID, SchemaTableID: ordersTableID, ColumnName: "id", DataType: "uuid", IsPrimaryKey: true, IsSelected: true, OrdinalPosition: 1},
+			},
+			relationships: nil,
+		},
+		&mockOntologyExportTableMetadataRepo{},
+		&mockOntologyExportColumnMetadataRepo{},
+		&mockOntologyExportQuestionRepo{},
+		&mockOntologyExportKnowledgeRepo{},
+		&mockOntologyExportGlossaryRepo{},
+		&mockOntologyExportQueryRepo{
+			items: []*models.Query{
+				{
+					ID:                    queryZID,
+					ProjectID:             projectID,
+					DatasourceID:          datasourceID,
+					NaturalLanguagePrompt: "Z prompt",
+					SQLQuery:              "SELECT * FROM users",
+					Dialect:               "PostgreSQL",
+					Status:                "approved",
+				},
+				{
+					ID:                    queryAID,
+					ProjectID:             projectID,
+					DatasourceID:          datasourceID,
+					NaturalLanguagePrompt: "A prompt",
+					SQLQuery:              "SELECT * FROM orders",
+					Dialect:               "PostgreSQL",
+					Status:                "approved",
+				},
+			},
+		},
+		&mockOntologyExportAgentRepo{
+			agents: []*models.Agent{
+				{ID: agentZID, ProjectID: projectID, Name: "z-agent"},
+				{ID: agentAID, ProjectID: projectID, Name: "a-agent"},
+			},
+			queryAccessBy: map[uuid.UUID][]uuid.UUID{
+				agentZID: {queryZID, queryAID},
+				agentAID: {queryAID},
+			},
+		},
+		zap.NewNop(),
+	)
+
+	bundle, err := service.BuildBundle(context.Background(), projectID, datasourceID)
+	require.NoError(t, err)
+
+	require.Len(t, bundle.Datasources, 1)
+	require.Equal(t, "orders", bundle.Datasources[0].SelectedSchema.Tables[0].TableName)
+	require.Equal(t, "users", bundle.Datasources[0].SelectedSchema.Tables[1].TableName)
+	require.Equal(t, []string{"id", "user_id", "status"}, []string{
+		bundle.Datasources[0].SelectedSchema.Tables[0].Columns[0].ColumnName,
+		bundle.Datasources[0].SelectedSchema.Tables[0].Columns[1].ColumnName,
+		bundle.Datasources[0].SelectedSchema.Tables[0].Columns[2].ColumnName,
+	})
+
+	require.Equal(t, []string{"A prompt", "Z prompt"}, []string{
+		bundle.ApprovedQueries[0].NaturalLanguagePrompt,
+		bundle.ApprovedQueries[1].NaturalLanguagePrompt,
+	})
+	require.Equal(t, []string{"query_001", "query_002"}, []string{
+		bundle.ApprovedQueries[0].Key,
+		bundle.ApprovedQueries[1].Key,
+	})
+
+	require.Equal(t, []string{"a-agent", "z-agent"}, []string{
+		bundle.Agents[0].Name,
+		bundle.Agents[1].Name,
+	})
+	require.Equal(t, []string{"query_001", "query_002"}, bundle.Agents[1].QueryKeys)
+
+	firstPayload, err := service.MarshalBundle(bundle)
+	require.NoError(t, err)
+	secondPayload, err := service.MarshalBundle(bundle)
+	require.NoError(t, err)
+	require.Equal(t, string(firstPayload), string(secondPayload))
+}
+
 func TestOntologyExportService_SuggestedFilename(t *testing.T) {
 	service := &ontologyExportService{}
 

--- a/pkg/services/ontology_export_test.go
+++ b/pkg/services/ontology_export_test.go
@@ -1,0 +1,393 @@
+package services
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	"github.com/ekaya-inc/ekaya-engine/pkg/repositories"
+)
+
+type mockOntologyExportProjectRepo struct {
+	project *models.Project
+}
+
+func (m *mockOntologyExportProjectRepo) Get(ctx context.Context, id uuid.UUID) (*models.Project, error) {
+	return m.project, nil
+}
+
+type mockOntologyExportDatasourceService struct {
+	datasource *models.Datasource
+}
+
+func (m *mockOntologyExportDatasourceService) Get(ctx context.Context, projectID, id uuid.UUID) (*models.Datasource, error) {
+	return m.datasource, nil
+}
+
+type mockOntologyExportSchemaRepo struct {
+	tables        []*models.SchemaTable
+	columns       []*models.SchemaColumn
+	relationships []*models.SchemaRelationship
+}
+
+func (m *mockOntologyExportSchemaRepo) ListTablesByDatasource(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.SchemaTable, error) {
+	return m.tables, nil
+}
+
+func (m *mockOntologyExportSchemaRepo) ListColumnsByDatasource(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.SchemaColumn, error) {
+	return m.columns, nil
+}
+
+func (m *mockOntologyExportSchemaRepo) ListRelationshipsByDatasource(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.SchemaRelationship, error) {
+	return m.relationships, nil
+}
+
+type mockOntologyExportTableMetadataRepo struct {
+	items []*models.TableMetadata
+}
+
+func (m *mockOntologyExportTableMetadataRepo) List(ctx context.Context, projectID uuid.UUID) ([]*models.TableMetadata, error) {
+	return m.items, nil
+}
+
+type mockOntologyExportColumnMetadataRepo struct {
+	items []*models.ColumnMetadata
+}
+
+func (m *mockOntologyExportColumnMetadataRepo) GetByProject(ctx context.Context, projectID uuid.UUID) ([]*models.ColumnMetadata, error) {
+	return m.items, nil
+}
+
+type mockOntologyExportQuestionRepo struct {
+	items []*models.OntologyQuestion
+}
+
+func (m *mockOntologyExportQuestionRepo) List(ctx context.Context, projectID uuid.UUID, filters repositories.QuestionListFilters) (*repositories.QuestionListResult, error) {
+	start := filters.Offset
+	if start > len(m.items) {
+		start = len(m.items)
+	}
+	end := start + filters.Limit
+	if filters.Limit <= 0 || end > len(m.items) {
+		end = len(m.items)
+	}
+
+	return &repositories.QuestionListResult{
+		Questions:      m.items[start:end],
+		TotalCount:     len(m.items),
+		CountsByStatus: map[models.QuestionStatus]int{},
+	}, nil
+}
+
+type mockOntologyExportKnowledgeRepo struct {
+	items []*models.KnowledgeFact
+}
+
+func (m *mockOntologyExportKnowledgeRepo) GetByProject(ctx context.Context, projectID uuid.UUID) ([]*models.KnowledgeFact, error) {
+	return m.items, nil
+}
+
+type mockOntologyExportGlossaryRepo struct {
+	items []*models.BusinessGlossaryTerm
+}
+
+func (m *mockOntologyExportGlossaryRepo) GetByProject(ctx context.Context, projectID uuid.UUID) ([]*models.BusinessGlossaryTerm, error) {
+	return m.items, nil
+}
+
+type mockOntologyExportQueryRepo struct {
+	items []*models.Query
+}
+
+func (m *mockOntologyExportQueryRepo) ListByDatasource(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.Query, error) {
+	return m.items, nil
+}
+
+type mockOntologyExportAgentRepo struct {
+	agents        []*models.Agent
+	queryAccessBy map[uuid.UUID][]uuid.UUID
+}
+
+func (m *mockOntologyExportAgentRepo) ListByProject(ctx context.Context, projectID uuid.UUID) ([]*models.Agent, error) {
+	return m.agents, nil
+}
+
+func (m *mockOntologyExportAgentRepo) GetQueryAccessByAgentIDs(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID][]uuid.UUID, error) {
+	return m.queryAccessBy, nil
+}
+
+func TestOntologyExportService_BuildBundle(t *testing.T) {
+	projectID := uuid.New()
+	datasourceID := uuid.New()
+	ordersTableID := uuid.New()
+	usersTableID := uuid.New()
+	ordersIDColumnID := uuid.New()
+	ordersUserIDColumnID := uuid.New()
+	ordersStatusColumnID := uuid.New()
+	usersIDColumnID := uuid.New()
+	approvedEnabledQueryID := uuid.New()
+	approvedDisabledQueryID := uuid.New()
+	agentID := uuid.New()
+
+	tableType := models.TableTypeTransactional
+	tableDescription := "Orders placed by shoppers"
+	columnRole := models.ColumnRoleDimension
+	columnDescription := "Business order status"
+	source := models.ProvenanceManual
+
+	project := &models.Project{
+		ID:           projectID,
+		Name:         "The Look Demo",
+		IndustryType: models.IndustryMarketplace,
+		Parameters: map[string]any{
+			"ai_api_key":      "engine-secret",
+			"auth_server_url": "https://auth.example.com",
+		},
+		DomainSummary: &models.DomainSummary{
+			Description: "Marketplace analytics ontology",
+		},
+	}
+
+	datasource := &models.Datasource{
+		ID:             datasourceID,
+		ProjectID:      projectID,
+		Name:           "The Look",
+		DatasourceType: "postgres",
+		Provider:       "supabase",
+		Config: map[string]any{
+			"host":     "db.example.com",
+			"port":     5432,
+			"name":     "the_look",
+			"ssl_mode": "require",
+			"user":     "readonly",
+			"password": "dbpass",
+			"extra": map[string]any{
+				"schema": "public",
+				"token":  "nested-secret",
+			},
+		},
+	}
+
+	questions := []*models.OntologyQuestion{
+		{
+			ID:         uuid.New(),
+			ProjectID:  projectID,
+			Text:       "What does orders.status represent?",
+			Priority:   1,
+			IsRequired: true,
+			Category:   models.QuestionCategoryEnumeration,
+			Affects: &models.QuestionAffects{
+				Tables:  []string{"orders"},
+				Columns: []string{"orders.status"},
+			},
+			Status: models.QuestionStatusAnswered,
+			Answer: "It is the business order state.",
+		},
+		{
+			ID:        uuid.New(),
+			ProjectID: projectID,
+			Text:      "Deleted question",
+			Status:    models.QuestionStatusDeleted,
+		},
+	}
+
+	service := NewOntologyExportService(
+		&mockOntologyExportProjectRepo{project: project},
+		&mockOntologyExportDatasourceService{datasource: datasource},
+		&mockOntologyExportSchemaRepo{
+			tables: []*models.SchemaTable{
+				{ID: ordersTableID, ProjectID: projectID, DatasourceID: datasourceID, SchemaName: "public", TableName: "orders", IsSelected: true},
+				{ID: usersTableID, ProjectID: projectID, DatasourceID: datasourceID, SchemaName: "public", TableName: "users", IsSelected: true},
+			},
+			columns: []*models.SchemaColumn{
+				{ID: ordersIDColumnID, ProjectID: projectID, SchemaTableID: ordersTableID, ColumnName: "id", DataType: "uuid", IsPrimaryKey: true, IsSelected: true, OrdinalPosition: 1},
+				{ID: ordersUserIDColumnID, ProjectID: projectID, SchemaTableID: ordersTableID, ColumnName: "user_id", DataType: "uuid", IsSelected: true, OrdinalPosition: 2},
+				{ID: ordersStatusColumnID, ProjectID: projectID, SchemaTableID: ordersTableID, ColumnName: "status", DataType: "text", IsSelected: true, OrdinalPosition: 3, EnumValues: []string{"pending", "complete"}},
+				{ID: usersIDColumnID, ProjectID: projectID, SchemaTableID: usersTableID, ColumnName: "id", DataType: "uuid", IsPrimaryKey: true, IsSelected: true, OrdinalPosition: 1},
+			},
+			relationships: []*models.SchemaRelationship{
+				{
+					ID:               uuid.New(),
+					ProjectID:        projectID,
+					SourceTableID:    ordersTableID,
+					SourceColumnID:   ordersUserIDColumnID,
+					TargetTableID:    usersTableID,
+					TargetColumnID:   usersIDColumnID,
+					RelationshipType: models.RelationshipTypeFK,
+					Cardinality:      models.CardinalityNTo1,
+					Confidence:       1,
+				},
+			},
+		},
+		&mockOntologyExportTableMetadataRepo{
+			items: []*models.TableMetadata{
+				{
+					ProjectID:     projectID,
+					SchemaTableID: ordersTableID,
+					TableType:     &tableType,
+					Description:   &tableDescription,
+					IsEphemeral:   false,
+					Source:        source,
+				},
+			},
+		},
+		&mockOntologyExportColumnMetadataRepo{
+			items: []*models.ColumnMetadata{
+				{
+					ProjectID:      projectID,
+					SchemaColumnID: ordersStatusColumnID,
+					Role:           &columnRole,
+					Description:    &columnDescription,
+					Features: models.ColumnMetadataFeatures{
+						Synonyms: []string{"state"},
+					},
+					Source: source,
+				},
+			},
+		},
+		&mockOntologyExportQuestionRepo{items: questions},
+		&mockOntologyExportKnowledgeRepo{
+			items: []*models.KnowledgeFact{
+				{ProjectID: projectID, FactType: models.FactTypeBusinessRule, Value: "Only completed orders count toward GMV", Context: "Derived from finance review", Source: source},
+			},
+		},
+		&mockOntologyExportGlossaryRepo{
+			items: []*models.BusinessGlossaryTerm{
+				{
+					ProjectID:     projectID,
+					Term:          "GMV",
+					Definition:    "Gross merchandise volume",
+					DefiningSQL:   "SELECT SUM(total_amount) AS gmv FROM orders",
+					BaseTable:     "orders",
+					OutputColumns: []models.OutputColumn{{Name: "gmv", Type: "decimal", Description: "Gross merchandise volume"}},
+					Aliases:       []string{"gross merchandise volume"},
+					Source:        source,
+				},
+			},
+		},
+		&mockOntologyExportQueryRepo{
+			items: []*models.Query{
+				{
+					ID:                    approvedEnabledQueryID,
+					ProjectID:             projectID,
+					DatasourceID:          datasourceID,
+					NaturalLanguagePrompt: "Find orders",
+					SQLQuery:              "SELECT * FROM orders",
+					Dialect:               "PostgreSQL",
+					IsEnabled:             true,
+					Status:                "approved",
+					Parameters:            []models.QueryParameter{{Name: "status", Type: "string", Description: "Status", Required: false}},
+					OutputColumns:         []models.OutputColumn{{Name: "id", Type: "uuid", Description: "Order ID"}},
+				},
+				{
+					ID:                    approvedDisabledQueryID,
+					ProjectID:             projectID,
+					DatasourceID:          datasourceID,
+					NaturalLanguagePrompt: "Find users",
+					SQLQuery:              "SELECT * FROM users",
+					Dialect:               "PostgreSQL",
+					IsEnabled:             false,
+					Status:                "approved",
+				},
+				{
+					ID:                    uuid.New(),
+					ProjectID:             projectID,
+					DatasourceID:          datasourceID,
+					NaturalLanguagePrompt: "Rejected query",
+					SQLQuery:              "DELETE FROM users",
+					Dialect:               "PostgreSQL",
+					IsEnabled:             false,
+					Status:                "rejected",
+				},
+			},
+		},
+		&mockOntologyExportAgentRepo{
+			agents: []*models.Agent{
+				{
+					ID:              agentID,
+					ProjectID:       projectID,
+					Name:            "demo-agent",
+					APIKeyEncrypted: "agent-secret",
+				},
+			},
+			queryAccessBy: map[uuid.UUID][]uuid.UUID{
+				agentID: {approvedEnabledQueryID},
+			},
+		},
+		zap.NewNop(),
+	)
+
+	bundle, err := service.BuildBundle(context.Background(), projectID, datasourceID)
+	require.NoError(t, err)
+
+	require.Equal(t, models.OntologyExportFormat, bundle.Format)
+	require.Equal(t, models.OntologyExportVersion, bundle.Version)
+	require.Equal(t, []string{
+		models.AppIDOntologyForge,
+		models.AppIDAIDataLiaison,
+		models.AppIDAIAgents,
+	}, bundle.RequiredApps)
+
+	require.Len(t, bundle.Datasources, 1)
+	exportedDatasource := bundle.Datasources[0]
+	require.Equal(t, "The Look", exportedDatasource.Name)
+	require.Equal(t, "db.example.com", exportedDatasource.Config["host"])
+	require.NotContains(t, exportedDatasource.Config, "user")
+	require.NotContains(t, exportedDatasource.Config, "password")
+	require.Equal(t, map[string]any{"schema": "public"}, exportedDatasource.Config["extra"])
+
+	require.Len(t, exportedDatasource.SelectedSchema.Tables, 2)
+	require.Equal(t, "orders", exportedDatasource.SelectedSchema.Tables[0].TableName)
+	require.Len(t, exportedDatasource.SelectedSchema.Tables[0].Columns, 3)
+	require.Len(t, exportedDatasource.SelectedSchema.Relationships, 1)
+	require.Equal(t, "orders", exportedDatasource.SelectedSchema.Relationships[0].Source.Table.TableName)
+	require.Equal(t, "user_id", exportedDatasource.SelectedSchema.Relationships[0].Source.ColumnName)
+	require.Equal(t, "users", exportedDatasource.SelectedSchema.Relationships[0].Target.Table.TableName)
+
+	require.Len(t, bundle.Ontology.TableMetadata, 1)
+	require.Equal(t, "orders", bundle.Ontology.TableMetadata[0].Table.TableName)
+	require.Len(t, bundle.Ontology.ColumnMetadata, 1)
+	require.Equal(t, "status", bundle.Ontology.ColumnMetadata[0].Column.ColumnName)
+	require.Len(t, bundle.Ontology.Questions, 1)
+	require.Equal(t, models.QuestionStatusAnswered, bundle.Ontology.Questions[0].Status)
+	require.Equal(t, "orders", bundle.Ontology.Questions[0].Affects.Tables[0].TableName)
+	require.Len(t, bundle.Ontology.ProjectKnowledge, 1)
+	require.Len(t, bundle.Ontology.GlossaryTerms, 1)
+
+	require.Len(t, bundle.ApprovedQueries, 2)
+	require.Equal(t, "query_001", bundle.ApprovedQueries[0].Key)
+	require.Equal(t, "Find orders", bundle.ApprovedQueries[0].NaturalLanguagePrompt)
+	require.Equal(t, "query_002", bundle.ApprovedQueries[1].Key)
+	require.Equal(t, "Find users", bundle.ApprovedQueries[1].NaturalLanguagePrompt)
+
+	require.Len(t, bundle.Agents, 1)
+	require.Equal(t, "demo-agent", bundle.Agents[0].Name)
+	require.Equal(t, []string{"query_001"}, bundle.Agents[0].QueryKeys)
+
+	payload, err := service.MarshalBundle(bundle)
+	require.NoError(t, err)
+	payloadText := string(payload)
+	require.Contains(t, payloadText, "\n  \"format\":")
+	require.NotContains(t, payloadText, "engine-secret")
+	require.NotContains(t, payloadText, "auth_server_url")
+	require.NotContains(t, payloadText, "dbpass")
+	require.NotContains(t, payloadText, "nested-secret")
+	require.NotContains(t, payloadText, "agent-secret")
+}
+
+func TestOntologyExportService_SuggestedFilename(t *testing.T) {
+	service := &ontologyExportService{}
+
+	require.Equal(t, "the-look-demo-export.json", service.SuggestedFilename(&models.OntologyExportBundle{
+		Project: models.OntologyExportProject{Name: "The Look Demo"},
+	}))
+	require.Equal(t, "ontology-export.json", service.SuggestedFilename(nil))
+	require.True(t, strings.HasSuffix(service.SuggestedFilename(&models.OntologyExportBundle{
+		Project: models.OntologyExportProject{Name: "!!!"},
+	}), ".json"))
+}

--- a/pkg/services/ontology_export_test.go
+++ b/pkg/services/ontology_export_test.go
@@ -108,19 +108,6 @@ func (m *mockOntologyExportQueryRepo) ListByDatasource(ctx context.Context, proj
 	return m.items, nil
 }
 
-type mockOntologyExportAgentRepo struct {
-	agents        []*models.Agent
-	queryAccessBy map[uuid.UUID][]uuid.UUID
-}
-
-func (m *mockOntologyExportAgentRepo) ListByProject(ctx context.Context, projectID uuid.UUID) ([]*models.Agent, error) {
-	return m.agents, nil
-}
-
-func (m *mockOntologyExportAgentRepo) GetQueryAccessByAgentIDs(ctx context.Context, agentIDs []uuid.UUID) (map[uuid.UUID][]uuid.UUID, error) {
-	return m.queryAccessBy, nil
-}
-
 func TestOntologyExportService_BuildBundle(t *testing.T) {
 	projectID := uuid.New()
 	datasourceID := uuid.New()
@@ -132,7 +119,6 @@ func TestOntologyExportService_BuildBundle(t *testing.T) {
 	usersIDColumnID := uuid.New()
 	approvedEnabledQueryID := uuid.New()
 	approvedDisabledQueryID := uuid.New()
-	agentID := uuid.New()
 
 	tableType := models.TableTypeTransactional
 	tableDescription := "Orders placed by shoppers"
@@ -306,19 +292,6 @@ func TestOntologyExportService_BuildBundle(t *testing.T) {
 				},
 			},
 		},
-		&mockOntologyExportAgentRepo{
-			agents: []*models.Agent{
-				{
-					ID:              agentID,
-					ProjectID:       projectID,
-					Name:            "demo-agent",
-					APIKeyEncrypted: "agent-secret",
-				},
-			},
-			queryAccessBy: map[uuid.UUID][]uuid.UUID{
-				agentID: {approvedEnabledQueryID},
-			},
-		},
 		zap.NewNop(),
 	)
 
@@ -330,7 +303,6 @@ func TestOntologyExportService_BuildBundle(t *testing.T) {
 	require.Equal(t, []string{
 		models.AppIDOntologyForge,
 		models.AppIDAIDataLiaison,
-		models.AppIDAIAgents,
 	}, bundle.RequiredApps)
 
 	require.Len(t, bundle.Datasources, 1)
@@ -365,10 +337,6 @@ func TestOntologyExportService_BuildBundle(t *testing.T) {
 	require.Equal(t, "query_002", bundle.ApprovedQueries[1].Key)
 	require.Equal(t, "Find users", bundle.ApprovedQueries[1].NaturalLanguagePrompt)
 
-	require.Len(t, bundle.Agents, 1)
-	require.Equal(t, "demo-agent", bundle.Agents[0].Name)
-	require.Equal(t, []string{"query_001"}, bundle.Agents[0].QueryKeys)
-
 	payload, err := service.MarshalBundle(bundle)
 	require.NoError(t, err)
 	payloadText := string(payload)
@@ -378,6 +346,7 @@ func TestOntologyExportService_BuildBundle(t *testing.T) {
 	require.NotContains(t, payloadText, "dbpass")
 	require.NotContains(t, payloadText, "nested-secret")
 	require.NotContains(t, payloadText, "agent-secret")
+	require.NotContains(t, payloadText, "\"agents\"")
 }
 
 func TestOntologyExportService_BuildBundle_DeterministicOrdering(t *testing.T) {
@@ -391,8 +360,6 @@ func TestOntologyExportService_BuildBundle_DeterministicOrdering(t *testing.T) {
 	usersIDColumnID := uuid.New()
 	queryAID := uuid.New()
 	queryZID := uuid.New()
-	agentAID := uuid.New()
-	agentZID := uuid.New()
 
 	service := NewOntologyExportService(
 		&mockOntologyExportProjectRepo{
@@ -449,16 +416,6 @@ func TestOntologyExportService_BuildBundle_DeterministicOrdering(t *testing.T) {
 				},
 			},
 		},
-		&mockOntologyExportAgentRepo{
-			agents: []*models.Agent{
-				{ID: agentZID, ProjectID: projectID, Name: "z-agent"},
-				{ID: agentAID, ProjectID: projectID, Name: "a-agent"},
-			},
-			queryAccessBy: map[uuid.UUID][]uuid.UUID{
-				agentZID: {queryZID, queryAID},
-				agentAID: {queryAID},
-			},
-		},
 		zap.NewNop(),
 	)
 
@@ -483,17 +440,12 @@ func TestOntologyExportService_BuildBundle_DeterministicOrdering(t *testing.T) {
 		bundle.ApprovedQueries[1].Key,
 	})
 
-	require.Equal(t, []string{"a-agent", "z-agent"}, []string{
-		bundle.Agents[0].Name,
-		bundle.Agents[1].Name,
-	})
-	require.Equal(t, []string{"query_001", "query_002"}, bundle.Agents[1].QueryKeys)
-
 	firstPayload, err := service.MarshalBundle(bundle)
 	require.NoError(t, err)
 	secondPayload, err := service.MarshalBundle(bundle)
 	require.NoError(t, err)
 	require.Equal(t, string(firstPayload), string(secondPayload))
+	require.NotContains(t, string(firstPayload), "\"agents\"")
 }
 
 func TestOntologyExportService_SuggestedFilename(t *testing.T) {

--- a/pkg/services/ontology_import.go
+++ b/pkg/services/ontology_import.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.uber.org/zap"
 
-	"github.com/ekaya-inc/ekaya-engine/pkg/crypto"
 	"github.com/ekaya-inc/ekaya-engine/pkg/database"
 	"github.com/ekaya-inc/ekaya-engine/pkg/models"
 	sqlpkg "github.com/ekaya-inc/ekaya-engine/pkg/sql"
@@ -55,7 +54,6 @@ type ontologyImportService struct {
 	schemaRepo          ontologyImportSchemaRepository
 	dagRepo             ontologyImportDAGRepository
 	installedAppService ontologyImportInstalledAppService
-	encryptor           *crypto.CredentialEncryptor
 	logger              *zap.Logger
 }
 
@@ -90,7 +88,6 @@ func NewOntologyImportService(
 	schemaRepo ontologyImportSchemaRepository,
 	dagRepo ontologyImportDAGRepository,
 	installedAppService ontologyImportInstalledAppService,
-	encryptor *crypto.CredentialEncryptor,
 	logger *zap.Logger,
 ) OntologyImportService {
 	return &ontologyImportService{
@@ -99,7 +96,6 @@ func NewOntologyImportService(
 		schemaRepo:          schemaRepo,
 		dagRepo:             dagRepo,
 		installedAppService: installedAppService,
-		encryptor:           encryptor,
 		logger:              logger.Named("ontology-import"),
 	}
 }
@@ -191,7 +187,7 @@ func (s *ontologyImportService) prepareImportPlan(
 	if !ok {
 		return nil, fmt.Errorf("no tenant scope in context")
 	}
-	if completionState, err := loadOntologyCompletionState(ctx, scope.Conn, projectID); err != nil {
+	if completionState, err := loadOntologyCompletionState(ctx, scope.Conn, projectID, datasourceID); err != nil {
 		return nil, fmt.Errorf("load ontology completion state: %w", err)
 	} else if completionState.Provenance.IsValid() {
 		report.Problems = append(report.Problems, models.OntologyImportProblem{
@@ -227,139 +223,113 @@ func (s *ontologyImportService) prepareImportPlan(
 		}
 	}
 
-	selectedTables, err := s.schemaRepo.ListTablesByDatasource(ctx, projectID, datasourceID)
+	availableTables, err := s.schemaRepo.ListAllTablesByDatasource(ctx, projectID, datasourceID)
 	if err != nil {
-		return nil, fmt.Errorf("load selected schema tables: %w", err)
-	}
-	selectedColumns, err := s.schemaRepo.ListColumnsByDatasource(ctx, projectID, datasourceID)
-	if err != nil {
-		return nil, fmt.Errorf("load selected schema columns: %w", err)
+		return nil, fmt.Errorf("load datasource schema tables: %w", err)
 	}
 
-	targetTableByKey := make(map[string]*models.SchemaTable, len(selectedTables))
-	tableIDs := make([]uuid.UUID, 0, len(selectedTables))
-	for _, table := range selectedTables {
+	availableTableByKey := make(map[string]*models.SchemaTable, len(availableTables))
+	availableColumnsByTableKey := make(map[string]map[string]*models.SchemaColumn, len(availableTables))
+	availableColumnByKey := make(map[string]*models.SchemaColumn)
+	for _, table := range availableTables {
 		if table == nil {
 			continue
 		}
 		key := exportTableKey(table.SchemaName, table.TableName)
-		targetTableByKey[key] = table
-		tableIDs = append(tableIDs, table.ID)
+		availableTableByKey[key] = table
+
+		tableColumns, err := s.schemaRepo.ListAllColumnsByTable(ctx, projectID, table.ID)
+		if err != nil {
+			return nil, fmt.Errorf("load datasource schema columns for %s.%s: %w", table.SchemaName, table.TableName, err)
+		}
+
+		availableColumnsByTableKey[key] = make(map[string]*models.SchemaColumn, len(tableColumns))
+		for _, column := range tableColumns {
+			if column == nil {
+				continue
+			}
+			availableColumnsByTableKey[key][column.ColumnName] = column
+			availableColumnByKey[exportColumnKey(table.SchemaName, table.TableName, column.ColumnName)] = column
+		}
 	}
 
-	columnTableByID := make(map[uuid.UUID]*models.SchemaTable, len(selectedTables))
-	for _, table := range selectedTables {
-		if table != nil {
-			columnTableByID[table.ID] = table
-		}
-	}
-
-	targetColumnByKey := make(map[string]*models.SchemaColumn, len(selectedColumns))
-	columnIDs := make([]uuid.UUID, 0, len(selectedColumns))
-	selectedColumnsByTableKey := make(map[string]map[string]*models.SchemaColumn)
-	for _, column := range selectedColumns {
-		if column == nil {
-			continue
-		}
-		table := columnTableByID[column.SchemaTableID]
-		if table == nil {
-			continue
-		}
-		tableKey := exportTableKey(table.SchemaName, table.TableName)
-		key := exportColumnKey(table.SchemaName, table.TableName, column.ColumnName)
-		targetColumnByKey[key] = column
-		columnIDs = append(columnIDs, column.ID)
-		if selectedColumnsByTableKey[tableKey] == nil {
-			selectedColumnsByTableKey[tableKey] = make(map[string]*models.SchemaColumn)
-		}
-		selectedColumnsByTableKey[tableKey][column.ColumnName] = column
-	}
-
-	bundleTableKeys := make(map[string]struct{}, len(importDatasource.SelectedSchema.Tables))
-	bundleColumnKeys := make(map[string]struct{})
+	targetTableByKey := make(map[string]*models.SchemaTable, len(importDatasource.SelectedSchema.Tables))
+	targetColumnByKey := make(map[string]*models.SchemaColumn)
+	tableIDs := make([]uuid.UUID, 0, len(importDatasource.SelectedSchema.Tables))
+	columnIDs := make([]uuid.UUID, 0)
+	selectedTableIDs := make(map[uuid.UUID]struct{}, len(importDatasource.SelectedSchema.Tables))
+	selectedColumnIDs := make(map[uuid.UUID]struct{})
 	for _, table := range importDatasource.SelectedSchema.Tables {
 		tableKey := exportTableKey(table.SchemaName, table.TableName)
-		bundleTableKeys[tableKey] = struct{}{}
-		if _, ok := targetTableByKey[tableKey]; !ok {
+		targetTable, ok := availableTableByKey[tableKey]
+		if !ok {
 			report.MissingTables = append(report.MissingTables, models.OntologyExportTableRef{
 				SchemaName: table.SchemaName,
 				TableName:  table.TableName,
 			})
-		}
-
-		targetColumnsForTable := selectedColumnsByTableKey[tableKey]
-		bundleColumnsForTable := make(map[string]struct{}, len(table.Columns))
-		for _, column := range table.Columns {
-			bundleColumnsForTable[column.ColumnName] = struct{}{}
-			bundleColumnKeys[exportColumnKey(table.SchemaName, table.TableName, column.ColumnName)] = struct{}{}
-			if targetColumnsForTable == nil {
-				report.MissingColumns = append(report.MissingColumns, models.OntologyExportColumnRef{
-					Table: models.OntologyExportTableRef{
-						SchemaName: table.SchemaName,
-						TableName:  table.TableName,
-					},
-					ColumnName: column.ColumnName,
-				})
-				continue
-			}
-			if _, ok := targetColumnsForTable[column.ColumnName]; !ok {
-				report.MissingColumns = append(report.MissingColumns, models.OntologyExportColumnRef{
-					Table: models.OntologyExportTableRef{
-						SchemaName: table.SchemaName,
-						TableName:  table.TableName,
-					},
-					ColumnName: column.ColumnName,
-				})
-			}
-		}
-
-		for selectedColumnName := range targetColumnsForTable {
-			if _, ok := bundleColumnsForTable[selectedColumnName]; ok {
-				continue
-			}
-			report.UnexpectedColumns = append(report.UnexpectedColumns, models.OntologyExportColumnRef{
-				Table: models.OntologyExportTableRef{
-					SchemaName: table.SchemaName,
-					TableName:  table.TableName,
-				},
-				ColumnName: selectedColumnName,
-			})
-		}
-	}
-
-	for key, table := range targetTableByKey {
-		if _, ok := bundleTableKeys[key]; ok {
 			continue
 		}
-		report.UnexpectedTables = append(report.UnexpectedTables, models.OntologyExportTableRef{
-			SchemaName: table.SchemaName,
-			TableName:  table.TableName,
-		})
+
+		targetTableByKey[tableKey] = targetTable
+		if _, alreadySelected := selectedTableIDs[targetTable.ID]; !alreadySelected {
+			tableIDs = append(tableIDs, targetTable.ID)
+			selectedTableIDs[targetTable.ID] = struct{}{}
+		}
+
+		targetColumnsForTable := availableColumnsByTableKey[tableKey]
+		for _, column := range table.Columns {
+			targetColumn, ok := targetColumnsForTable[column.ColumnName]
+			if !ok {
+				report.MissingColumns = append(report.MissingColumns, models.OntologyExportColumnRef{
+					Table: models.OntologyExportTableRef{
+						SchemaName: table.SchemaName,
+						TableName:  table.TableName,
+					},
+					ColumnName: column.ColumnName,
+				})
+				continue
+			}
+
+			columnKey := exportColumnKey(table.SchemaName, table.TableName, column.ColumnName)
+			targetColumnByKey[columnKey] = targetColumn
+			if _, alreadySelected := selectedColumnIDs[targetColumn.ID]; !alreadySelected {
+				columnIDs = append(columnIDs, targetColumn.ID)
+				selectedColumnIDs[targetColumn.ID] = struct{}{}
+			}
+		}
 	}
 
 	for _, relationship := range importDatasource.SelectedSchema.Relationships {
 		sourceKey := exportColumnKey(relationship.Source.Table.SchemaName, relationship.Source.Table.TableName, relationship.Source.ColumnName)
 		targetKey := exportColumnKey(relationship.Target.Table.SchemaName, relationship.Target.Table.TableName, relationship.Target.ColumnName)
 		if _, ok := targetColumnByKey[sourceKey]; !ok {
+			message := "Source column is not included in the imported schema."
+			if _, exists := availableColumnByKey[sourceKey]; !exists {
+				message = "Source column does not exist on the target datasource."
+			}
 			report.UnresolvedRelationships = append(report.UnresolvedRelationships, models.OntologyImportRelationshipIssue{
 				Source:  relationship.Source,
 				Target:  relationship.Target,
-				Message: "Source column is not selected on the target datasource.",
+				Message: message,
 			})
 			continue
 		}
 		if _, ok := targetColumnByKey[targetKey]; !ok {
+			message := "Target column is not included in the imported schema."
+			if _, exists := availableColumnByKey[targetKey]; !exists {
+				message = "Target column does not exist on the target datasource."
+			}
 			report.UnresolvedRelationships = append(report.UnresolvedRelationships, models.OntologyImportRelationshipIssue{
 				Source:  relationship.Source,
 				Target:  relationship.Target,
-				Message: "Target column is not selected on the target datasource.",
+				Message: message,
 			})
 		}
 	}
 
 	if report.HasProblems() {
 		sortOntologyImportReport(&report)
-		return nil, newOntologyImportValidationError(400, "schema_validation_failed", "Ontology bundle does not match the selected datasource schema", report)
+		return nil, newOntologyImportValidationError(400, "schema_validation_failed", "Ontology bundle does not match the target datasource schema", report)
 	}
 
 	if err := normalizeBundleQueries(bundle, &report); err != nil {
@@ -373,21 +343,6 @@ func (s *ontologyImportService) prepareImportPlan(
 	queryIDsByKey := make(map[string]uuid.UUID, len(bundle.ApprovedQueries))
 	for _, query := range bundle.ApprovedQueries {
 		queryIDsByKey[query.Key] = uuid.New()
-	}
-	for _, agent := range bundle.Agents {
-		for _, key := range agent.QueryKeys {
-			if _, ok := queryIDsByKey[key]; ok {
-				continue
-			}
-			report.Problems = append(report.Problems, models.OntologyImportProblem{
-				Code:    "invalid_agent_query_key",
-				Message: fmt.Sprintf("Agent %q references unknown query key %q.", agent.Name, key),
-			})
-		}
-	}
-	if report.HasProblems() {
-		sortOntologyImportReport(&report)
-		return nil, newOntologyImportValidationError(400, "invalid_bundle", "Ontology bundle contains invalid agent mappings", report)
 	}
 
 	return &ontologyImportPlan{
@@ -429,9 +384,6 @@ func (s *ontologyImportService) applyImport(ctx context.Context, tx pgx.Tx, plan
 		return err
 	}
 	if err := s.insertQueries(ctx, tx, plan); err != nil {
-		return err
-	}
-	if err := s.insertAgents(ctx, tx, plan); err != nil {
 		return err
 	}
 	if err := s.updateProjectOntologyState(ctx, tx, plan); err != nil {
@@ -543,9 +495,6 @@ func (s *ontologyImportService) clearExistingImportState(ctx context.Context, tx
 	}
 	if _, err := tx.Exec(ctx, `DELETE FROM engine_business_glossary WHERE project_id = $1`, projectID); err != nil {
 		return fmt.Errorf("delete glossary: %w", err)
-	}
-	if _, err := tx.Exec(ctx, `DELETE FROM engine_agents WHERE project_id = $1`, projectID); err != nil {
-		return fmt.Errorf("delete agents: %w", err)
 	}
 	if _, err := tx.Exec(ctx, `
 		UPDATE engine_queries
@@ -788,46 +737,15 @@ func (s *ontologyImportService) insertQueries(ctx context.Context, tx pgx.Tx, pl
 	return nil
 }
 
-func (s *ontologyImportService) insertAgents(ctx context.Context, tx pgx.Tx, plan *ontologyImportPlan) error {
-	for _, agent := range plan.bundle.Agents {
-		plainKey, err := generateAPIKey()
-		if err != nil {
-			return fmt.Errorf("generate API key for agent %q: %w", agent.Name, err)
-		}
-		encryptedKey, err := s.encryptor.Encrypt(plainKey)
-		if err != nil {
-			return fmt.Errorf("encrypt API key for agent %q: %w", agent.Name, err)
-		}
-
-		agentID := uuid.New()
-		if _, err := tx.Exec(ctx, `
-			INSERT INTO engine_agents (id, project_id, name, api_key_encrypted, created_at, updated_at, last_access_at)
-			VALUES ($1, $2, $3, $4, $5, $5, NULL)
-		`, agentID, plan.project.ID, agent.Name, encryptedKey, plan.importedAt); err != nil {
-			return fmt.Errorf("insert agent %q: %w", agent.Name, err)
-		}
-
-		for _, key := range agent.QueryKeys {
-			if _, err := tx.Exec(ctx, `
-				INSERT INTO engine_agent_queries (agent_id, query_id)
-				VALUES ($1, $2)
-			`, agentID, plan.queryIDsByKey[key]); err != nil {
-				return fmt.Errorf("insert agent query access for %q/%q: %w", agent.Name, key, err)
-			}
-		}
-	}
-
-	return nil
-}
-
 func (s *ontologyImportService) updateProjectOntologyState(ctx context.Context, tx pgx.Tx, plan *ontologyImportPlan) error {
 	parameters, err := loadProjectParameters(ctx, tx, plan.project.ID)
 	if err != nil {
 		return err
 	}
 
-	parameters[projectParamOntologyCompletionProvenance] = string(models.OntologyCompletionProvenanceImported)
-	parameters[projectParamOntologyCompletedAt] = plan.importedAt.Format(projectParamOntologyCompletedAtFormat)
+	if err := setOntologyCompletionState(parameters, plan.datasource.ID, models.OntologyCompletionProvenanceImported, plan.importedAt); err != nil {
+		return err
+	}
 
 	parametersJSON, err := json.Marshal(parameters)
 	if err != nil {

--- a/pkg/services/ontology_import.go
+++ b/pkg/services/ontology_import.go
@@ -1,0 +1,1020 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/crypto"
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+	sqlpkg "github.com/ekaya-inc/ekaya-engine/pkg/sql"
+	sqlvalidator "github.com/ekaya-inc/ekaya-engine/pkg/sql"
+)
+
+const ontologyImportDatasourceKey = "primary"
+
+// OntologyImportService imports versioned ontology bundles into an existing datasource.
+type OntologyImportService interface {
+	ImportBundle(ctx context.Context, projectID, datasourceID uuid.UUID, bundleBytes []byte) (*models.OntologyImportResult, error)
+}
+
+type ontologyImportProjectRepository interface {
+	Get(ctx context.Context, id uuid.UUID) (*models.Project, error)
+}
+
+type ontologyImportDatasourceService interface {
+	Get(ctx context.Context, projectID, id uuid.UUID) (*models.Datasource, error)
+}
+
+type ontologyImportSchemaRepository interface {
+	ListTablesByDatasource(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.SchemaTable, error)
+	ListAllTablesByDatasource(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.SchemaTable, error)
+	ListColumnsByDatasource(ctx context.Context, projectID, datasourceID uuid.UUID) ([]*models.SchemaColumn, error)
+	ListAllColumnsByTable(ctx context.Context, projectID, tableID uuid.UUID) ([]*models.SchemaColumn, error)
+}
+
+type ontologyImportDAGRepository interface {
+	GetLatestByDatasource(ctx context.Context, datasourceID uuid.UUID) (*models.OntologyDAG, error)
+}
+
+type ontologyImportInstalledAppService interface {
+	IsInstalled(ctx context.Context, projectID uuid.UUID, appID string) (bool, error)
+}
+
+type ontologyImportService struct {
+	projectRepo         ontologyImportProjectRepository
+	datasourceService   ontologyImportDatasourceService
+	schemaRepo          ontologyImportSchemaRepository
+	dagRepo             ontologyImportDAGRepository
+	installedAppService ontologyImportInstalledAppService
+	encryptor           *crypto.CredentialEncryptor
+	logger              *zap.Logger
+}
+
+// OntologyImportValidationError is returned when a bundle cannot be imported safely.
+type OntologyImportValidationError struct {
+	StatusCode int
+	Code       string
+	Message    string
+	Report     models.OntologyImportValidationReport
+}
+
+func (e *OntologyImportValidationError) Error() string {
+	return e.Message
+}
+
+type ontologyImportPlan struct {
+	bundle        *models.OntologyExportBundle
+	project       *models.Project
+	datasource    *models.Datasource
+	importedAt    time.Time
+	tableByKey    map[string]*models.SchemaTable
+	columnByKey   map[string]*models.SchemaColumn
+	tableIDs      []uuid.UUID
+	columnIDs     []uuid.UUID
+	queryIDsByKey map[string]uuid.UUID
+}
+
+// NewOntologyImportService creates a new ontology import service.
+func NewOntologyImportService(
+	projectRepo ontologyImportProjectRepository,
+	datasourceService ontologyImportDatasourceService,
+	schemaRepo ontologyImportSchemaRepository,
+	dagRepo ontologyImportDAGRepository,
+	installedAppService ontologyImportInstalledAppService,
+	encryptor *crypto.CredentialEncryptor,
+	logger *zap.Logger,
+) OntologyImportService {
+	return &ontologyImportService{
+		projectRepo:         projectRepo,
+		datasourceService:   datasourceService,
+		schemaRepo:          schemaRepo,
+		dagRepo:             dagRepo,
+		installedAppService: installedAppService,
+		encryptor:           encryptor,
+		logger:              logger.Named("ontology-import"),
+	}
+}
+
+func (s *ontologyImportService) ImportBundle(ctx context.Context, projectID, datasourceID uuid.UUID, bundleBytes []byte) (*models.OntologyImportResult, error) {
+	plan, err := s.prepareImportPlan(ctx, projectID, datasourceID, bundleBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+
+	tx, err := scope.Conn.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin ontology import transaction: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // best effort cleanup
+
+	if err := s.applyImport(ctx, tx, plan); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit ontology import: %w", err)
+	}
+
+	return &models.OntologyImportResult{
+		ImportedAt:           plan.importedAt,
+		CompletionProvenance: models.OntologyCompletionProvenanceImported,
+	}, nil
+}
+
+func (s *ontologyImportService) prepareImportPlan(
+	ctx context.Context,
+	projectID, datasourceID uuid.UUID,
+	bundleBytes []byte,
+) (*ontologyImportPlan, error) {
+	report := models.OntologyImportValidationReport{}
+
+	if len(bundleBytes) == 0 {
+		report.Problems = append(report.Problems, models.OntologyImportProblem{
+			Code:    "invalid_bundle",
+			Message: "Ontology bundle file is empty.",
+		})
+		return nil, newOntologyImportValidationError(400, "invalid_bundle", "Invalid ontology bundle", report)
+	}
+
+	if len(bundleBytes) > models.OntologyImportMaxBytes {
+		report.Problems = append(report.Problems, models.OntologyImportProblem{
+			Code:    "file_too_large",
+			Message: "Ontology bundle exceeds the 5 MB maximum size.",
+		})
+		return nil, newOntologyImportValidationError(400, "file_too_large", "Ontology bundle exceeds the 5 MB maximum size", report)
+	}
+
+	bundle, err := decodeOntologyImportBundle(bundleBytes)
+	if err != nil {
+		report.Problems = append(report.Problems, models.OntologyImportProblem{
+			Code:    "invalid_bundle",
+			Message: err.Error(),
+		})
+		return nil, newOntologyImportValidationError(400, "invalid_bundle", "Invalid ontology bundle", report)
+	}
+
+	project, err := s.projectRepo.Get(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("load project: %w", err)
+	}
+
+	ds, err := s.datasourceService.Get(ctx, projectID, datasourceID)
+	if err != nil {
+		return nil, fmt.Errorf("load datasource: %w", err)
+	}
+
+	if latestDAG, err := s.dagRepo.GetLatestByDatasource(ctx, datasourceID); err != nil {
+		return nil, fmt.Errorf("load ontology state: %w", err)
+	} else if latestDAG != nil {
+		report.Problems = append(report.Problems, models.OntologyImportProblem{
+			Code:    "ontology_state_exists",
+			Message: "Delete the existing ontology state before importing a bundle.",
+		})
+		return nil, newOntologyImportValidationError(409, "ontology_state_exists", "Delete the existing ontology state before importing", report)
+	}
+
+	scope, ok := database.GetTenantScope(ctx)
+	if !ok {
+		return nil, fmt.Errorf("no tenant scope in context")
+	}
+	if completionState, err := loadOntologyCompletionState(ctx, scope.Conn, projectID); err != nil {
+		return nil, fmt.Errorf("load ontology completion state: %w", err)
+	} else if completionState.Provenance.IsValid() {
+		report.Problems = append(report.Problems, models.OntologyImportProblem{
+			Code:    "ontology_state_exists",
+			Message: "Delete the existing ontology state before importing a bundle.",
+		})
+		return nil, newOntologyImportValidationError(409, "ontology_state_exists", "Delete the existing ontology state before importing", report)
+	}
+
+	importDatasource := bundle.Datasources[0]
+	if ds.DatasourceType != importDatasource.DatasourceType {
+		report.DatabaseTypeMismatch = &models.OntologyImportDatabaseTypeMismatch{
+			BundleType: importDatasource.DatasourceType,
+			TargetType: ds.DatasourceType,
+		}
+		return nil, newOntologyImportValidationError(400, "database_type_mismatch", "Datasource type does not match the ontology bundle", report)
+	}
+
+	for _, appID := range bundle.RequiredApps {
+		if !models.KnownAppIDs[appID] {
+			report.Problems = append(report.Problems, models.OntologyImportProblem{
+				Code:    "invalid_required_app",
+				Message: fmt.Sprintf("Bundle references unknown required app %q.", appID),
+			})
+			continue
+		}
+		installed, err := s.installedAppService.IsInstalled(ctx, projectID, appID)
+		if err != nil {
+			return nil, fmt.Errorf("check required app %s: %w", appID, err)
+		}
+		if !installed {
+			report.MissingRequiredApps = append(report.MissingRequiredApps, appID)
+		}
+	}
+
+	selectedTables, err := s.schemaRepo.ListTablesByDatasource(ctx, projectID, datasourceID)
+	if err != nil {
+		return nil, fmt.Errorf("load selected schema tables: %w", err)
+	}
+	selectedColumns, err := s.schemaRepo.ListColumnsByDatasource(ctx, projectID, datasourceID)
+	if err != nil {
+		return nil, fmt.Errorf("load selected schema columns: %w", err)
+	}
+
+	targetTableByKey := make(map[string]*models.SchemaTable, len(selectedTables))
+	tableIDs := make([]uuid.UUID, 0, len(selectedTables))
+	for _, table := range selectedTables {
+		if table == nil {
+			continue
+		}
+		key := exportTableKey(table.SchemaName, table.TableName)
+		targetTableByKey[key] = table
+		tableIDs = append(tableIDs, table.ID)
+	}
+
+	columnTableByID := make(map[uuid.UUID]*models.SchemaTable, len(selectedTables))
+	for _, table := range selectedTables {
+		if table != nil {
+			columnTableByID[table.ID] = table
+		}
+	}
+
+	targetColumnByKey := make(map[string]*models.SchemaColumn, len(selectedColumns))
+	columnIDs := make([]uuid.UUID, 0, len(selectedColumns))
+	selectedColumnsByTableKey := make(map[string]map[string]*models.SchemaColumn)
+	for _, column := range selectedColumns {
+		if column == nil {
+			continue
+		}
+		table := columnTableByID[column.SchemaTableID]
+		if table == nil {
+			continue
+		}
+		tableKey := exportTableKey(table.SchemaName, table.TableName)
+		key := exportColumnKey(table.SchemaName, table.TableName, column.ColumnName)
+		targetColumnByKey[key] = column
+		columnIDs = append(columnIDs, column.ID)
+		if selectedColumnsByTableKey[tableKey] == nil {
+			selectedColumnsByTableKey[tableKey] = make(map[string]*models.SchemaColumn)
+		}
+		selectedColumnsByTableKey[tableKey][column.ColumnName] = column
+	}
+
+	bundleTableKeys := make(map[string]struct{}, len(importDatasource.SelectedSchema.Tables))
+	bundleColumnKeys := make(map[string]struct{})
+	for _, table := range importDatasource.SelectedSchema.Tables {
+		tableKey := exportTableKey(table.SchemaName, table.TableName)
+		bundleTableKeys[tableKey] = struct{}{}
+		if _, ok := targetTableByKey[tableKey]; !ok {
+			report.MissingTables = append(report.MissingTables, models.OntologyExportTableRef{
+				SchemaName: table.SchemaName,
+				TableName:  table.TableName,
+			})
+		}
+
+		targetColumnsForTable := selectedColumnsByTableKey[tableKey]
+		bundleColumnsForTable := make(map[string]struct{}, len(table.Columns))
+		for _, column := range table.Columns {
+			bundleColumnsForTable[column.ColumnName] = struct{}{}
+			bundleColumnKeys[exportColumnKey(table.SchemaName, table.TableName, column.ColumnName)] = struct{}{}
+			if targetColumnsForTable == nil {
+				report.MissingColumns = append(report.MissingColumns, models.OntologyExportColumnRef{
+					Table: models.OntologyExportTableRef{
+						SchemaName: table.SchemaName,
+						TableName:  table.TableName,
+					},
+					ColumnName: column.ColumnName,
+				})
+				continue
+			}
+			if _, ok := targetColumnsForTable[column.ColumnName]; !ok {
+				report.MissingColumns = append(report.MissingColumns, models.OntologyExportColumnRef{
+					Table: models.OntologyExportTableRef{
+						SchemaName: table.SchemaName,
+						TableName:  table.TableName,
+					},
+					ColumnName: column.ColumnName,
+				})
+			}
+		}
+
+		for selectedColumnName := range targetColumnsForTable {
+			if _, ok := bundleColumnsForTable[selectedColumnName]; ok {
+				continue
+			}
+			report.UnexpectedColumns = append(report.UnexpectedColumns, models.OntologyExportColumnRef{
+				Table: models.OntologyExportTableRef{
+					SchemaName: table.SchemaName,
+					TableName:  table.TableName,
+				},
+				ColumnName: selectedColumnName,
+			})
+		}
+	}
+
+	for key, table := range targetTableByKey {
+		if _, ok := bundleTableKeys[key]; ok {
+			continue
+		}
+		report.UnexpectedTables = append(report.UnexpectedTables, models.OntologyExportTableRef{
+			SchemaName: table.SchemaName,
+			TableName:  table.TableName,
+		})
+	}
+
+	for _, relationship := range importDatasource.SelectedSchema.Relationships {
+		sourceKey := exportColumnKey(relationship.Source.Table.SchemaName, relationship.Source.Table.TableName, relationship.Source.ColumnName)
+		targetKey := exportColumnKey(relationship.Target.Table.SchemaName, relationship.Target.Table.TableName, relationship.Target.ColumnName)
+		if _, ok := targetColumnByKey[sourceKey]; !ok {
+			report.UnresolvedRelationships = append(report.UnresolvedRelationships, models.OntologyImportRelationshipIssue{
+				Source:  relationship.Source,
+				Target:  relationship.Target,
+				Message: "Source column is not selected on the target datasource.",
+			})
+			continue
+		}
+		if _, ok := targetColumnByKey[targetKey]; !ok {
+			report.UnresolvedRelationships = append(report.UnresolvedRelationships, models.OntologyImportRelationshipIssue{
+				Source:  relationship.Source,
+				Target:  relationship.Target,
+				Message: "Target column is not selected on the target datasource.",
+			})
+		}
+	}
+
+	if report.HasProblems() {
+		sortOntologyImportReport(&report)
+		return nil, newOntologyImportValidationError(400, "schema_validation_failed", "Ontology bundle does not match the selected datasource schema", report)
+	}
+
+	if err := normalizeBundleQueries(bundle, &report); err != nil {
+		return nil, err
+	}
+	if report.HasProblems() {
+		sortOntologyImportReport(&report)
+		return nil, newOntologyImportValidationError(400, "invalid_bundle", "Ontology bundle contains invalid approved queries", report)
+	}
+
+	queryIDsByKey := make(map[string]uuid.UUID, len(bundle.ApprovedQueries))
+	for _, query := range bundle.ApprovedQueries {
+		queryIDsByKey[query.Key] = uuid.New()
+	}
+	for _, agent := range bundle.Agents {
+		for _, key := range agent.QueryKeys {
+			if _, ok := queryIDsByKey[key]; ok {
+				continue
+			}
+			report.Problems = append(report.Problems, models.OntologyImportProblem{
+				Code:    "invalid_agent_query_key",
+				Message: fmt.Sprintf("Agent %q references unknown query key %q.", agent.Name, key),
+			})
+		}
+	}
+	if report.HasProblems() {
+		sortOntologyImportReport(&report)
+		return nil, newOntologyImportValidationError(400, "invalid_bundle", "Ontology bundle contains invalid agent mappings", report)
+	}
+
+	return &ontologyImportPlan{
+		bundle:        bundle,
+		project:       project,
+		datasource:    ds,
+		importedAt:    time.Now().UTC(),
+		tableByKey:    targetTableByKey,
+		columnByKey:   targetColumnByKey,
+		tableIDs:      tableIDs,
+		columnIDs:     columnIDs,
+		queryIDsByKey: queryIDsByKey,
+	}, nil
+}
+
+func (s *ontologyImportService) applyImport(ctx context.Context, tx pgx.Tx, plan *ontologyImportPlan) error {
+	if err := s.replaceSelectedScope(ctx, tx, plan); err != nil {
+		return err
+	}
+	if err := s.clearExistingImportState(ctx, tx, plan); err != nil {
+		return err
+	}
+	if err := s.insertRelationships(ctx, tx, plan); err != nil {
+		return err
+	}
+	if err := s.insertTableMetadata(ctx, tx, plan); err != nil {
+		return err
+	}
+	if err := s.insertColumnMetadata(ctx, tx, plan); err != nil {
+		return err
+	}
+	if err := s.insertQuestions(ctx, tx, plan); err != nil {
+		return err
+	}
+	if err := s.insertKnowledge(ctx, tx, plan); err != nil {
+		return err
+	}
+	if err := s.insertGlossary(ctx, tx, plan); err != nil {
+		return err
+	}
+	if err := s.insertQueries(ctx, tx, plan); err != nil {
+		return err
+	}
+	if err := s.insertAgents(ctx, tx, plan); err != nil {
+		return err
+	}
+	if err := s.updateProjectOntologyState(ctx, tx, plan); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *ontologyImportService) replaceSelectedScope(ctx context.Context, tx pgx.Tx, plan *ontologyImportPlan) error {
+	now := plan.importedAt
+	if _, err := tx.Exec(ctx, `
+		UPDATE engine_schema_columns
+		SET is_selected = false, updated_at = $3
+		WHERE project_id = $1
+		  AND schema_table_id IN (
+		    SELECT id FROM engine_schema_tables
+		    WHERE project_id = $1 AND datasource_id = $2 AND deleted_at IS NULL
+		  )
+		  AND deleted_at IS NULL
+	`, plan.project.ID, plan.datasource.ID, now); err != nil {
+		return fmt.Errorf("clear selected columns: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE engine_schema_tables
+		SET is_selected = false, updated_at = $3
+		WHERE project_id = $1 AND datasource_id = $2 AND deleted_at IS NULL
+	`, plan.project.ID, plan.datasource.ID, now); err != nil {
+		return fmt.Errorf("clear selected tables: %w", err)
+	}
+
+	if len(plan.tableIDs) > 0 {
+		if _, err := tx.Exec(ctx, `
+			UPDATE engine_schema_tables
+			SET is_selected = true, updated_at = $2
+			WHERE id = ANY($1)
+		`, plan.tableIDs, now); err != nil {
+			return fmt.Errorf("select imported tables: %w", err)
+		}
+	}
+
+	if len(plan.columnIDs) > 0 {
+		if _, err := tx.Exec(ctx, `
+			UPDATE engine_schema_columns
+			SET is_selected = true, updated_at = $2
+			WHERE id = ANY($1)
+		`, plan.columnIDs, now); err != nil {
+			return fmt.Errorf("select imported columns: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (s *ontologyImportService) clearExistingImportState(ctx context.Context, tx pgx.Tx, plan *ontologyImportPlan) error {
+	projectID := plan.project.ID
+	datasourceID := plan.datasource.ID
+
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM engine_ontology_table_metadata
+		WHERE project_id = $1
+		  AND schema_table_id IN (
+		    SELECT id FROM engine_schema_tables
+		    WHERE project_id = $1 AND datasource_id = $2 AND deleted_at IS NULL
+		  )
+	`, projectID, datasourceID); err != nil {
+		return fmt.Errorf("delete table metadata: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM engine_ontology_column_metadata
+		WHERE project_id = $1
+		  AND schema_column_id IN (
+		    SELECT c.id
+		    FROM engine_schema_columns c
+		    JOIN engine_schema_tables t ON t.id = c.schema_table_id
+		    WHERE c.project_id = $1
+		      AND t.datasource_id = $2
+		      AND c.deleted_at IS NULL
+		      AND t.deleted_at IS NULL
+		  )
+	`, projectID, datasourceID); err != nil {
+		return fmt.Errorf("delete column metadata: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE engine_schema_relationships
+		SET deleted_at = $2, updated_at = $2
+		WHERE project_id = $1
+		  AND deleted_at IS NULL
+		  AND source_table_id IN (
+		    SELECT id FROM engine_schema_tables
+		    WHERE project_id = $1 AND datasource_id = $3 AND deleted_at IS NULL
+		  )
+		  AND target_table_id IN (
+		    SELECT id FROM engine_schema_tables
+		    WHERE project_id = $1 AND datasource_id = $3 AND deleted_at IS NULL
+		  )
+	`, projectID, plan.importedAt, datasourceID); err != nil {
+		return fmt.Errorf("clear relationships: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `DELETE FROM engine_ontology_questions WHERE project_id = $1`, projectID); err != nil {
+		return fmt.Errorf("delete ontology questions: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM engine_project_knowledge WHERE project_id = $1`, projectID); err != nil {
+		return fmt.Errorf("delete project knowledge: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM engine_business_glossary WHERE project_id = $1`, projectID); err != nil {
+		return fmt.Errorf("delete glossary: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM engine_agents WHERE project_id = $1`, projectID); err != nil {
+		return fmt.Errorf("delete agents: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE engine_queries
+		SET deleted_at = $3, updated_at = $3
+		WHERE project_id = $1 AND datasource_id = $2 AND deleted_at IS NULL
+	`, projectID, datasourceID, plan.importedAt); err != nil {
+		return fmt.Errorf("soft delete existing queries: %w", err)
+	}
+
+	return nil
+}
+
+func (s *ontologyImportService) insertRelationships(ctx context.Context, tx pgx.Tx, plan *ontologyImportPlan) error {
+	for _, relationship := range plan.bundle.Datasources[0].SelectedSchema.Relationships {
+		sourceID := plan.columnByKey[exportColumnRefKey(relationship.Source)].ID
+		targetID := plan.columnByKey[exportColumnRefKey(relationship.Target)].ID
+		sourceTableID := plan.tableByKey[exportTableRefKey(relationship.Source.Table)].ID
+		targetTableID := plan.tableByKey[exportTableRefKey(relationship.Target.Table)].ID
+
+		validationJSON, err := marshalJSONText(relationship.Validation)
+		if err != nil {
+			return fmt.Errorf("marshal relationship validation: %w", err)
+		}
+
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO engine_schema_relationships (
+				id, project_id, source_table_id, source_column_id, target_table_id, target_column_id,
+				relationship_type, cardinality, confidence, inference_method, is_validated,
+				validation_results, is_approved, created_at, updated_at
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $14)
+			ON CONFLICT (source_column_id, target_column_id)
+				WHERE deleted_at IS NULL
+			DO UPDATE SET
+				relationship_type = EXCLUDED.relationship_type,
+				cardinality = EXCLUDED.cardinality,
+				confidence = EXCLUDED.confidence,
+				inference_method = EXCLUDED.inference_method,
+				is_validated = EXCLUDED.is_validated,
+				validation_results = EXCLUDED.validation_results,
+				is_approved = EXCLUDED.is_approved,
+				deleted_at = NULL,
+				updated_at = EXCLUDED.updated_at
+		`, uuid.New(), plan.project.ID, sourceTableID, sourceID, targetTableID, targetID,
+			relationship.RelationshipType, relationship.Cardinality, relationship.Confidence,
+			relationship.InferenceMethod, relationship.IsValidated, validationJSON, relationship.IsApproved,
+			plan.importedAt); err != nil {
+			return fmt.Errorf("insert relationship %s -> %s: %w", exportColumnRefKey(relationship.Source), exportColumnRefKey(relationship.Target), err)
+		}
+	}
+
+	return nil
+}
+
+func (s *ontologyImportService) insertTableMetadata(ctx context.Context, tx pgx.Tx, plan *ontologyImportPlan) error {
+	for _, item := range plan.bundle.Ontology.TableMetadata {
+		featuresJSON, err := marshalJSONText(item.Features)
+		if err != nil {
+			return fmt.Errorf("marshal table metadata features: %w", err)
+		}
+
+		var preferredAlternative *string
+		if item.PreferredAlternative != nil {
+			preferredAlternative = &item.PreferredAlternative.TableName
+		}
+
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO engine_ontology_table_metadata (
+				id, project_id, schema_table_id, table_type, description, usage_notes,
+				is_ephemeral, preferred_alternative, confidence, features,
+				source, last_edit_source, created_by, updated_by, created_at, updated_at
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, NULL, NULL, $13, $13)
+		`, uuid.New(), plan.project.ID, plan.tableByKey[exportTableRefKey(item.Table)].ID,
+			item.TableType, item.Description, item.UsageNotes, item.IsEphemeral, preferredAlternative,
+			item.Confidence, featuresJSON, normalizeBundleSource(item.Source), item.LastEditSource, plan.importedAt); err != nil {
+			return fmt.Errorf("insert table metadata for %s: %w", exportTableRefKey(item.Table), err)
+		}
+	}
+
+	return nil
+}
+
+func (s *ontologyImportService) insertColumnMetadata(ctx context.Context, tx pgx.Tx, plan *ontologyImportPlan) error {
+	for _, item := range plan.bundle.Ontology.ColumnMetadata {
+		featuresJSON, err := marshalJSONText(item.Features)
+		if err != nil {
+			return fmt.Errorf("marshal column metadata features: %w", err)
+		}
+
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO engine_ontology_column_metadata (
+				id, project_id, schema_column_id, classification_path, purpose, semantic_type, role,
+				description, confidence, features, needs_enum_analysis, needs_fk_resolution,
+				needs_cross_column_check, needs_clarification, clarification_question, is_sensitive,
+				source, last_edit_source, created_by, updated_by, created_at, updated_at
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, NULL, NULL, $19, $19)
+		`, uuid.New(), plan.project.ID, plan.columnByKey[exportColumnRefKey(item.Column)].ID,
+			item.ClassificationPath, item.Purpose, item.SemanticType, item.Role, item.Description, item.Confidence,
+			featuresJSON, item.NeedsEnumAnalysis, item.NeedsFKResolution, item.NeedsCrossColumnCheck,
+			item.NeedsClarification, item.ClarificationQuestion, item.IsSensitive, normalizeBundleSource(item.Source),
+			item.LastEditSource, plan.importedAt); err != nil {
+			return fmt.Errorf("insert column metadata for %s: %w", exportColumnRefKey(item.Column), err)
+		}
+	}
+
+	return nil
+}
+
+func (s *ontologyImportService) insertQuestions(ctx context.Context, tx pgx.Tx, plan *ontologyImportPlan) error {
+	for _, question := range plan.bundle.Ontology.Questions {
+		affects := &models.QuestionAffects{}
+		if question.Affects != nil {
+			for _, table := range question.Affects.Tables {
+				affects.Tables = append(affects.Tables, table.TableName)
+			}
+			for _, column := range question.Affects.Columns {
+				affects.Columns = append(affects.Columns, column.Table.TableName+"."+column.ColumnName)
+			}
+		}
+
+		affectsJSON, err := marshalJSONText(affects)
+		if err != nil {
+			return fmt.Errorf("marshal question affects: %w", err)
+		}
+
+		var answeredAt *time.Time
+		if question.Status == models.QuestionStatusAnswered && strings.TrimSpace(question.Answer) != "" {
+			answerTime := plan.importedAt
+			answeredAt = &answerTime
+		}
+
+		var sourceEntityType *string
+		var sourceEntityKey *string
+		if len(affects.Tables) > 0 {
+			entityType := "table"
+			sourceEntityType = &entityType
+			sourceEntityKey = &affects.Tables[0]
+		}
+
+		contentHash := (&models.OntologyQuestion{
+			Category: question.Category,
+			Text:     question.Text,
+		}).ComputeContentHash()
+
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO engine_ontology_questions (
+				id, project_id, content_hash, text, reasoning, category, priority, is_required,
+				affects, source_entity_type, source_entity_key, status, status_reason, answer,
+				answered_by, answered_at, created_at, updated_at
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NULL, $15, $16, $16)
+		`, uuid.New(), plan.project.ID, contentHash, question.Text, nullableString(question.Reasoning),
+			nullableString(question.Category), question.Priority, question.IsRequired, affectsJSON,
+			sourceEntityType, sourceEntityKey, string(question.Status), nullableString(question.StatusReason),
+			nullableString(question.Answer), answeredAt, plan.importedAt); err != nil {
+			return fmt.Errorf("insert ontology question %q: %w", question.Text, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *ontologyImportService) insertKnowledge(ctx context.Context, tx pgx.Tx, plan *ontologyImportPlan) error {
+	for _, fact := range plan.bundle.Ontology.ProjectKnowledge {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO engine_project_knowledge (
+				id, project_id, fact_type, value, context, source, last_edit_source,
+				created_by, updated_by, created_at, updated_at
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, NULL, NULL, $8, $8)
+		`, uuid.New(), plan.project.ID, fact.FactType, fact.Value, nullableString(fact.Context),
+			normalizeBundleSource(fact.Source), fact.LastEditSource, plan.importedAt); err != nil {
+			return fmt.Errorf("insert project knowledge fact %q: %w", fact.Value, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *ontologyImportService) insertGlossary(ctx context.Context, tx pgx.Tx, plan *ontologyImportPlan) error {
+	for _, term := range plan.bundle.Ontology.GlossaryTerms {
+		outputColumnsJSON, err := marshalJSONText(term.OutputColumns)
+		if err != nil {
+			return fmt.Errorf("marshal glossary output columns: %w", err)
+		}
+
+		termID := uuid.New()
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO engine_business_glossary (
+				id, project_id, term, definition, defining_sql, base_table, output_columns,
+				enrichment_status, enrichment_error, source, last_edit_source, created_by, updated_by,
+				created_at, updated_at
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NULL, NULL, $12, $12)
+		`, termID, plan.project.ID, term.Term, term.Definition, term.DefiningSQL, nullableString(term.BaseTable),
+			outputColumnsJSON, nullableString(term.EnrichmentStatus), nullableString(term.EnrichmentError),
+			normalizeBundleSource(term.Source), term.LastEditSource, plan.importedAt); err != nil {
+			return fmt.Errorf("insert glossary term %q: %w", term.Term, err)
+		}
+
+		for _, alias := range term.Aliases {
+			if _, err := tx.Exec(ctx, `
+				INSERT INTO engine_glossary_aliases (id, glossary_id, alias, created_at)
+				VALUES ($1, $2, $3, $4)
+			`, uuid.New(), termID, alias, plan.importedAt); err != nil {
+				return fmt.Errorf("insert glossary alias %q: %w", alias, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *ontologyImportService) insertQueries(ctx context.Context, tx pgx.Tx, plan *ontologyImportPlan) error {
+	for _, query := range plan.bundle.ApprovedQueries {
+		parametersJSON, err := marshalJSONText(query.Parameters)
+		if err != nil {
+			return fmt.Errorf("marshal query parameters: %w", err)
+		}
+		outputColumnsJSON, err := marshalJSONText(query.OutputColumns)
+		if err != nil {
+			return fmt.Errorf("marshal query output columns: %w", err)
+		}
+
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO engine_queries (
+				id, project_id, datasource_id, natural_language_prompt, additional_context,
+				sql_query, dialect, is_enabled, usage_count, last_used_at, parameters, output_columns,
+				constraints, status, suggested_by, suggestion_context, tags, allows_modification,
+				reviewed_by, reviewed_at, rejection_reason, parent_query_id, created_at, updated_at, deleted_at
+			) VALUES (
+				$1, $2, $3, $4, $5,
+				$6, $7, $8, 0, NULL, $9, $10,
+				$11, 'approved', NULL, NULL, $12, $13,
+				NULL, NULL, NULL, NULL, $14, $14, NULL
+			)
+		`, plan.queryIDsByKey[query.Key], plan.project.ID, plan.datasource.ID, query.NaturalLanguagePrompt,
+			query.AdditionalContext, query.SQL, query.Dialect, query.Enabled, parametersJSON, outputColumnsJSON,
+			query.Constraints, query.Tags, query.AllowsModification, plan.importedAt); err != nil {
+			return fmt.Errorf("insert approved query %q: %w", query.Key, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *ontologyImportService) insertAgents(ctx context.Context, tx pgx.Tx, plan *ontologyImportPlan) error {
+	for _, agent := range plan.bundle.Agents {
+		plainKey, err := generateAPIKey()
+		if err != nil {
+			return fmt.Errorf("generate API key for agent %q: %w", agent.Name, err)
+		}
+		encryptedKey, err := s.encryptor.Encrypt(plainKey)
+		if err != nil {
+			return fmt.Errorf("encrypt API key for agent %q: %w", agent.Name, err)
+		}
+
+		agentID := uuid.New()
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO engine_agents (id, project_id, name, api_key_encrypted, created_at, updated_at, last_access_at)
+			VALUES ($1, $2, $3, $4, $5, $5, NULL)
+		`, agentID, plan.project.ID, agent.Name, encryptedKey, plan.importedAt); err != nil {
+			return fmt.Errorf("insert agent %q: %w", agent.Name, err)
+		}
+
+		for _, key := range agent.QueryKeys {
+			if _, err := tx.Exec(ctx, `
+				INSERT INTO engine_agent_queries (agent_id, query_id)
+				VALUES ($1, $2)
+			`, agentID, plan.queryIDsByKey[key]); err != nil {
+				return fmt.Errorf("insert agent query access for %q/%q: %w", agent.Name, key, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *ontologyImportService) updateProjectOntologyState(ctx context.Context, tx pgx.Tx, plan *ontologyImportPlan) error {
+	parameters, err := loadProjectParameters(ctx, tx, plan.project.ID)
+	if err != nil {
+		return err
+	}
+
+	parameters[projectParamOntologyCompletionProvenance] = string(models.OntologyCompletionProvenanceImported)
+	parameters[projectParamOntologyCompletedAt] = plan.importedAt.Format(projectParamOntologyCompletedAtFormat)
+
+	parametersJSON, err := json.Marshal(parameters)
+	if err != nil {
+		return fmt.Errorf("encode project parameters: %w", err)
+	}
+
+	var domainSummaryJSON *string
+	if plan.bundle.Project.DomainSummary != nil {
+		raw, err := marshalJSONText(plan.bundle.Project.DomainSummary)
+		if err != nil {
+			return fmt.Errorf("marshal domain summary: %w", err)
+		}
+		domainSummaryJSON = &raw
+	}
+
+	industryType := plan.bundle.Project.IndustryType
+	if industryType == "" {
+		industryType = plan.project.IndustryType
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE engine_projects
+		SET parameters = $2, industry_type = $3, domain_summary = $4, updated_at = $5
+		WHERE id = $1
+	`, plan.project.ID, parametersJSON, industryType, domainSummaryJSON, plan.importedAt); err != nil {
+		return fmt.Errorf("update imported project state: %w", err)
+	}
+
+	return nil
+}
+
+func decodeOntologyImportBundle(bundleBytes []byte) (*models.OntologyExportBundle, error) {
+	var bundle models.OntologyExportBundle
+	decoder := json.NewDecoder(strings.NewReader(string(bundleBytes)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&bundle); err != nil {
+		return nil, fmt.Errorf("failed to parse ontology bundle JSON: %w", err)
+	}
+
+	if bundle.Format != models.OntologyExportFormat {
+		return nil, fmt.Errorf("unsupported ontology bundle format %q", bundle.Format)
+	}
+	if bundle.Version != models.OntologyExportVersion {
+		return nil, fmt.Errorf("unsupported ontology bundle version %d", bundle.Version)
+	}
+	if len(bundle.Datasources) != 1 {
+		return nil, fmt.Errorf("ontology import requires exactly one datasource bundle")
+	}
+	if bundle.Security.IncludesDatasourceCredentials || bundle.Security.IncludesAIConfig || bundle.Security.IncludesAgentAPIKeys {
+		return nil, fmt.Errorf("ontology bundle must not include datasource credentials, AI config, or agent API keys")
+	}
+
+	return &bundle, nil
+}
+
+func normalizeBundleQueries(bundle *models.OntologyExportBundle, report *models.OntologyImportValidationReport) error {
+	for index := range bundle.ApprovedQueries {
+		query := &bundle.ApprovedQueries[index]
+		if query.DatasourceKey != ontologyImportDatasourceKey {
+			report.Problems = append(report.Problems, models.OntologyImportProblem{
+				Code:    "invalid_query_datasource_key",
+				Message: fmt.Sprintf("Approved query %q references datasource key %q.", query.Key, query.DatasourceKey),
+			})
+			continue
+		}
+
+		validationResult := sqlvalidator.ValidateAndNormalize(query.SQL)
+		if validationResult.Error != nil {
+			report.Problems = append(report.Problems, models.OntologyImportProblem{
+				Code:    "invalid_query_sql",
+				Message: fmt.Sprintf("Approved query %q is invalid: %s", query.Key, validationResult.Error.Error()),
+			})
+			continue
+		}
+		query.SQL = validationResult.NormalizedSQL
+
+		sqlType, err := ValidateSQLType(query.SQL, query.AllowsModification)
+		if err != nil {
+			report.Problems = append(report.Problems, models.OntologyImportProblem{
+				Code:    "invalid_query_sql",
+				Message: fmt.Sprintf("Approved query %q is invalid: %s", query.Key, err.Error()),
+			})
+			continue
+		}
+		if ShouldAutoCorrectAllowsModification(sqlType, query.AllowsModification) {
+			query.AllowsModification = false
+		}
+		if err := sqlpkg.ValidateParameterDefinitions(query.SQL, query.Parameters); err != nil {
+			report.Problems = append(report.Problems, models.OntologyImportProblem{
+				Code:    "invalid_query_parameters",
+				Message: fmt.Sprintf("Approved query %q has invalid parameter definitions: %s", query.Key, err.Error()),
+			})
+		}
+	}
+
+	return nil
+}
+
+func newOntologyImportValidationError(statusCode int, code, message string, report models.OntologyImportValidationReport) error {
+	sortOntologyImportReport(&report)
+	return &OntologyImportValidationError{
+		StatusCode: statusCode,
+		Code:       code,
+		Message:    message,
+		Report:     report,
+	}
+}
+
+func sortOntologyImportReport(report *models.OntologyImportValidationReport) {
+	sort.Slice(report.Problems, func(i, j int) bool {
+		if report.Problems[i].Code != report.Problems[j].Code {
+			return report.Problems[i].Code < report.Problems[j].Code
+		}
+		return report.Problems[i].Message < report.Problems[j].Message
+	})
+	sort.Slice(report.MissingTables, func(i, j int) bool {
+		return compareImportTableRefs(report.MissingTables[i], report.MissingTables[j]) < 0
+	})
+	sort.Slice(report.UnexpectedTables, func(i, j int) bool {
+		return compareImportTableRefs(report.UnexpectedTables[i], report.UnexpectedTables[j]) < 0
+	})
+	sort.Slice(report.MissingColumns, func(i, j int) bool {
+		return compareImportColumnRefs(report.MissingColumns[i], report.MissingColumns[j]) < 0
+	})
+	sort.Slice(report.UnexpectedColumns, func(i, j int) bool {
+		return compareImportColumnRefs(report.UnexpectedColumns[i], report.UnexpectedColumns[j]) < 0
+	})
+	sort.Slice(report.UnresolvedRelationships, func(i, j int) bool {
+		if cmp := compareImportColumnRefs(report.UnresolvedRelationships[i].Source, report.UnresolvedRelationships[j].Source); cmp != 0 {
+			return cmp < 0
+		}
+		return compareImportColumnRefs(report.UnresolvedRelationships[i].Target, report.UnresolvedRelationships[j].Target) < 0
+	})
+	sort.Strings(report.MissingRequiredApps)
+}
+
+func compareImportTableRefs(left, right models.OntologyExportTableRef) int {
+	if left.SchemaName != right.SchemaName {
+		return strings.Compare(left.SchemaName, right.SchemaName)
+	}
+	return strings.Compare(left.TableName, right.TableName)
+}
+
+func compareImportColumnRefs(left, right models.OntologyExportColumnRef) int {
+	if cmp := compareImportTableRefs(left.Table, right.Table); cmp != 0 {
+		return cmp
+	}
+	return strings.Compare(left.ColumnName, right.ColumnName)
+}
+
+func exportTableKey(schemaName, tableName string) string {
+	return strings.TrimSpace(schemaName) + "." + strings.TrimSpace(tableName)
+}
+
+func exportTableRefKey(ref models.OntologyExportTableRef) string {
+	return exportTableKey(ref.SchemaName, ref.TableName)
+}
+
+func exportColumnKey(schemaName, tableName, columnName string) string {
+	return exportTableKey(schemaName, tableName) + "." + strings.TrimSpace(columnName)
+}
+
+func exportColumnRefKey(ref models.OntologyExportColumnRef) string {
+	return exportColumnKey(ref.Table.SchemaName, ref.Table.TableName, ref.ColumnName)
+}
+
+func marshalJSONText(value any) (string, error) {
+	if value == nil {
+		return "null", nil
+	}
+	bytes, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+func nullableString(value string) *string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	return &value
+}
+
+func normalizeBundleSource(source string) string {
+	if models.ProvenanceSource(source).IsValid() {
+		return source
+	}
+	return models.ProvenanceManual
+}

--- a/pkg/services/ontology_import_regression_test.go
+++ b/pkg/services/ontology_import_regression_test.go
@@ -1,0 +1,430 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/ekaya-inc/ekaya-engine/pkg/database"
+	"github.com/ekaya-inc/ekaya-engine/pkg/models"
+)
+
+type mockOntologyImportProjectRepo struct {
+	project *models.Project
+}
+
+func (m *mockOntologyImportProjectRepo) Get(_ context.Context, _ uuid.UUID) (*models.Project, error) {
+	return m.project, nil
+}
+
+type mockOntologyImportDatasourceLookup struct {
+	datasources map[uuid.UUID]*models.Datasource
+}
+
+func (m *mockOntologyImportDatasourceLookup) Get(_ context.Context, _ uuid.UUID, id uuid.UUID) (*models.Datasource, error) {
+	ds, ok := m.datasources[id]
+	if !ok {
+		return nil, fmt.Errorf("datasource %s not found", id)
+	}
+	return ds, nil
+}
+
+type mockOntologyImportDAGRepo struct {
+	latestByDatasource map[uuid.UUID]*models.OntologyDAG
+}
+
+func (m *mockOntologyImportDAGRepo) GetLatestByDatasource(_ context.Context, datasourceID uuid.UUID) (*models.OntologyDAG, error) {
+	if m.latestByDatasource == nil {
+		return nil, nil
+	}
+	return m.latestByDatasource[datasourceID], nil
+}
+
+type mockOntologyImportInstalledApps struct{}
+
+func (m *mockOntologyImportInstalledApps) IsInstalled(_ context.Context, _ uuid.UUID, _ string) (bool, error) {
+	return true, nil
+}
+
+func TestGetOntologyStatus_CompletionStateScopedByDatasource(t *testing.T) {
+	tc := setupSchemaServiceTest(t)
+	cleanupOntologyImportTestState(t, tc)
+	defer cleanupOntologyImportTestState(t, tc)
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	otherDatasource := ensureAdditionalImportTestDatasource(t, tc, "Secondary Datasource")
+
+	scope, ok := database.GetTenantScope(ctx)
+	require.True(t, ok)
+
+	importedAt := mustParseTime(t, "2026-03-24T10:00:00Z")
+	require.NoError(t, storeOntologyCompletionState(
+		ctx,
+		scope.Conn,
+		tc.projectID,
+		tc.dsID,
+		models.OntologyCompletionProvenanceImported,
+		importedAt,
+	))
+
+	dagSvc := NewOntologyDAGService(nil, tc.repo, nil, nil, nil, nil, nil, zap.NewNop())
+
+	statusForImportedDatasource, err := dagSvc.GetOntologyStatus(ctx, tc.projectID, tc.dsID)
+	require.NoError(t, err)
+	require.True(t, statusForImportedDatasource.HasOntology)
+	require.Equal(t, models.OntologyCompletionProvenanceImported, statusForImportedDatasource.CompletionProvenance)
+
+	statusForOtherDatasource, err := dagSvc.GetOntologyStatus(ctx, tc.projectID, otherDatasource.ID)
+	require.NoError(t, err)
+	assert.False(t, statusForOtherDatasource.HasOntology)
+	assert.Equal(t, models.OntologyCompletionProvenance(""), statusForOtherDatasource.CompletionProvenance)
+	assert.Nil(t, statusForOtherDatasource.LastBuiltAt)
+}
+
+func TestOntologyImportService_PrepareImportPlan_IgnoresOtherDatasourceCompletionState(t *testing.T) {
+	tc := setupSchemaServiceTest(t)
+	cleanupOntologyImportTestState(t, tc)
+	defer cleanupOntologyImportTestState(t, tc)
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	sourceDatasource := &models.Datasource{
+		ID:             tc.dsID,
+		ProjectID:      tc.projectID,
+		Name:           "Primary Datasource",
+		DatasourceType: "postgres",
+	}
+	targetDatasource := ensureAdditionalImportTestDatasource(t, tc, "Import Target")
+	usersTable := createImportTestTable(t, tc, ctx, targetDatasource.ID, "public", "users", false)
+	createImportTestColumn(t, tc, ctx, usersTable.ID, "id", "uuid", 1, false)
+
+	scope, ok := database.GetTenantScope(ctx)
+	require.True(t, ok)
+	require.NoError(t, storeOntologyCompletionState(
+		ctx,
+		scope.Conn,
+		tc.projectID,
+		sourceDatasource.ID,
+		models.OntologyCompletionProvenanceImported,
+		mustParseTime(t, "2026-03-24T10:00:00Z"),
+	))
+
+	svc := newTestOntologyImportService(tc.projectID, tc.repo, sourceDatasource, targetDatasource)
+	_, err := svc.prepareImportPlan(ctx, tc.projectID, targetDatasource.ID, mustMarshalOntologyImportBundle(t, targetDatasource, []models.OntologyExportTable{
+		{
+			SchemaName: "public",
+			TableName:  "users",
+			Columns: []models.OntologyExportColumn{
+				{ColumnName: "id", DataType: "uuid", IsPrimaryKey: true, OrdinalPosition: 1},
+			},
+		},
+	}))
+	require.NoError(t, err)
+}
+
+func TestOntologyImportService_PrepareImportPlan_UsesAvailableDatasourceSchema(t *testing.T) {
+	tc := setupSchemaServiceTest(t)
+	cleanupOntologyImportTestState(t, tc)
+	defer cleanupOntologyImportTestState(t, tc)
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	datasource := &models.Datasource{
+		ID:             tc.dsID,
+		ProjectID:      tc.projectID,
+		Name:           "Primary Datasource",
+		DatasourceType: "postgres",
+	}
+	usersTable := createImportTestTable(t, tc, ctx, datasource.ID, "public", "users", false)
+	usersIDColumn := createImportTestColumn(t, tc, ctx, usersTable.ID, "id", "uuid", 1, false)
+	usersEmailColumn := createImportTestColumn(t, tc, ctx, usersTable.ID, "email", "text", 2, false)
+	ordersTable := createImportTestTable(t, tc, ctx, datasource.ID, "public", "orders", true)
+	createImportTestColumn(t, tc, ctx, ordersTable.ID, "id", "uuid", 1, true)
+
+	svc := newTestOntologyImportService(tc.projectID, tc.repo, datasource)
+	plan, err := svc.prepareImportPlan(ctx, tc.projectID, datasource.ID, mustMarshalOntologyImportBundle(t, datasource, []models.OntologyExportTable{
+		{
+			SchemaName: "public",
+			TableName:  "users",
+			Columns: []models.OntologyExportColumn{
+				{ColumnName: "id", DataType: "uuid", IsPrimaryKey: true, OrdinalPosition: 1},
+				{ColumnName: "email", DataType: "text", OrdinalPosition: 2},
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	require.Len(t, plan.tableIDs, 1)
+	require.Equal(t, usersTable.ID, plan.tableIDs[0])
+	require.ElementsMatch(t, []uuid.UUID{usersIDColumn.ID, usersEmailColumn.ID}, plan.columnIDs)
+	require.NotContains(t, plan.tableIDs, ordersTable.ID)
+}
+
+func TestOntologyImportService_ImportBundle_PreservesExistingAgents(t *testing.T) {
+	tc := setupSchemaServiceTest(t)
+	cleanupOntologyImportTestState(t, tc)
+	defer cleanupOntologyImportTestState(t, tc)
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	datasource := &models.Datasource{
+		ID:             tc.dsID,
+		ProjectID:      tc.projectID,
+		Name:           "Primary Datasource",
+		DatasourceType: "postgres",
+	}
+	usersTable := createImportTestTable(t, tc, ctx, datasource.ID, "public", "users", false)
+	createImportTestColumn(t, tc, ctx, usersTable.ID, "id", "uuid", 1, false)
+
+	scope, ok := database.GetTenantScope(ctx)
+	require.True(t, ok)
+
+	agentID := uuid.New()
+	_, err := scope.Conn.Exec(ctx, `
+		INSERT INTO engine_agents (id, project_id, name, api_key_encrypted, created_at, updated_at, last_access_at)
+		VALUES ($1, $2, $3, $4, NOW(), NOW(), NULL)
+	`, agentID, tc.projectID, "existing-agent", "encrypted")
+	require.NoError(t, err)
+
+	svc := newTestOntologyImportService(tc.projectID, tc.repo, datasource)
+	_, err = svc.ImportBundle(ctx, tc.projectID, datasource.ID, mustMarshalOntologyImportBundle(t, datasource, []models.OntologyExportTable{
+		{
+			SchemaName: "public",
+			TableName:  "users",
+			Columns: []models.OntologyExportColumn{
+				{ColumnName: "id", DataType: "uuid", IsPrimaryKey: true, OrdinalPosition: 1},
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	var count int
+	err = scope.Conn.QueryRow(ctx, `SELECT COUNT(*) FROM engine_agents WHERE project_id = $1`, tc.projectID).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func newTestOntologyImportService(projectID uuid.UUID, schemaRepo ontologyImportSchemaRepository, datasources ...*models.Datasource) *ontologyImportService {
+	project := &models.Project{
+		ID:   projectID,
+		Name: "Ontology Import Test Project",
+	}
+
+	datasourceByID := make(map[uuid.UUID]*models.Datasource, len(datasources))
+	for _, datasource := range datasources {
+		datasourceByID[datasource.ID] = datasource
+	}
+
+	return &ontologyImportService{
+		projectRepo:         &mockOntologyImportProjectRepo{project: project},
+		datasourceService:   &mockOntologyImportDatasourceLookup{datasources: datasourceByID},
+		schemaRepo:          schemaRepo,
+		dagRepo:             &mockOntologyImportDAGRepo{},
+		installedAppService: &mockOntologyImportInstalledApps{},
+		logger:              zap.NewNop(),
+	}
+}
+
+func mustMarshalOntologyImportBundle(t *testing.T, datasource *models.Datasource, tables []models.OntologyExportTable) []byte {
+	t.Helper()
+
+	bundle := models.OntologyExportBundle{
+		Format:  models.OntologyExportFormat,
+		Version: models.OntologyExportVersion,
+		Project: models.OntologyExportProject{
+			Name: "Ontology Import Test Project",
+		},
+		Datasources: []models.OntologyExportDatasource{
+			{
+				Key:            ontologyImportDatasourceKey,
+				Name:           datasource.Name,
+				DatasourceType: datasource.DatasourceType,
+				SelectedSchema: models.OntologyExportSelectedSchema{
+					Tables: tables,
+				},
+			},
+		},
+		Security: models.OntologyExportSecurity{},
+	}
+
+	payload, err := json.Marshal(bundle)
+	require.NoError(t, err)
+	return payload
+}
+
+func ensureAdditionalImportTestDatasource(t *testing.T, tc *schemaServiceTestContext, name string) *models.Datasource {
+	t.Helper()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	scope, ok := database.GetTenantScope(ctx)
+	require.True(t, ok)
+
+	datasource := &models.Datasource{
+		ID:             uuid.New(),
+		ProjectID:      tc.projectID,
+		Name:           name,
+		DatasourceType: "postgres",
+	}
+	_, err := scope.Conn.Exec(ctx, `
+		INSERT INTO engine_datasources (id, project_id, name, datasource_type, datasource_config)
+		VALUES ($1, $2, $3, $4, $5)
+	`, datasource.ID, datasource.ProjectID, datasource.Name, datasource.DatasourceType, "{}")
+	require.NoError(t, err)
+
+	return datasource
+}
+
+func createImportTestTable(
+	t *testing.T,
+	tc *schemaServiceTestContext,
+	ctx context.Context,
+	datasourceID uuid.UUID,
+	schemaName, tableName string,
+	isSelected bool,
+) *models.SchemaTable {
+	t.Helper()
+
+	table := &models.SchemaTable{
+		ProjectID:    tc.projectID,
+		DatasourceID: datasourceID,
+		SchemaName:   schemaName,
+		TableName:    tableName,
+		IsSelected:   isSelected,
+	}
+	require.NoError(t, tc.repo.UpsertTable(ctx, table))
+
+	return table
+}
+
+func createImportTestColumn(
+	t *testing.T,
+	tc *schemaServiceTestContext,
+	ctx context.Context,
+	tableID uuid.UUID,
+	columnName, dataType string,
+	ordinal int,
+	isSelected bool,
+) *models.SchemaColumn {
+	t.Helper()
+
+	column := &models.SchemaColumn{
+		ProjectID:       tc.projectID,
+		SchemaTableID:   tableID,
+		ColumnName:      columnName,
+		DataType:        dataType,
+		IsNullable:      true,
+		IsPrimaryKey:    columnName == "id",
+		IsSelected:      isSelected,
+		OrdinalPosition: ordinal,
+	}
+	require.NoError(t, tc.repo.UpsertColumn(ctx, column))
+
+	return column
+}
+
+func cleanupOntologyImportTestState(t *testing.T, tc *schemaServiceTestContext) {
+	t.Helper()
+
+	ctx, cleanup := tc.createTestContext()
+	defer cleanup()
+
+	scope, ok := database.GetTenantScope(ctx)
+	require.True(t, ok)
+
+	statements := []struct {
+		sql  string
+		args []any
+	}{
+		{
+			sql: `DELETE FROM engine_agent_queries WHERE agent_id IN (SELECT id FROM engine_agents WHERE project_id = $1)`,
+			args: []any{
+				tc.projectID,
+			},
+		},
+		{
+			sql:  `DELETE FROM engine_agents WHERE project_id = $1`,
+			args: []any{tc.projectID},
+		},
+		{
+			sql:  `DELETE FROM engine_queries WHERE project_id = $1`,
+			args: []any{tc.projectID},
+		},
+		{
+			sql: `DELETE FROM engine_dag_nodes WHERE dag_id IN (SELECT id FROM engine_ontology_dag WHERE project_id = $1)`,
+			args: []any{
+				tc.projectID,
+			},
+		},
+		{
+			sql:  `DELETE FROM engine_ontology_dag WHERE project_id = $1`,
+			args: []any{tc.projectID},
+		},
+		{
+			sql:  `DELETE FROM engine_ontology_questions WHERE project_id = $1`,
+			args: []any{tc.projectID},
+		},
+		{
+			sql:  `DELETE FROM engine_project_knowledge WHERE project_id = $1`,
+			args: []any{tc.projectID},
+		},
+		{
+			sql:  `DELETE FROM engine_business_glossary WHERE project_id = $1`,
+			args: []any{tc.projectID},
+		},
+		{
+			sql:  `DELETE FROM engine_ontology_column_metadata WHERE project_id = $1`,
+			args: []any{tc.projectID},
+		},
+		{
+			sql:  `DELETE FROM engine_ontology_table_metadata WHERE project_id = $1`,
+			args: []any{tc.projectID},
+		},
+		{
+			sql:  `DELETE FROM engine_schema_relationships WHERE project_id = $1`,
+			args: []any{tc.projectID},
+		},
+		{
+			sql:  `DELETE FROM engine_schema_columns WHERE project_id = $1`,
+			args: []any{tc.projectID},
+		},
+		{
+			sql:  `DELETE FROM engine_schema_tables WHERE project_id = $1`,
+			args: []any{tc.projectID},
+		},
+		{
+			sql:  `UPDATE engine_projects SET parameters = NULL, domain_summary = NULL WHERE id = $1`,
+			args: []any{tc.projectID},
+		},
+		{
+			sql:  `DELETE FROM engine_datasources WHERE project_id = $1 AND id <> $2`,
+			args: []any{tc.projectID, tc.dsID},
+		},
+	}
+
+	for _, statement := range statements {
+		_, err := scope.Conn.Exec(ctx, statement.sql, statement.args...)
+		require.NoError(t, err)
+	}
+}
+
+func mustParseTime(t *testing.T, value string) time.Time {
+	t.Helper()
+
+	parsed, err := time.Parse(time.RFC3339, value)
+	require.NoError(t, err)
+	return parsed.UTC()
+}

--- a/ui/src/components/ontology/OntologyDAG.tsx
+++ b/ui/src/components/ontology/OntologyDAG.tsx
@@ -15,12 +15,24 @@ import {
   Network,
   RefreshCw,
   Trash2,
+  Upload,
   X,
 } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type ChangeEvent } from 'react';
 
+import { getUserRoles } from '../../lib/auth-token';
 import engineApi from '../../services/engineApi';
-import type { DAGNodeName, DAGNodeStatus, DAGStatusResponse, DAGStatus, OntologyStatusResponse } from '../../types';
+import type {
+  DAGNodeName,
+  DAGNodeStatus,
+  DAGStatusResponse,
+  DAGStatus,
+  OntologyImportColumnRef,
+  OntologyImportRelationshipIssue,
+  OntologyImportTableRef,
+  OntologyImportValidationReport,
+  OntologyStatusResponse,
+} from '../../types';
 import { DAGNodeDescriptions } from '../../types';
 import { Button } from '../ui/Button';
 import {
@@ -46,6 +58,7 @@ interface OntologyDAGProps {
 // Polling interval in milliseconds (2 seconds as per plan)
 const POLL_INTERVAL_MS = 2000;
 const DEFAULT_EXPORT_FILENAME = 'ontology-export.json';
+const MAX_IMPORT_BYTES = 5 * 1024 * 1024;
 
 // Helper to get status icon for a node
 const getNodeStatusIcon = (status: DAGNodeStatus, isCurrentNode: boolean) => {
@@ -130,17 +143,26 @@ export const OntologyDAG = ({
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [deleteConfirmText, setDeleteConfirmText] = useState('');
   const [isExporting, setIsExporting] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const [importErrorMessage, setImportErrorMessage] = useState<string | null>(null);
+  const [importReport, setImportReport] = useState<OntologyImportValidationReport | null>(null);
   const [projectOverview, setProjectOverview] = useState('');
   const [isLoadingOverview, setIsLoadingOverview] = useState(true);
 
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isMountedRef = useRef(true);
+  const importInputRef = useRef<HTMLInputElement | null>(null);
 
   // Derived state
+  const roles = getUserRoles();
+  const isAdmin = roles.includes('admin');
   const isRunning = dagStatus?.status === 'running' || dagStatus?.status === 'pending';
   const isComplete = dagStatus?.status === 'completed';
   const isFailed = dagStatus?.status === 'failed';
   const isCancelled = dagStatus?.status === 'cancelled';
+  const hasOntology = Boolean(ontologyStatus?.has_ontology);
+  const isImportedComplete =
+    hasOntology && ontologyStatus?.completion_provenance === 'imported';
 
   // Stop polling
   const stopPolling = useCallback(() => {
@@ -262,6 +284,11 @@ export const OntologyDAG = ({
     }
   }, [projectId, datasourceId, stopPolling, fetchStatus]);
 
+  const clearImportFeedback = useCallback(() => {
+    setImportErrorMessage(null);
+    setImportReport(null);
+  }, []);
+
   // Delete ontology
   const handleDelete = useCallback(async () => {
     try {
@@ -273,8 +300,13 @@ export const OntologyDAG = ({
 
       // Reset state
       setDagStatus(null);
+      setOntologyStatus({
+        has_ontology: false,
+        schema_changed_since_build: false,
+      });
       setShowDeleteDialog(false);
       setDeleteConfirmText('');
+      clearImportFeedback();
       stopPolling();
     } catch (err) {
       if (!isMountedRef.current) return;
@@ -287,7 +319,7 @@ export const OntologyDAG = ({
         setIsDeleting(false);
       }
     }
-  }, [projectId, datasourceId, stopPolling, onError]);
+  }, [clearImportFeedback, projectId, datasourceId, stopPolling, onError]);
 
   const handleExport = useCallback(async () => {
     try {
@@ -313,6 +345,79 @@ export const OntologyDAG = ({
       }
     }
   }, [datasourceId, onError, projectId]);
+
+  const handleImport = useCallback(async (file: File) => {
+    try {
+      setIsImporting(true);
+      setError(null);
+      clearImportFeedback();
+
+      const response = await engineApi.importOntologyBundle(projectId, datasourceId, file);
+
+      if (!isMountedRef.current) return;
+
+      if (response.data) {
+        stopPolling();
+        setDagStatus(null);
+        setOntologyStatus({
+          has_ontology: true,
+          last_built_at: response.data.imported_at,
+          completion_provenance: response.data.completion_provenance,
+          schema_changed_since_build: false,
+        });
+      }
+    } catch (err) {
+      if (!isMountedRef.current) return;
+      const failure = getImportFailure(err);
+      setImportErrorMessage(failure.message);
+      setImportReport(failure.report);
+    } finally {
+      if (isMountedRef.current) {
+        setIsImporting(false);
+      }
+    }
+  }, [clearImportFeedback, datasourceId, projectId, stopPolling]);
+
+  const handleImportInputChange = useCallback(async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) {
+      return;
+    }
+
+    if (!file.name.toLowerCase().endsWith('.json')) {
+      setImportErrorMessage('Ontology bundle must be a .json file');
+      setImportReport({
+        problems: [
+          {
+            code: 'invalid_file',
+            message: 'Ontology bundle must use the .json file extension.',
+          },
+        ],
+      });
+      return;
+    }
+
+    if (file.size > MAX_IMPORT_BYTES) {
+      setImportErrorMessage('Ontology bundle exceeds the 5 MB maximum size');
+      setImportReport({
+        problems: [
+          {
+            code: 'file_too_large',
+            message: 'Ontology bundle exceeds the 5 MB maximum size.',
+          },
+        ],
+      });
+      return;
+    }
+
+    await handleImport(file);
+  }, [handleImport]);
+
+  const openImportPicker = useCallback(() => {
+    clearImportFeedback();
+    importInputRef.current?.click();
+  }, [clearImportFeedback]);
 
   // Initial load
   useEffect(() => {
@@ -404,8 +509,8 @@ export const OntologyDAG = ({
 
   // Notify parent of ontology existence status
   useEffect(() => {
-    onStatusChange?.(dagStatus !== null);
-  }, [dagStatus, onStatusChange]);
+    onStatusChange?.(hasOntology);
+  }, [hasOntology, onStatusChange]);
 
   // Count completed nodes
   const completedNodes = dagStatus?.nodes.filter((n) => n.status === 'completed').length ?? 0;
@@ -570,7 +675,7 @@ export const OntologyDAG = ({
   }
 
   // Error state (when fetch fails completely)
-  if (error && !dagStatus) {
+  if (error && !dagStatus && !hasOntology) {
     return (
       <div className="rounded-lg border border-border-light bg-surface-primary p-8 shadow-sm">
         <div className="text-center">
@@ -586,8 +691,151 @@ export const OntologyDAG = ({
     );
   }
 
+  if (isImportedComplete) {
+    return (
+      <div className="rounded-lg border border-border-light bg-surface-primary shadow-sm">
+        <div className="flex items-center justify-between p-4 border-b border-border-light">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-green-500/10">
+              <Check className="h-5 w-5 text-green-600" />
+            </div>
+            <div>
+              <h3 className="font-semibold text-text-primary">Ontology Import Complete</h3>
+              <p className="text-sm text-text-secondary">
+                Imported ontology bundle is active for this datasource
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setShowDeleteDialog(true)}
+              disabled={isDeleting}
+              className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20"
+            >
+              <Trash2 className="h-4 w-4 mr-2" />
+              Delete Ontology
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => void handleExport()}
+              disabled={isExporting}
+            >
+              {isExporting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Exporting...
+                </>
+              ) : (
+                <>
+                  <Download className="h-4 w-4 mr-2" />
+                  Export Ontology
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+
+        <div className="p-6 space-y-4">
+          <div className="flex items-start gap-3 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-900/20">
+            <Check className="h-5 w-5 flex-shrink-0 text-green-600" />
+            <div>
+              <p className="font-medium text-green-800 dark:text-green-200">
+                Ontology bundle imported successfully
+              </p>
+            </div>
+          </div>
+
+          {ontologyStatus?.last_built_at && (
+            <p className="text-sm text-text-secondary">
+              Imported on {formatTimestamp(ontologyStatus.last_built_at)}.
+            </p>
+          )}
+
+          {ontologyStatus?.schema_changed_since_build && ontologyStatus.change_summary && (
+            <div className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/20">
+              <AlertCircle className="h-5 w-5 flex-shrink-0 text-amber-600" />
+              <p className="text-sm text-amber-800 dark:text-amber-200">
+                Schema changes detected since import: {formatChangeSummary(ontologyStatus.change_summary)}.
+              </p>
+            </div>
+          )}
+        </div>
+
+        <Dialog open={showDeleteDialog} onOpenChange={(open) => {
+          setShowDeleteDialog(open);
+          if (!open) {
+            setDeleteConfirmText('');
+          }
+        }}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Delete Ontology?</DialogTitle>
+              <DialogDescription>
+                This will permanently delete all ontology data, including table metadata, relationships,
+                questions, and chat history. This action cannot be undone.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="py-4 space-y-4">
+              <div className="rounded-lg bg-red-50 border border-red-200 p-4 dark:bg-red-900/20 dark:border-red-800">
+                <div className="flex items-start gap-3">
+                  <AlertCircle className="h-5 w-5 text-red-600 flex-shrink-0 mt-0.5" />
+                  <div className="text-sm text-red-800 dark:text-red-200">
+                    <p className="font-medium mb-1">Warning: This is a destructive action</p>
+                    <p>
+                      All imported ontology knowledge will be permanently deleted. You will need to
+                      import again or run a fresh extraction to restore it.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <label htmlFor="delete-confirm" className="block text-sm font-medium text-text-primary mb-2">
+                  Type <code className="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-800 rounded text-xs font-mono">delete ontology</code> to confirm
+                </label>
+                <Input
+                  id="delete-confirm"
+                  type="text"
+                  value={deleteConfirmText}
+                  onChange={(e) => setDeleteConfirmText(e.target.value)}
+                  placeholder="delete ontology"
+                  className="w-full"
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setShowDeleteDialog(false);
+                  setDeleteConfirmText('');
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={() => void handleDelete()}
+                disabled={deleteConfirmText !== 'delete ontology' || isDeleting}
+                className="bg-red-600 hover:bg-red-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isDeleting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Deleting...
+                  </>
+                ) : (
+                  'Delete Ontology'
+                )}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    );
+  }
+
   // Empty state (no DAG has been run yet)
-  if (!dagStatus) {
+  if (!dagStatus && !hasOntology) {
     const isOverviewValid = projectOverview.length >= 20;
     return (
       <div className="rounded-lg border border-border-light bg-surface-primary p-12 shadow-sm">
@@ -600,6 +848,38 @@ export const OntologyDAG = ({
             Before we analyze your schema, tell us about your application. Who uses it and what do
             they do with this data? This context helps build a more accurate business ontology.
           </p>
+
+          <input
+            ref={importInputRef}
+            type="file"
+            accept=".json,application/json"
+            className="hidden"
+            onChange={(event) => void handleImportInputChange(event)}
+          />
+
+          {(importErrorMessage !== null || importReport !== null) && (
+            <div className="mx-auto mb-6 max-w-3xl rounded-lg border border-amber-200 bg-amber-50 p-4 text-left dark:border-amber-800 dark:bg-amber-900/20">
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex items-start gap-3">
+                  <AlertCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-600" />
+                  <div className="space-y-3">
+                    <div>
+                      <p className="font-medium text-amber-800 dark:text-amber-200">
+                        {importErrorMessage ?? 'Unable to import ontology bundle'}
+                      </p>
+                      <p className="mt-1 text-sm text-amber-700 dark:text-amber-300">
+                        Fix the bundle or target datasource mismatch, then try again.
+                      </p>
+                    </div>
+                    <ImportValidationDetails report={importReport} />
+                  </div>
+                </div>
+                <Button variant="ghost" size="sm" onClick={clearImportFeedback}>
+                  Dismiss
+                </Button>
+              </div>
+            </div>
+          )}
 
           {/* Overview textarea */}
           <div className="max-w-2xl mx-auto mb-6 text-left">
@@ -624,27 +904,51 @@ export const OntologyDAG = ({
             </div>
           </div>
 
-          {/* Button - disabled until 20 chars */}
-          <Button
-            onClick={() => void handleStart()}
-            disabled={isStarting || !isOverviewValid || isLoadingOverview}
-            className="bg-purple-600 hover:bg-purple-700 text-white disabled:opacity-50"
-          >
-            {isStarting ? (
-              <>
-                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                Starting...
-              </>
-            ) : (
-              <>
-                <Brain className="h-4 w-4 mr-2" />
-                Start Extraction
-              </>
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <Button
+              onClick={() => void handleStart()}
+              disabled={isStarting || isImporting || !isOverviewValid || isLoadingOverview}
+              className="bg-purple-600 hover:bg-purple-700 text-white disabled:opacity-50"
+            >
+              {isStarting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Starting...
+                </>
+              ) : (
+                <>
+                  <Brain className="h-4 w-4 mr-2" />
+                  Start Extraction
+                </>
+              )}
+            </Button>
+            {isAdmin && (
+              <Button
+                variant="outline"
+                onClick={openImportPicker}
+                disabled={isImporting || isStarting || isLoadingOverview}
+              >
+                {isImporting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Importing...
+                  </>
+                ) : (
+                  <>
+                    <Upload className="h-4 w-4 mr-2" />
+                    Import Ontology
+                  </>
+                )}
+              </Button>
             )}
-          </Button>
+          </div>
         </div>
       </div>
     );
+  }
+
+  if (!dagStatus) {
+    return null;
   }
 
   // DAG visualization
@@ -938,4 +1242,135 @@ function downloadBlob(blob: Blob, filename: string): void {
   link.click();
   link.remove();
   URL.revokeObjectURL(objectUrl);
+}
+
+function formatTimestamp(value: string): string {
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) {
+    return value;
+  }
+  return timestamp.toLocaleString();
+}
+
+function getImportFailure(error: unknown): {
+  message: string;
+  report: OntologyImportValidationReport | null;
+} {
+  if (typeof error === 'object' && error !== null) {
+    const maybeMessage = 'message' in error ? error.message : undefined;
+    const maybeReport = 'report' in error ? error.report : undefined;
+
+    return {
+      message: typeof maybeMessage === 'string' ? maybeMessage : 'Failed to import ontology bundle',
+      report: isOntologyImportValidationReportValue(maybeReport) ? maybeReport : null,
+    };
+  }
+
+  return {
+    message: error instanceof Error ? error.message : 'Failed to import ontology bundle',
+    report: null,
+  };
+}
+
+function isOntologyImportValidationReportValue(
+  value: unknown
+): value is OntologyImportValidationReport {
+  return typeof value === 'object' && value !== null;
+}
+
+function ImportValidationDetails({
+  report,
+}: {
+  report: OntologyImportValidationReport | null;
+}) {
+  if (!report) {
+    return null;
+  }
+
+  const rows: Array<{ label: string; items: string[] }> = [];
+
+  if (report.database_type_mismatch) {
+    rows.push({
+      label: 'Database type mismatch',
+      items: [
+        `Bundle: ${report.database_type_mismatch.bundle_type}, target: ${report.database_type_mismatch.target_type}`,
+      ],
+    });
+  }
+  if (report.problems?.length) {
+    rows.push({
+      label: 'Problems',
+      items: report.problems.map((problem) => problem.message),
+    });
+  }
+  if (report.missing_required_apps?.length) {
+    rows.push({
+      label: 'Missing required apps',
+      items: report.missing_required_apps,
+    });
+  }
+  if (report.missing_tables?.length) {
+    rows.push({
+      label: 'Missing tables',
+      items: report.missing_tables.map(formatTableRef),
+    });
+  }
+  if (report.unexpected_tables?.length) {
+    rows.push({
+      label: 'Unexpected selected tables',
+      items: report.unexpected_tables.map(formatTableRef),
+    });
+  }
+  if (report.missing_columns?.length) {
+    rows.push({
+      label: 'Missing columns',
+      items: report.missing_columns.map(formatColumnRef),
+    });
+  }
+  if (report.unexpected_columns?.length) {
+    rows.push({
+      label: 'Unexpected selected columns',
+      items: report.unexpected_columns.map(formatColumnRef),
+    });
+  }
+  if (report.unresolved_relationships?.length) {
+    rows.push({
+      label: 'Unresolved relationships',
+      items: report.unresolved_relationships.map(formatRelationshipIssue),
+    });
+  }
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3">
+      {rows.map((row) => (
+        <div key={row.label}>
+          <p className="text-sm font-medium text-amber-900 dark:text-amber-100">{row.label}</p>
+          <ul className="mt-1 list-disc pl-5 text-sm text-amber-800 dark:text-amber-200">
+            {row.items.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function formatTableRef(ref: OntologyImportTableRef): string {
+  if (ref.schema_name) {
+    return `${ref.schema_name}.${ref.table_name}`;
+  }
+  return ref.table_name;
+}
+
+function formatColumnRef(ref: OntologyImportColumnRef): string {
+  return `${formatTableRef(ref.table)}.${ref.column_name}`;
+}
+
+function formatRelationshipIssue(issue: OntologyImportRelationshipIssue): string {
+  return `${formatColumnRef(issue.source)} -> ${formatColumnRef(issue.target)}: ${issue.message}`;
 }

--- a/ui/src/components/ontology/OntologyDAG.tsx
+++ b/ui/src/components/ontology/OntologyDAG.tsx
@@ -10,6 +10,7 @@ import {
   Brain,
   Check,
   Circle,
+  Download,
   Loader2,
   Network,
   RefreshCw,
@@ -44,6 +45,26 @@ interface OntologyDAGProps {
 
 // Polling interval in milliseconds (2 seconds as per plan)
 const POLL_INTERVAL_MS = 2000;
+const DEFAULT_EXPORT_FILENAME = 'ontology-export.json';
+
+interface FilePickerAcceptType {
+  description?: string;
+  accept: Record<string, string[]>;
+}
+
+interface FilePickerWritable {
+  write(data: Blob): Promise<void>;
+  close(): Promise<void>;
+}
+
+interface FilePickerHandle {
+  createWritable(): Promise<FilePickerWritable>;
+}
+
+interface FilePickerOptions {
+  suggestedName?: string;
+  types?: FilePickerAcceptType[];
+}
 
 // Helper to get status icon for a node
 const getNodeStatusIcon = (status: DAGNodeStatus, isCurrentNode: boolean) => {
@@ -127,6 +148,9 @@ export const OntologyDAG = ({
   const [error, setError] = useState<string | null>(null);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [deleteConfirmText, setDeleteConfirmText] = useState('');
+  const [showExportDialog, setShowExportDialog] = useState(false);
+  const [exportFilename, setExportFilename] = useState(DEFAULT_EXPORT_FILENAME);
+  const [isExporting, setIsExporting] = useState(false);
   const [projectOverview, setProjectOverview] = useState('');
   const [isLoadingOverview, setIsLoadingOverview] = useState(true);
 
@@ -285,6 +309,44 @@ export const OntologyDAG = ({
       }
     }
   }, [projectId, datasourceId, stopPolling, onError]);
+
+  const handleExport = useCallback(async () => {
+    const normalizedFilename = normalizeExportFilename(exportFilename);
+
+    try {
+      setIsExporting(true);
+      setError(null);
+
+      const fileHandle = await pickSaveLocation(normalizedFilename);
+      const blob = await engineApi.exportOntologyBundle(projectId, datasourceId);
+
+      if (fileHandle) {
+        const writable = await fileHandle.createWritable();
+        await writable.write(blob);
+        await writable.close();
+      } else {
+        downloadBlob(blob, normalizedFilename);
+      }
+
+      if (!isMountedRef.current) return;
+
+      setShowExportDialog(false);
+      setExportFilename(normalizedFilename);
+    } catch (err) {
+      if (!isMountedRef.current) return;
+      if (isAbortError(err)) {
+        return;
+      }
+      const errorMessage = err instanceof Error ? err.message : 'Failed to export ontology bundle';
+      console.error('Failed to export ontology bundle:', err);
+      setError(errorMessage);
+      onError?.(errorMessage);
+    } finally {
+      if (isMountedRef.current) {
+        setIsExporting(false);
+      }
+    }
+  }, [datasourceId, exportFilename, onError, projectId]);
 
   // Initial load
   useEffect(() => {
@@ -647,6 +709,25 @@ export const OntologyDAG = ({
               Delete Ontology
             </Button>
           )}
+          {isComplete && (
+            <Button
+              variant="outline"
+              onClick={() => setShowExportDialog(true)}
+              disabled={isExporting}
+            >
+              {isExporting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Exporting...
+                </>
+              ) : (
+                <>
+                  <Download className="h-4 w-4 mr-2" />
+                  Export Ontology
+                </>
+              )}
+            </Button>
+          )}
           {isComplete && ontologyStatus?.schema_changed_since_build && (
             <Button
               onClick={() => void handleStart()}
@@ -871,8 +952,122 @@ export const OntologyDAG = ({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <Dialog open={showExportDialog} onOpenChange={(open) => {
+        setShowExportDialog(open);
+        if (!open && !isExporting) {
+          setExportFilename(DEFAULT_EXPORT_FILENAME);
+        }
+      }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Export Ontology Bundle</DialogTitle>
+            <DialogDescription>
+              Save a portable JSON bundle for project seeding. Datasource credentials, AI
+              credentials, and agent API keys are excluded.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="py-4 space-y-4">
+            <div>
+              <label htmlFor="export-filename" className="block text-sm font-medium text-text-primary mb-2">
+                Filename
+              </label>
+              <Input
+                id="export-filename"
+                type="text"
+                value={exportFilename}
+                onChange={(e) => setExportFilename(e.target.value)}
+                placeholder={DEFAULT_EXPORT_FILENAME}
+                className="w-full"
+              />
+            </div>
+            <div className="rounded-lg bg-amber-50 border border-amber-200 p-4 dark:bg-amber-900/20 dark:border-amber-800">
+              <div className="flex items-start gap-3">
+                <AlertCircle className="h-5 w-5 text-amber-600 flex-shrink-0 mt-0.5" />
+                <div className="text-sm text-amber-800 dark:text-amber-200">
+                  <p className="font-medium mb-1">Credentials are not exported</p>
+                  <p>
+                    Re-importing this bundle later will still require datasource binding and fresh
+                    agent credentials.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setShowExportDialog(false);
+                setExportFilename(DEFAULT_EXPORT_FILENAME);
+              }}
+              disabled={isExporting}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => void handleExport()}
+              disabled={isExporting || normalizeExportFilename(exportFilename).length === 0}
+              className="bg-purple-600 hover:bg-purple-700 text-white disabled:opacity-50"
+            >
+              {isExporting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Exporting...
+                </>
+              ) : (
+                'Save Bundle'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };
 
 export default OntologyDAG;
+
+function normalizeExportFilename(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed.toLowerCase().endsWith('.json') ? trimmed : `${trimmed}.json`;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+async function pickSaveLocation(suggestedName: string): Promise<FilePickerHandle | null> {
+  const savePicker = (
+    window as Window & typeof globalThis & { showSaveFilePicker?: (options: FilePickerOptions) => Promise<FilePickerHandle> }
+  ).showSaveFilePicker;
+
+  if (!savePicker) {
+    return null;
+  }
+
+  return savePicker({
+    suggestedName,
+    types: [
+      {
+        description: 'JSON files',
+        accept: { 'application/json': ['.json'] },
+      },
+    ],
+  });
+}
+
+function downloadBlob(blob: Blob, filename: string): void {
+  const objectUrl = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = objectUrl;
+  link.download = filename;
+  link.style.display = 'none';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(objectUrl);
+}

--- a/ui/src/components/ontology/OntologyDAG.tsx
+++ b/ui/src/components/ontology/OntologyDAG.tsx
@@ -47,25 +47,6 @@ interface OntologyDAGProps {
 const POLL_INTERVAL_MS = 2000;
 const DEFAULT_EXPORT_FILENAME = 'ontology-export.json';
 
-interface FilePickerAcceptType {
-  description?: string;
-  accept: Record<string, string[]>;
-}
-
-interface FilePickerWritable {
-  write(data: Blob): Promise<void>;
-  close(): Promise<void>;
-}
-
-interface FilePickerHandle {
-  createWritable(): Promise<FilePickerWritable>;
-}
-
-interface FilePickerOptions {
-  suggestedName?: string;
-  types?: FilePickerAcceptType[];
-}
-
 // Helper to get status icon for a node
 const getNodeStatusIcon = (status: DAGNodeStatus, isCurrentNode: boolean) => {
   switch (status) {
@@ -148,8 +129,6 @@ export const OntologyDAG = ({
   const [error, setError] = useState<string | null>(null);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [deleteConfirmText, setDeleteConfirmText] = useState('');
-  const [showExportDialog, setShowExportDialog] = useState(false);
-  const [exportFilename, setExportFilename] = useState(DEFAULT_EXPORT_FILENAME);
   const [isExporting, setIsExporting] = useState(false);
   const [projectOverview, setProjectOverview] = useState('');
   const [isLoadingOverview, setIsLoadingOverview] = useState(true);
@@ -311,27 +290,14 @@ export const OntologyDAG = ({
   }, [projectId, datasourceId, stopPolling, onError]);
 
   const handleExport = useCallback(async () => {
-    const normalizedFilename = normalizeExportFilename(exportFilename);
-
     try {
       setIsExporting(true);
       setError(null);
 
-      const fileHandle = await pickSaveLocation(normalizedFilename);
       const blob = await engineApi.exportOntologyBundle(projectId, datasourceId);
-
-      if (fileHandle) {
-        const writable = await fileHandle.createWritable();
-        await writable.write(blob);
-        await writable.close();
-      } else {
-        downloadBlob(blob, normalizedFilename);
-      }
+      downloadBlob(blob, DEFAULT_EXPORT_FILENAME);
 
       if (!isMountedRef.current) return;
-
-      setShowExportDialog(false);
-      setExportFilename(normalizedFilename);
     } catch (err) {
       if (!isMountedRef.current) return;
       if (isAbortError(err)) {
@@ -346,7 +312,7 @@ export const OntologyDAG = ({
         setIsExporting(false);
       }
     }
-  }, [datasourceId, exportFilename, onError, projectId]);
+  }, [datasourceId, onError, projectId]);
 
   // Initial load
   useEffect(() => {
@@ -712,7 +678,7 @@ export const OntologyDAG = ({
           {isComplete && (
             <Button
               variant="outline"
-              onClick={() => setShowExportDialog(true)}
+              onClick={() => void handleExport()}
               disabled={isExporting}
             >
               {isExporting ? (
@@ -952,112 +918,14 @@ export const OntologyDAG = ({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-
-      <Dialog open={showExportDialog} onOpenChange={(open) => {
-        setShowExportDialog(open);
-        if (!open && !isExporting) {
-          setExportFilename(DEFAULT_EXPORT_FILENAME);
-        }
-      }}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Export Ontology Bundle</DialogTitle>
-            <DialogDescription>
-              Save a portable JSON bundle for project seeding. Datasource credentials, AI
-              credentials, and agent API keys are excluded.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="py-4 space-y-4">
-            <div>
-              <label htmlFor="export-filename" className="block text-sm font-medium text-text-primary mb-2">
-                Filename
-              </label>
-              <Input
-                id="export-filename"
-                type="text"
-                value={exportFilename}
-                onChange={(e) => setExportFilename(e.target.value)}
-                placeholder={DEFAULT_EXPORT_FILENAME}
-                className="w-full"
-              />
-            </div>
-            <div className="rounded-lg bg-amber-50 border border-amber-200 p-4 dark:bg-amber-900/20 dark:border-amber-800">
-              <div className="flex items-start gap-3">
-                <AlertCircle className="h-5 w-5 text-amber-600 flex-shrink-0 mt-0.5" />
-                <div className="text-sm text-amber-800 dark:text-amber-200">
-                  <p className="font-medium mb-1">Credentials are not exported</p>
-                  <p>
-                    Re-importing this bundle later will still require datasource binding and fresh
-                    agent credentials.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => {
-                setShowExportDialog(false);
-                setExportFilename(DEFAULT_EXPORT_FILENAME);
-              }}
-              disabled={isExporting}
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={() => void handleExport()}
-              disabled={isExporting || normalizeExportFilename(exportFilename).length === 0}
-              className="bg-purple-600 hover:bg-purple-700 text-white disabled:opacity-50"
-            >
-              {isExporting ? (
-                <>
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  Exporting...
-                </>
-              ) : (
-                'Save Bundle'
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   );
 };
 
 export default OntologyDAG;
 
-function normalizeExportFilename(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return '';
-  }
-  return trimmed.toLowerCase().endsWith('.json') ? trimmed : `${trimmed}.json`;
-}
-
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === 'AbortError';
-}
-
-async function pickSaveLocation(suggestedName: string): Promise<FilePickerHandle | null> {
-  const savePicker = (
-    window as Window & typeof globalThis & { showSaveFilePicker?: (options: FilePickerOptions) => Promise<FilePickerHandle> }
-  ).showSaveFilePicker;
-
-  if (!savePicker) {
-    return null;
-  }
-
-  return savePicker({
-    suggestedName,
-    types: [
-      {
-        description: 'JSON files',
-        accept: { 'application/json': ['.json'] },
-      },
-    ],
-  });
 }
 
 function downloadBlob(blob: Blob, filename: string): void {

--- a/ui/src/components/ontology/__tests__/OntologyDAG.test.tsx
+++ b/ui/src/components/ontology/__tests__/OntologyDAG.test.tsx
@@ -498,7 +498,6 @@ describe('OntologyDAG - Export Ontology', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    Object.assign(window, { showSaveFilePicker: undefined });
     vi.mocked(engineApi.getProjectOverview).mockResolvedValue({
       success: true,
       data: { overview: null },
@@ -531,49 +530,7 @@ describe('OntologyDAG - Export Ontology', () => {
     });
   });
 
-  it('downloads the bundle with showSaveFilePicker when available', async () => {
-    const write = vi.fn().mockResolvedValue(undefined);
-    const close = vi.fn().mockResolvedValue(undefined);
-    const createWritable = vi.fn().mockResolvedValue({ write, close });
-    const showSaveFilePicker = vi.fn().mockResolvedValue({ createWritable });
-    const blob = new Blob(['{"format":"ekaya-ontology-export"}'], { type: 'application/json' });
-
-    vi.mocked(engineApi.getOntologyDAGStatus).mockResolvedValue({
-      success: true,
-      data: mockCompletedDAG,
-    });
-    vi.mocked(engineApi.exportOntologyBundle).mockResolvedValue(blob);
-    Object.assign(window, { showSaveFilePicker });
-
-    const user = userEvent.setup();
-    render(<OntologyDAG {...mockProps} />);
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /export ontology/i })).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByRole('button', { name: /export ontology/i }));
-
-    await waitFor(() => {
-      expect(screen.getByTestId('dialog-title')).toHaveTextContent('Export Ontology Bundle');
-    });
-
-    const filenameInput = screen.getByTestId('export-filename-input');
-    await user.clear(filenameInput);
-    await user.type(filenameInput, 'the-look-bundle');
-    await user.click(screen.getByRole('button', { name: /save bundle/i }));
-
-    await waitFor(() => {
-      expect(showSaveFilePicker).toHaveBeenCalledWith(expect.objectContaining({
-        suggestedName: 'the-look-bundle.json',
-      }));
-      expect(engineApi.exportOntologyBundle).toHaveBeenCalledWith('proj-1', 'ds-1');
-      expect(write).toHaveBeenCalledWith(blob);
-      expect(close).toHaveBeenCalled();
-    });
-  });
-
-  it('falls back to browser download when File System Access API is unavailable', async () => {
+  it('downloads the bundle directly from the export button', async () => {
     const blob = new Blob(['{"format":"ekaya-ontology-export"}'], { type: 'application/json' });
     const originalCreateElement = document.createElement.bind(document);
     const link = originalCreateElement('a');
@@ -594,7 +551,6 @@ describe('OntologyDAG - Export Ontology', () => {
       data: mockCompletedDAG,
     });
     vi.mocked(engineApi.exportOntologyBundle).mockResolvedValue(blob);
-    Object.assign(window, { showSaveFilePicker: undefined });
 
     const user = userEvent.setup();
     render(<OntologyDAG {...mockProps} />);
@@ -604,7 +560,55 @@ describe('OntologyDAG - Export Ontology', () => {
     });
 
     await user.click(screen.getByRole('button', { name: /export ontology/i }));
-    await user.click(screen.getByRole('button', { name: /save bundle/i }));
+
+    await waitFor(() => {
+      expect(engineApi.exportOntologyBundle).toHaveBeenCalledWith('proj-1', 'ds-1');
+      expect(createObjectURL).toHaveBeenCalledWith(blob);
+      expect(click).toHaveBeenCalled();
+      expect(remove).toHaveBeenCalled();
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:export');
+      expect(appendChild).toHaveBeenCalled();
+    });
+
+    createObjectURL.mockRestore();
+    revokeObjectURL.mockRestore();
+    appendChild.mockRestore();
+    createElement.mockRestore();
+    click.mockRestore();
+    remove.mockRestore();
+  });
+
+  it('downloads directly even if File System Access API exists', async () => {
+    const blob = new Blob(['{"format":"ekaya-ontology-export"}'], { type: 'application/json' });
+    const originalCreateElement = document.createElement.bind(document);
+    const link = originalCreateElement('a');
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:export');
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    const click = vi.spyOn(link, 'click').mockImplementation(() => {});
+    const remove = vi.spyOn(link, 'remove').mockImplementation(() => {});
+    const appendChild = vi.spyOn(document.body, 'appendChild');
+    const createElement = vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName.toLowerCase() === 'a') {
+        return link;
+      }
+      return originalCreateElement(tagName);
+    });
+
+    vi.mocked(engineApi.getOntologyDAGStatus).mockResolvedValue({
+      success: true,
+      data: mockCompletedDAG,
+    });
+    vi.mocked(engineApi.exportOntologyBundle).mockResolvedValue(blob);
+    Object.assign(window, { showSaveFilePicker: vi.fn() });
+
+    const user = userEvent.setup();
+    render(<OntologyDAG {...mockProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /export ontology/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /export ontology/i }));
 
     await waitFor(() => {
       expect(engineApi.exportOntologyBundle).toHaveBeenCalledWith('proj-1', 'ds-1');

--- a/ui/src/components/ontology/__tests__/OntologyDAG.test.tsx
+++ b/ui/src/components/ontology/__tests__/OntologyDAG.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import * as authToken from '../../../lib/auth-token';
 import engineApi from '../../../services/engineApi';
 import type { DAGStatusResponse } from '../../../types';
 import { OntologyDAG } from '../OntologyDAG';
@@ -16,7 +17,12 @@ vi.mock('../../../services/engineApi', () => ({
     cancelOntologyDAG: vi.fn(),
     deleteOntology: vi.fn(),
     exportOntologyBundle: vi.fn(),
+    importOntologyBundle: vi.fn(),
   },
+}));
+
+vi.mock('../../../lib/auth-token', () => ({
+  getUserRoles: vi.fn(() => []),
 }));
 
 // Mock the Dialog components to render without portal
@@ -103,6 +109,7 @@ describe('OntologyDAG - Retry Failed Extraction', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(authToken.getUserRoles).mockReturnValue([]);
     vi.mocked(engineApi.getProjectOverview).mockResolvedValue({
       success: true,
       data: { overview: null },
@@ -184,6 +191,7 @@ describe('OntologyDAG - Delete Ontology Functionality', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(authToken.getUserRoles).mockReturnValue([]);
     // Default mock for getProjectOverview - returns no overview
     vi.mocked(engineApi.getProjectOverview).mockResolvedValue({
       success: true,
@@ -436,6 +444,11 @@ describe('OntologyDAG - Delete Ontology Functionality', () => {
   });
 
   it('calls onStatusChange with true when DAG exists', async () => {
+    vi.mocked(engineApi.getOntologyStatus).mockResolvedValueOnce({
+      success: true,
+      data: { has_ontology: true, schema_changed_since_build: false, completion_provenance: 'extracted' },
+    });
+
     const onStatusChange = vi.fn();
     render(<OntologyDAG {...mockProps} onStatusChange={onStatusChange} />);
 
@@ -445,6 +458,10 @@ describe('OntologyDAG - Delete Ontology Functionality', () => {
   });
 
   it('calls onStatusChange when DAG is deleted', async () => {
+    vi.mocked(engineApi.getOntologyStatus).mockResolvedValueOnce({
+      success: true,
+      data: { has_ontology: true, schema_changed_since_build: false, completion_provenance: 'extracted' },
+    });
     vi.mocked(engineApi.deleteOntology).mockResolvedValueOnce({
       data: { message: 'Deleted' },
       success: true,
@@ -488,6 +505,157 @@ describe('OntologyDAG - Delete Ontology Functionality', () => {
   });
 });
 
+describe('OntologyDAG - Import Ontology', () => {
+  const mockProps = {
+    projectId: 'proj-1',
+    datasourceId: 'ds-1',
+    onComplete: vi.fn(),
+    onError: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authToken.getUserRoles).mockReturnValue(['admin']);
+    vi.mocked(engineApi.getProjectOverview).mockResolvedValue({
+      success: true,
+      data: { overview: null },
+    });
+    vi.mocked(engineApi.getOntologyDAGStatus).mockResolvedValue({
+      success: true,
+      data: null,
+    });
+    vi.mocked(engineApi.getOntologyStatus).mockResolvedValue({
+      success: true,
+      data: { has_ontology: false, schema_changed_since_build: false },
+    });
+  });
+
+  it('shows Import Ontology on the ready-to-extract empty state for admins', async () => {
+    render(<OntologyDAG {...mockProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Ready to Extract Ontology')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: /import ontology/i })).toBeInTheDocument();
+  });
+
+  it('does not show Import Ontology for non-admin users', async () => {
+    vi.mocked(authToken.getUserRoles).mockReturnValue(['user']);
+
+    render(<OntologyDAG {...mockProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Ready to Extract Ontology')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('button', { name: /import ontology/i })).not.toBeInTheDocument();
+  });
+
+  it('imports a bundle and switches to the import-complete state', async () => {
+    vi.mocked(engineApi.importOntologyBundle).mockResolvedValue({
+      success: true,
+      data: {
+        imported_at: '2026-03-24T10:00:00Z',
+        completion_provenance: 'imported',
+      },
+    });
+
+    const onStatusChange = vi.fn();
+    const user = userEvent.setup();
+    render(<OntologyDAG {...mockProps} onStatusChange={onStatusChange} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /import ontology/i })).toBeInTheDocument();
+    });
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['{"format":"ekaya-ontology-export"}'], 'bundle.json', {
+      type: 'application/json',
+    });
+
+    await user.upload(fileInput, file);
+
+    await waitFor(() => {
+      expect(engineApi.importOntologyBundle).toHaveBeenCalledWith('proj-1', 'ds-1', file);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Ontology Import Complete')).toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          'This datasource is using imported ontology state instead of an extracted DAG.',
+        ),
+      ).not.toBeInTheDocument();
+      expect(onStatusChange).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it('shows a client-side size error and skips the API call for oversized bundles', async () => {
+    const user = userEvent.setup();
+    render(<OntologyDAG {...mockProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /import ontology/i })).toBeInTheDocument();
+    });
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['{}'], 'bundle.json', { type: 'application/json' });
+    Object.defineProperty(file, 'size', { value: 5 * 1024 * 1024 + 1 });
+
+    await user.upload(fileInput, file);
+
+    await waitFor(() => {
+      expect(screen.getByText('Ontology bundle exceeds the 5 MB maximum size')).toBeInTheDocument();
+    });
+    expect(engineApi.importOntologyBundle).not.toHaveBeenCalled();
+  });
+
+  it('renders a structured validation report and dismisses it', async () => {
+    vi.mocked(engineApi.importOntologyBundle).mockRejectedValue({
+      message: 'Ontology bundle does not match the selected datasource schema',
+      report: {
+        missing_required_apps: ['ai_data_liaison'],
+        missing_tables: [{ schema_name: 'public', table_name: 'orders' }],
+        missing_columns: [
+          {
+            table: { schema_name: 'public', table_name: 'orders' },
+            column_name: 'status',
+          },
+        ],
+      },
+    });
+
+    const user = userEvent.setup();
+    render(<OntologyDAG {...mockProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /import ontology/i })).toBeInTheDocument();
+    });
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['{"format":"ekaya-ontology-export"}'], 'bundle.json', {
+      type: 'application/json',
+    });
+
+    await user.upload(fileInput, file);
+
+    await waitFor(() => {
+      expect(screen.getByText('Ontology bundle does not match the selected datasource schema')).toBeInTheDocument();
+      expect(screen.getByText('Missing required apps')).toBeInTheDocument();
+      expect(screen.getByText('ai_data_liaison')).toBeInTheDocument();
+      expect(screen.getByText('public.orders')).toBeInTheDocument();
+      expect(screen.getByText('public.orders.status')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /dismiss/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Missing required apps')).not.toBeInTheDocument();
+    });
+  });
+});
+
 describe('OntologyDAG - Export Ontology', () => {
   const mockProps = {
     projectId: 'proj-1',
@@ -498,6 +666,7 @@ describe('OntologyDAG - Export Ontology', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(authToken.getUserRoles).mockReturnValue([]);
     vi.mocked(engineApi.getProjectOverview).mockResolvedValue({
       success: true,
       data: { overview: null },

--- a/ui/src/components/ontology/__tests__/OntologyDAG.test.tsx
+++ b/ui/src/components/ontology/__tests__/OntologyDAG.test.tsx
@@ -15,6 +15,7 @@ vi.mock('../../../services/engineApi', () => ({
     startOntologyExtraction: vi.fn(),
     cancelOntologyDAG: vi.fn(),
     deleteOntology: vi.fn(),
+    exportOntologyBundle: vi.fn(),
   },
 }));
 
@@ -46,7 +47,7 @@ vi.mock('../../ui/Input', () => ({
   }) => (
     <input
       id={id}
-      data-testid="delete-confirm-input"
+      data-testid={id ? `${id}-input` : 'input'}
       type={type ?? 'text'}
       value={value}
       onChange={onChange}
@@ -484,5 +485,141 @@ describe('OntologyDAG - Delete Ontology Functionality', () => {
     await waitFor(() => {
       expect(onStatusChange).toHaveBeenCalledWith(false);
     });
+  });
+});
+
+describe('OntologyDAG - Export Ontology', () => {
+  const mockProps = {
+    projectId: 'proj-1',
+    datasourceId: 'ds-1',
+    onComplete: vi.fn(),
+    onError: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(window, { showSaveFilePicker: undefined });
+    vi.mocked(engineApi.getProjectOverview).mockResolvedValue({
+      success: true,
+      data: { overview: null },
+    });
+  });
+
+  it('shows Export Ontology only when the DAG is complete', async () => {
+    vi.mocked(engineApi.getOntologyDAGStatus).mockResolvedValue({
+      success: true,
+      data: mockCompletedDAG,
+    });
+
+    render(<OntologyDAG {...mockProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /export ontology/i })).toBeInTheDocument();
+    });
+  });
+
+  it('does not show Export Ontology when the DAG is not complete', async () => {
+    vi.mocked(engineApi.getOntologyDAGStatus).mockResolvedValue({
+      success: true,
+      data: mockFailedDAG,
+    });
+
+    render(<OntologyDAG {...mockProps} />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /export ontology/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('downloads the bundle with showSaveFilePicker when available', async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const close = vi.fn().mockResolvedValue(undefined);
+    const createWritable = vi.fn().mockResolvedValue({ write, close });
+    const showSaveFilePicker = vi.fn().mockResolvedValue({ createWritable });
+    const blob = new Blob(['{"format":"ekaya-ontology-export"}'], { type: 'application/json' });
+
+    vi.mocked(engineApi.getOntologyDAGStatus).mockResolvedValue({
+      success: true,
+      data: mockCompletedDAG,
+    });
+    vi.mocked(engineApi.exportOntologyBundle).mockResolvedValue(blob);
+    Object.assign(window, { showSaveFilePicker });
+
+    const user = userEvent.setup();
+    render(<OntologyDAG {...mockProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /export ontology/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /export ontology/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dialog-title')).toHaveTextContent('Export Ontology Bundle');
+    });
+
+    const filenameInput = screen.getByTestId('export-filename-input');
+    await user.clear(filenameInput);
+    await user.type(filenameInput, 'the-look-bundle');
+    await user.click(screen.getByRole('button', { name: /save bundle/i }));
+
+    await waitFor(() => {
+      expect(showSaveFilePicker).toHaveBeenCalledWith(expect.objectContaining({
+        suggestedName: 'the-look-bundle.json',
+      }));
+      expect(engineApi.exportOntologyBundle).toHaveBeenCalledWith('proj-1', 'ds-1');
+      expect(write).toHaveBeenCalledWith(blob);
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
+  it('falls back to browser download when File System Access API is unavailable', async () => {
+    const blob = new Blob(['{"format":"ekaya-ontology-export"}'], { type: 'application/json' });
+    const originalCreateElement = document.createElement.bind(document);
+    const link = originalCreateElement('a');
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:export');
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    const click = vi.spyOn(link, 'click').mockImplementation(() => {});
+    const remove = vi.spyOn(link, 'remove').mockImplementation(() => {});
+    const appendChild = vi.spyOn(document.body, 'appendChild');
+    const createElement = vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName.toLowerCase() === 'a') {
+        return link;
+      }
+      return originalCreateElement(tagName);
+    });
+
+    vi.mocked(engineApi.getOntologyDAGStatus).mockResolvedValue({
+      success: true,
+      data: mockCompletedDAG,
+    });
+    vi.mocked(engineApi.exportOntologyBundle).mockResolvedValue(blob);
+    Object.assign(window, { showSaveFilePicker: undefined });
+
+    const user = userEvent.setup();
+    render(<OntologyDAG {...mockProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /export ontology/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /export ontology/i }));
+    await user.click(screen.getByRole('button', { name: /save bundle/i }));
+
+    await waitFor(() => {
+      expect(engineApi.exportOntologyBundle).toHaveBeenCalledWith('proj-1', 'ds-1');
+      expect(createObjectURL).toHaveBeenCalledWith(blob);
+      expect(click).toHaveBeenCalled();
+      expect(remove).toHaveBeenCalled();
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:export');
+      expect(appendChild).toHaveBeenCalled();
+    });
+
+    createObjectURL.mockRestore();
+    revokeObjectURL.mockRestore();
+    appendChild.mockRestore();
+    createElement.mockRestore();
+    click.mockRestore();
+    remove.mockRestore();
   });
 });

--- a/ui/src/services/__tests__/engineApi.methods.test.ts
+++ b/ui/src/services/__tests__/engineApi.methods.test.ts
@@ -7,6 +7,7 @@ vi.mock('../../lib/api', () => ({
 
 import { fetchWithAuth } from '../../lib/api';
 import engineApi from '../engineApi';
+import type { OntologyImportError } from '../engineApi';
 
 const mockFetchWithAuth = vi.mocked(fetchWithAuth);
 
@@ -1264,6 +1265,65 @@ describe('engineApi ontology change methods', () => {
         expect.objectContaining({ method: 'DELETE' })
       );
       expect(result).toEqual(responseData);
+    });
+  });
+
+  describe('importOntologyBundle', () => {
+    it('uploads multipart form data to the import endpoint', async () => {
+      const responseData = {
+        success: true,
+        data: {
+          imported_at: '2026-03-24T10:00:00Z',
+          completion_provenance: 'imported',
+        },
+      };
+      mockJsonResponse(responseData);
+
+      const file = new File(['{"format":"ekaya-ontology-export"}'], 'bundle.json', {
+        type: 'application/json',
+      });
+
+      const result = await engineApi.importOntologyBundle('proj-1', 'ds-1', file);
+
+      expect(mockFetchWithAuth).toHaveBeenCalledWith(
+        '/api/projects/proj-1/datasources/ds-1/ontology/import',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.any(FormData),
+        })
+      );
+      const callArgs = mockFetchWithAuth.mock.calls[0]?.[1] as RequestInit;
+      expect(callArgs.headers).toBeUndefined();
+      expect(result).toEqual(responseData);
+    });
+
+    it('throws OntologyImportError with validation report on failure', async () => {
+      mockFetchWithAuth.mockResolvedValue({
+        status: 400,
+        ok: false,
+        statusText: 'Bad Request',
+        json: () => Promise.resolve({
+          success: false,
+          error: 'schema_validation_failed',
+          message: 'Ontology bundle does not match the selected datasource schema',
+          data: {
+            missing_tables: [{ schema_name: 'public', table_name: 'orders' }],
+          },
+        }),
+      } as unknown as Response);
+
+      const file = new File(['{"format":"ekaya-ontology-export"}'], 'bundle.json', {
+        type: 'application/json',
+      });
+
+      await expect(engineApi.importOntologyBundle('proj-1', 'ds-1', file)).rejects.toMatchObject({
+        name: 'OntologyImportError',
+        message: 'Ontology bundle does not match the selected datasource schema',
+        code: 'schema_validation_failed',
+        report: {
+          missing_tables: [{ schema_name: 'public', table_name: 'orders' }],
+        },
+      } satisfies Partial<OntologyImportError>);
     });
   });
 

--- a/ui/src/services/__tests__/engineApi.methods.test.ts
+++ b/ui/src/services/__tests__/engineApi.methods.test.ts
@@ -28,6 +28,16 @@ function mock204Response() {
   } as unknown as Response);
 }
 
+function mockBlobResponse(blob: Blob, status = 200) {
+  mockFetchWithAuth.mockResolvedValue({
+    status,
+    ok: status >= 200 && status < 300,
+    statusText: 'OK',
+    blob: () => Promise.resolve(blob),
+    json: () => Promise.resolve({}),
+  } as unknown as Response);
+}
+
 describe('engineApi datasource methods', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -1395,6 +1405,23 @@ describe('engineApi MCP config methods', () => {
         })
       );
       expect(result).toEqual(responseData);
+    });
+  });
+
+  describe('exportOntologyBundle', () => {
+    it('sends GET to /ontology/export and returns the response blob', async () => {
+      const blob = new Blob(['{"format":"ekaya-ontology-export"}'], { type: 'application/json' });
+      mockBlobResponse(blob);
+
+      const result = await engineApi.exportOntologyBundle('proj-1', 'ds-1');
+
+      expect(mockFetchWithAuth).toHaveBeenCalledWith(
+        '/api/projects/proj-1/datasources/ds-1/ontology/export',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Accept: 'application/json' }),
+        })
+      );
+      expect(result).toBe(blob);
     });
   });
 });

--- a/ui/src/services/engineApi.ts
+++ b/ui/src/services/engineApi.ts
@@ -1223,6 +1223,35 @@ class EngineApiService {
   }
 
   /**
+   * Download ontology export bundle as raw JSON.
+   * GET /api/projects/{projectId}/datasources/{datasourceId}/ontology/export
+   */
+  async exportOntologyBundle(
+    projectId: string,
+    datasourceId: string
+  ): Promise<Blob> {
+    const url = `${this.baseURL}/${projectId}/datasources/${datasourceId}/ontology/export`;
+    const response = await fetchWithAuth(url, {
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      let message = `HTTP ${response.status}: ${response.statusText}`;
+      try {
+        const data = await response.json() as ApiResponse<unknown>;
+        message = data.message ?? data.error ?? message;
+      } catch {
+        // Keep the default HTTP message when the error body is not JSON.
+      }
+      throw new Error(message);
+    }
+
+    return response.blob();
+  }
+
+  /**
    * Cancel a running ontology DAG
    * POST /api/projects/{projectId}/datasources/{datasourceId}/ontology/dag/cancel
    */

--- a/ui/src/services/engineApi.ts
+++ b/ui/src/services/engineApi.ts
@@ -46,6 +46,8 @@ import type {
   MCPAuditEvent,
   MCPConfigResponse,
   OntologyChange,
+  OntologyImportResult,
+  OntologyImportValidationReport,
   OntologyStatusResponse,
   PaginatedResponse,
   ParseProjectKnowledgeResponse,
@@ -76,6 +78,21 @@ import type {
 } from '../types';
 
 const ENGINE_BASE_URL = '/api/projects';
+
+export class OntologyImportError extends Error {
+  code: string | undefined;
+  report: OntologyImportValidationReport | undefined;
+
+  constructor(
+    message: string,
+    options?: { code?: string; report?: OntologyImportValidationReport }
+  ) {
+    super(message);
+    this.name = 'OntologyImportError';
+    this.code = options?.code;
+    this.report = options?.report;
+  }
+}
 
 class EngineApiService {
   private baseURL: string;
@@ -1252,6 +1269,41 @@ class EngineApiService {
   }
 
   /**
+   * Upload ontology import bundle as multipart/form-data.
+   * POST /api/projects/{projectId}/datasources/{datasourceId}/ontology/import
+   */
+  async importOntologyBundle(
+    projectId: string,
+    datasourceId: string,
+    file: File
+  ): Promise<ApiResponse<OntologyImportResult>> {
+    const url = `${this.baseURL}/${projectId}/datasources/${datasourceId}/ontology/import`;
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const response = await fetchWithAuth(url, {
+      method: 'POST',
+      body: formData,
+    });
+
+    const data = (await response.json()) as ApiResponse<
+      OntologyImportResult | OntologyImportValidationReport
+    >;
+
+    if (!response.ok) {
+      throw new OntologyImportError(
+        data.message ?? data.error ?? `HTTP ${response.status}: ${response.statusText}`,
+        {
+          ...(data.error ? { code: data.error } : {}),
+          ...(isOntologyImportValidationReport(data.data) ? { report: data.data } : {}),
+        }
+      );
+    }
+
+    return data as ApiResponse<OntologyImportResult>;
+  }
+
+  /**
    * Cancel a running ontology DAG
    * POST /api/projects/{projectId}/datasources/{datasourceId}/ontology/dag/cancel
    */
@@ -1539,3 +1591,9 @@ class EngineApiService {
 // Create and export singleton instance
 const engineApi = new EngineApiService();
 export default engineApi;
+
+function isOntologyImportValidationReport(
+  value: unknown
+): value is OntologyImportValidationReport {
+  return typeof value === 'object' && value !== null;
+}

--- a/ui/src/types/ontology.ts
+++ b/ui/src/types/ontology.ts
@@ -556,8 +556,53 @@ export interface DAGStatusResponse {
 export interface OntologyStatusResponse {
   has_ontology: boolean;
   last_built_at?: string;
+  completion_provenance?: OntologyCompletionProvenance;
   schema_changed_since_build: boolean;
   change_summary?: ChangeSummary;
+}
+
+export type OntologyCompletionProvenance = 'extracted' | 'imported';
+
+export interface OntologyImportResult {
+  imported_at: string;
+  completion_provenance: OntologyCompletionProvenance;
+}
+
+export interface OntologyImportProblem {
+  code: string;
+  message: string;
+}
+
+export interface OntologyImportTableRef {
+  schema_name?: string;
+  table_name: string;
+}
+
+export interface OntologyImportColumnRef {
+  table: OntologyImportTableRef;
+  column_name: string;
+}
+
+export interface OntologyImportDatabaseTypeMismatch {
+  bundle_type: string;
+  target_type: string;
+}
+
+export interface OntologyImportRelationshipIssue {
+  source: OntologyImportColumnRef;
+  target: OntologyImportColumnRef;
+  message: string;
+}
+
+export interface OntologyImportValidationReport {
+  problems?: OntologyImportProblem[];
+  database_type_mismatch?: OntologyImportDatabaseTypeMismatch;
+  missing_tables?: OntologyImportTableRef[];
+  unexpected_tables?: OntologyImportTableRef[];
+  missing_columns?: OntologyImportColumnRef[];
+  unexpected_columns?: OntologyImportColumnRef[];
+  unresolved_relationships?: OntologyImportRelationshipIssue[];
+  missing_required_apps?: string[];
 }
 
 // ===================================================================


### PR DESCRIPTION
## Summary
- add ontology export bundle generation and browser download support
- add ontology bundle import service, handler, and admin UI import flow on the ontology page
- track ontology completion provenance per datasource and fix imported-state schema-change false positives
- keep the v1 bundle credential-free and remove agent export/import from the bundle contract

## Motivation
- support packaging a curated ontology from one datasource and importing it into a matching datasource without re-running the full extraction flow

## Impact
- imported ontologies render an import-complete state with delete/export actions instead of the DAG
- approved queries, glossary terms, project knowledge, and ontology metadata round-trip through the bundle
- bundle validation now checks against the target datasource schema rather than the current selected scope only
- provisioning-triggered import is still not wired in this branch

## Testing
- make check

## Follow-Up
- add the provisioning contract later if and when that path is ready
